### PR TITLE
Lock down server-internal functions that were exposed on the public Convex API

### DIFF
--- a/convex/cliSessions.ts
+++ b/convex/cliSessions.ts
@@ -1,7 +1,7 @@
-import { internalMutation, mutation, query } from './_generated/server'
+import { internalMutation, internalQuery, mutation } from './_generated/server'
 import { v } from 'convex/values'
 
-export const getByUserCode = query({
+export const getByUserCode = internalQuery({
   args: { userCode: v.string() },
   returns: v.union(
     v.object({
@@ -35,7 +35,7 @@ export const getByUserCode = query({
   },
 })
 
-export const getBySecretId = query({
+export const getBySecretId = internalQuery({
   args: { secretId: v.string() },
   returns: v.union(
     v.object({

--- a/convex/email.ts
+++ b/convex/email.ts
@@ -1,4 +1,4 @@
-import { action, internalMutation, internalQuery, query } from "./_generated/server";
+import { action, internalAction, internalMutation, internalQuery, query } from "./_generated/server";
 import { v } from "convex/values";
 import { Resend } from "resend";
 import { render } from "@react-email/render";
@@ -87,7 +87,7 @@ const BROADCASTS: Record<
   },
 };
 
-export const sendWaitlistConfirmEmail = action({
+export const sendWaitlistConfirmEmail = internalAction({
   args: {
     email: v.string(),
     lookupId: v.string(),

--- a/convex/httpCli.ts
+++ b/convex/httpCli.ts
@@ -1,5 +1,5 @@
 import { httpAction } from './_generated/server'
-import { api, internal } from './_generated/api'
+import { internal } from './_generated/api'
 import type { Id } from './_generated/dataModel'
 
 const USER_CODE_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
@@ -75,7 +75,7 @@ export const authPoll = httpAction(async (ctx, request) => {
     return jsonResponse({ error: 'Missing secretId parameter' }, 400)
   }
 
-  const session = await ctx.runQuery(api.cliSessions.getBySecretId, { secretId })
+  const session = await ctx.runQuery(internal.cliSessions.getBySecretId, { secretId })
 
   if (!session || session.expiresAt <= Date.now()) {
     return jsonResponse({ status: 'expired' })

--- a/convex/waitlist.ts
+++ b/convex/waitlist.ts
@@ -1,6 +1,6 @@
 import { mutation, query } from './_generated/server'
 import { v } from 'convex/values'
-import { api } from './_generated/api'
+import { internal } from './_generated/api'
 import { v4 as uuidv4 } from 'uuid'
 
 export const joinWaitlist = mutation({
@@ -32,7 +32,7 @@ export const joinWaitlist = mutation({
     })
 
     // Send confirmation email (non-blocking)
-    ctx.scheduler.runAfter(0, api.email.sendWaitlistConfirmEmail, {
+    ctx.scheduler.runAfter(0, internal.email.sendWaitlistConfirmEmail, {
       email: args.email.toLowerCase(),
       lookupId,
     }).catch((error: unknown) => {
@@ -81,7 +81,7 @@ export const joinWaitlistWithAuth = mutation({
     })
 
     // Send confirmation email (non-blocking)
-    ctx.scheduler.runAfter(0, api.email.sendWaitlistConfirmEmail, {
+    ctx.scheduler.runAfter(0, internal.email.sendWaitlistConfirmEmail, {
       email: user.email!,
       lookupId,
     }).catch((error: unknown) => {


### PR DESCRIPTION
## Summary

While running a static pass over the Convex backend (with
[convex-doctor](https://github.com/fagnersales/convex-doctor)), three function
registrations stood out as public (`api.*`) even though nothing client-side calls them. Two of
them are genuine security issues, not just style: one is an unauthenticated email-sending
endpoint, and one leaks the CLI device-flow secret. This PR converts them (plus one adjacent
lookup) to `internal*` registrations. No behavior changes for any legitimate caller — the diff
is 10 lines of registration/reference changes.

## What was wrong

### 1. `email.sendWaitlistConfirmEmail` was a public, unauthenticated email relay

It was registered as `action({...})` with no auth check, taking `email` and `lookupId` as
arguments and sending mail via the project's Resend account:

```ts
export const sendWaitlistConfirmEmail = action({
  args: { email: v.string(), lookupId: v.string() },
  handler: async (_, args) => { /* resend.emails.send({ to: args.email, ... }) */ }
})
```

Any browser client (or `curl` against the deployment) could call
`api.email.sendWaitlistConfirmEmail` to send "You're on the AI Stack waitlist" emails to any
address, at any volume — burning Resend quota, damaging the sending domain's reputation, and
spamming victims. The `lookupId` argument is also attacker-controlled and gets embedded in the
CTA link (`/waitlist/<lookupId>`).

Its only legitimate callers are the two `ctx.scheduler.runAfter(0, ...)` calls in
`waitlist.ts`, which run server-side and can reference internal functions. It's now an
`internalAction`, scheduled via `internal.email.sendWaitlistConfirmEmail`.

### 2. `cliSessions.getByUserCode` leaked the device-flow secret

The CLI login flow is a standard device-authorization flow: `authStart` mints a long random
`secretId` (a UUID, held by the CLI) and a short 6-character `userCode` (shown to the user and
placed in the browser URL as `/cli/auth?code=XXXXXX`). The CLI polls with the `secretId` and
receives the bearer token once the user approves.

The security of that flow depends on the user code *not* being convertible into the secret.
But `getByUserCode` was a public query that returned the full session — **including
`secretId`** — given only the user code:

```ts
export const getByUserCode = query({
  args: { userCode: v.string() },
  // returns { ..., secretId: v.string(), ... }
```

Anyone who saw the code during login (screen share, shoulder surf, browser history, a pasted
URL) could call this query, obtain the `secretId`, and then poll `/cli/auth/poll` themselves —
stealing the 90-day CLI token the moment the user clicked "approve". Nothing in the codebase
calls this function at all (the approval page only uses `approveSession`, which takes the
user code directly and requires authentication), so making it an `internalQuery` closes the
hole with zero callers affected. Deleting it outright would also be fine if you prefer.

### 3. `cliSessions.getBySecretId` — server-only, now internal

Only called from the `authPoll` HTTP action via `ctx.runQuery`. Lower severity than the two
above (you need the secret to look up anything), but it returns session internals and has no
reason to be on the public API. Now an `internalQuery`, referenced as
`internal.cliSessions.getBySecretId` from `httpCli.ts`.

This follows Convex's best-practice guidance that `ctx.runQuery`/`ctx.scheduler` targets
should be `internal.*`:
https://docs.convex.dev/understanding/best-practices/#only-schedule-and-ctxrun-internal-functions

## What I deliberately did NOT change

- **`rateLimit.checkApiRateLimit`** is also flagged as a public mutation called server-side
  (from the unsubscribe HTTP action), but it's *also* called from the TanStack server route
  `src/routes/api.stacks.$slug.tsx` through a plain Convex HTTP client, which can only reach
  public functions. Making it internal would break that route without extra plumbing. Worth a
  look separately: as a public mutation, anyone can increment the rate-limit counter for an
  arbitrary `ip` argument and lock other users out of the unsubscribe/API endpoints.
- The dead waitlist/migration functions, `Date.now()`-in-query warnings, and the various
  `.collect()`/await-in-loop lints — mostly one-off migration scripts, admin dashboards, or
  small catalog tables where the pattern is fine in practice.

## How I verified

- `tsc -p convex --noEmit` passes (the generated `api.d.ts` infers types from the modules, so
  no regeneration was needed).
- Full vitest suite passes: 206 passed, 2 skipped — including the `email.test.ts` and
  `httpCliHelpers.test.ts` suites that cover the touched flows.
- Re-ran the static scan: the three flagged `api.*` server-side references are gone.
- Grepped `src/` and `convex/` to confirm no client code references any of the three
  functions (`getByUserCode` had no references at all).

One deploy-time note: if any real client out in the wild (e.g. an older deployed frontend or
external tooling) does call these three via the public API, this change would break it — I
found no such caller in this repo, and the CLI itself talks to the HTTP endpoints, not to
these functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
