### PR TITLE
feat(cli): silent auto-sync — opt-in ask, SessionStart hook, --auto mode, failure escalation

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,6 +20,18 @@ npx @use-aistack/cli sync
 
 Requires a one-time `login` first.
 
+### `npx @use-aistack/cli sync --auto on` / `off`
+
+Optional: keep your stack fresh without manual syncs. `on` writes a `SessionStart` hook (`async: true`) into `~/.claude/settings.json`. The hook runs a silent sync at most once per day when a Claude Code session starts. `off` removes the hook and revokes the standing opt-in.
+
+```sh
+npx @use-aistack/cli sync --auto on            # enable, default every 24h
+npx @use-aistack/cli sync --auto on --every 12 # custom frequency in hours
+npx @use-aistack/cli sync --auto off           # revoke
+```
+
+The silent run (`sync --auto`) never prompts and publishes only under this opt-in. Each run appends one line to `~/.config/aistack/sync.log` (capped at 200 lines). The next interactive `sync` reports the last result. After 3 failures in a row, one visible message appears in Claude Code and names the fix. No email, no dialogs.
+
 ### `npx @use-aistack/cli login`
 
 Link this machine to your AI Stack account via browser.

--- a/packages/cli/src/autosync/hook.test.ts
+++ b/packages/cli/src/autosync/hook.test.ts
@@ -1,0 +1,174 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+	AUTO_SYNC_HOOK_COMMAND,
+	autoSyncHookInstalled,
+	installAutoSyncHook,
+	removeAutoSyncHook,
+} from "./hook.js";
+
+/**
+ * SessionStart hook install/remove — wayfinder #62 (map #60).
+ *
+ * ~/.claude/settings.json belongs to the user. The two rules these tests pin:
+ * never rewrite a file we cannot parse, and never touch hooks that are not
+ * ours.
+ */
+
+let dir: string;
+let file: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "aistack-hook-"));
+	file = join(dir, "settings.json");
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+function read(): Record<string, unknown> {
+	return JSON.parse(readFileSync(file, "utf-8"));
+}
+
+describe("installAutoSyncHook", () => {
+	test("creates the file when it is missing", () => {
+		const res = installAutoSyncHook(file);
+		expect(res.ok).toBe(true);
+		const settings = read() as {
+			hooks: {
+				SessionStart: { hooks: { command: string; async: boolean }[] }[];
+			};
+		};
+		const entry = settings.hooks.SessionStart[0].hooks[0];
+		expect(entry.command).toBe(AUTO_SYNC_HOOK_COMMAND);
+		expect(entry.async).toBe(true);
+	});
+
+	test("the command self-updates via @latest with an offline fallback", () => {
+		expect(AUTO_SYNC_HOOK_COMMAND).toContain("@use-aistack/cli@latest");
+		expect(AUTO_SYNC_HOOK_COMMAND).toContain("|| npx -y --prefer-offline");
+	});
+
+	test("preserves foreign hooks and other settings keys", () => {
+		writeFileSync(
+			file,
+			JSON.stringify({
+				model: "opus",
+				hooks: {
+					SessionStart: [{ hooks: [{ type: "command", command: "echo hi" }] }],
+					PreToolUse: [
+						{ matcher: "Bash", hooks: [{ type: "command", command: "lint" }] },
+					],
+				},
+			}),
+		);
+		installAutoSyncHook(file);
+		const settings = read() as {
+			model: string;
+			hooks: { SessionStart: unknown[]; PreToolUse: unknown[] };
+		};
+		expect(settings.model).toBe("opus");
+		expect(settings.hooks.PreToolUse).toHaveLength(1);
+		expect(settings.hooks.SessionStart).toHaveLength(2);
+	});
+
+	test("is idempotent — a second install does not duplicate the hook", () => {
+		installAutoSyncHook(file);
+		installAutoSyncHook(file);
+		const settings = read() as {
+			hooks: { SessionStart: { hooks: unknown[] }[] };
+		};
+		expect(settings.hooks.SessionStart).toHaveLength(1);
+	});
+
+	test("replaces an older version of our command instead of stacking", () => {
+		writeFileSync(
+			file,
+			JSON.stringify({
+				hooks: {
+					SessionStart: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: "npx -y @use-aistack/cli sync --auto",
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+		installAutoSyncHook(file);
+		const settings = read() as {
+			hooks: { SessionStart: { hooks: { command: string }[] }[] };
+		};
+		expect(settings.hooks.SessionStart).toHaveLength(1);
+		expect(settings.hooks.SessionStart[0].hooks[0].command).toBe(
+			AUTO_SYNC_HOOK_COMMAND,
+		);
+	});
+
+	test("refuses to touch a file that is not valid JSON", () => {
+		writeFileSync(file, "{not json");
+		const res = installAutoSyncHook(file);
+		expect(res.ok).toBe(false);
+		expect(readFileSync(file, "utf-8")).toBe("{not json");
+	});
+});
+
+describe("removeAutoSyncHook", () => {
+	test("a missing file is already the goal state", () => {
+		expect(removeAutoSyncHook(file).ok).toBe(true);
+	});
+
+	test("removes only our hook and cleans up empty containers", () => {
+		installAutoSyncHook(file);
+		const res = removeAutoSyncHook(file);
+		expect(res.ok).toBe(true);
+		expect(read()).toEqual({});
+	});
+
+	test("keeps foreign SessionStart hooks and other events", () => {
+		writeFileSync(
+			file,
+			JSON.stringify({
+				hooks: {
+					SessionStart: [{ hooks: [{ type: "command", command: "echo hi" }] }],
+					PreToolUse: [{ hooks: [{ type: "command", command: "lint" }] }],
+				},
+			}),
+		);
+		installAutoSyncHook(file);
+		removeAutoSyncHook(file);
+		const settings = read() as {
+			hooks: {
+				SessionStart: { hooks: { command: string }[] }[];
+				PreToolUse: unknown[];
+			};
+		};
+		expect(settings.hooks.SessionStart).toHaveLength(1);
+		expect(settings.hooks.SessionStart[0].hooks[0].command).toBe("echo hi");
+		expect(settings.hooks.PreToolUse).toHaveLength(1);
+	});
+
+	test("refuses to touch a file that is not valid JSON", () => {
+		writeFileSync(file, "{not json");
+		const res = removeAutoSyncHook(file);
+		expect(res.ok).toBe(false);
+		expect(readFileSync(file, "utf-8")).toBe("{not json");
+	});
+});
+
+describe("autoSyncHookInstalled", () => {
+	test("false before install, true after, false after remove", () => {
+		expect(autoSyncHookInstalled(file)).toBe(false);
+		installAutoSyncHook(file);
+		expect(autoSyncHookInstalled(file)).toBe(true);
+		removeAutoSyncHook(file);
+		expect(autoSyncHookInstalled(file)).toBe(false);
+	});
+});

--- a/packages/cli/src/autosync/hook.ts
+++ b/packages/cli/src/autosync/hook.ts
@@ -1,0 +1,150 @@
+// The background trigger (#62, map #60): a `SessionStart` hook in
+// ~/.claude/settings.json, `async: true`.
+//
+// SessionStart, not SessionEnd — teardown is not guaranteed (crash, SIGKILL,
+// closed terminal), and at start-of-session the previous sessions are fully on
+// disk. The command runs `@latest` through npx, so unattended machines update
+// by construction. The `||` fallback covers the offline case: when the network
+// resolve of `@latest` fails, the second npx runs the cached copy.
+// `sync --auto` always exits 0, so the fallback never fires on a sync failure.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export const CLAUDE_SETTINGS_FILE = join(homedir(), ".claude", "settings.json");
+
+export const AUTO_SYNC_HOOK_COMMAND =
+	"npx -y @use-aistack/cli@latest sync --auto || npx -y --prefer-offline @use-aistack/cli sync --auto";
+
+interface HookEntry {
+	type: string;
+	command?: string;
+	async?: boolean;
+}
+
+interface HookMatcher {
+	matcher?: string;
+	hooks?: HookEntry[];
+}
+
+interface ClaudeSettings {
+	hooks?: Record<string, HookMatcher[]>;
+	[key: string]: unknown;
+}
+
+/** Recognize our hook across versions: package name plus the auto flag. */
+function isOurs(entry: HookEntry): boolean {
+	return (
+		typeof entry.command === "string" &&
+		entry.command.includes("@use-aistack/cli") &&
+		entry.command.includes("sync --auto")
+	);
+}
+
+export interface HookResult {
+	ok: boolean;
+	message: string;
+}
+
+function readClaudeSettings(
+	file: string,
+): { settings: ClaudeSettings } | { error: string } {
+	if (!existsSync(file)) return { settings: {} };
+	try {
+		const raw = JSON.parse(readFileSync(file, "utf-8"));
+		if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+			return { settings: raw as ClaudeSettings };
+		}
+		return { error: `${file} does not hold a JSON object` };
+	} catch {
+		// Never rewrite a file we cannot parse — it is the user's Claude Code
+		// configuration, and a rewrite would destroy whatever is in it.
+		return { error: `${file} is not valid JSON — fix it, then retry` };
+	}
+}
+
+/**
+ * Add the SessionStart auto-sync hook. Idempotent: an existing aistack
+ * auto-sync entry (any version of the command) is replaced, not duplicated.
+ * All other hooks are preserved byte-for-byte in structure.
+ */
+export function installAutoSyncHook(
+	file: string = CLAUDE_SETTINGS_FILE,
+): HookResult {
+	const read = readClaudeSettings(file);
+	if ("error" in read) return { ok: false, message: read.error };
+	const settings = read.settings;
+
+	const hooks = settings.hooks ?? {};
+	const sessionStart = Array.isArray(hooks.SessionStart)
+		? hooks.SessionStart
+		: [];
+
+	const kept = sessionStart
+		.map((m) => ({
+			...m,
+			hooks: (m.hooks ?? []).filter((h) => !isOurs(h)),
+		}))
+		.filter((m) => (m.hooks?.length ?? 0) > 0);
+
+	kept.push({
+		hooks: [{ type: "command", command: AUTO_SYNC_HOOK_COMMAND, async: true }],
+	});
+
+	settings.hooks = { ...hooks, SessionStart: kept };
+	mkdirSync(dirname(file), { recursive: true });
+	writeFileSync(file, `${JSON.stringify(settings, null, 2)}\n`);
+	return { ok: true, message: `SessionStart hook written to ${file}` };
+}
+
+/**
+ * Remove only our hook. Other SessionStart hooks and other events stay. A
+ * missing file or an absent hook is success — the goal state already holds.
+ */
+export function removeAutoSyncHook(
+	file: string = CLAUDE_SETTINGS_FILE,
+): HookResult {
+	if (!existsSync(file)) return { ok: true, message: "no hook to remove" };
+	const read = readClaudeSettings(file);
+	if ("error" in read) return { ok: false, message: read.error };
+	const settings = read.settings;
+
+	const sessionStart = settings.hooks?.SessionStart;
+	if (!Array.isArray(sessionStart)) {
+		return { ok: true, message: "no hook to remove" };
+	}
+
+	const kept = sessionStart
+		.map((m) => ({
+			...m,
+			hooks: (m.hooks ?? []).filter((h) => !isOurs(h)),
+		}))
+		.filter((m) => (m.hooks?.length ?? 0) > 0);
+
+	const hooks = { ...settings.hooks };
+	if (kept.length > 0) {
+		hooks.SessionStart = kept;
+	} else {
+		delete hooks.SessionStart;
+	}
+	if (Object.keys(hooks).length > 0) {
+		settings.hooks = hooks;
+	} else {
+		delete settings.hooks;
+	}
+
+	writeFileSync(file, `${JSON.stringify(settings, null, 2)}\n`);
+	return { ok: true, message: `hook removed from ${file}` };
+}
+
+/** Is the auto-sync hook present? Used by status reporting. */
+export function autoSyncHookInstalled(
+	file: string = CLAUDE_SETTINGS_FILE,
+): boolean {
+	const read = readClaudeSettings(file);
+	if ("error" in read) return false;
+	const sessionStart = read.settings.hooks?.SessionStart;
+	if (!Array.isArray(sessionStart)) return false;
+	return sessionStart.some((m) => (m.hooks ?? []).some((h) => isOurs(h)));
+}

--- a/packages/cli/src/autosync/optin.test.ts
+++ b/packages/cli/src/autosync/optin.test.ts
@@ -1,0 +1,84 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { getSettings, saveSettings } from "../config.js";
+import { disableAutoSync, enableAutoSync } from "./optin.js";
+
+/**
+ * Enable/disable the standing opt-in — wayfinder #62 (map #60).
+ *
+ * The invariants: enable is flag+hook or neither, disable flips the flag even
+ * when the hook file resists (the flag is the publish gate, the hook is just
+ * the trigger).
+ */
+
+let dir: string;
+let settingsFile: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "aistack-optin-"));
+	settingsFile = join(dir, "settings.json");
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("enableAutoSync", () => {
+	test("writes the hook, then persists the flag and the answer", () => {
+		const installHook = vi.fn(() => ({ ok: true, message: "written" }));
+		const res = enableAutoSync(24, { settingsFile, installHook });
+		expect(res.ok).toBe(true);
+		expect(installHook).toHaveBeenCalledOnce();
+		const s = getSettings(settingsFile);
+		expect(s.autoSync).toEqual({ enabled: true, frequencyHours: 24 });
+		expect(s.autoSyncAnswered).toBe(true);
+	});
+
+	test("a failed hook write persists nothing", () => {
+		const installHook = vi.fn(() => ({ ok: false, message: "bad json" }));
+		const res = enableAutoSync(24, { settingsFile, installHook });
+		expect(res.ok).toBe(false);
+		expect(getSettings(settingsFile).autoSync).toBeUndefined();
+		expect(getSettings(settingsFile).autoSyncAnswered).toBeUndefined();
+	});
+
+	test("a custom frequency persists", () => {
+		enableAutoSync(6, {
+			settingsFile,
+			installHook: () => ({ ok: true, message: "" }),
+		});
+		expect(getSettings(settingsFile).autoSync?.frequencyHours).toBe(6);
+	});
+});
+
+describe("disableAutoSync", () => {
+	test("flips the flag and removes the hook", () => {
+		saveSettings(
+			{ autoSync: { enabled: true, frequencyHours: 6 } },
+			settingsFile,
+		);
+		const removeHook = vi.fn(() => ({ ok: true, message: "removed" }));
+		const res = disableAutoSync({ settingsFile, removeHook });
+		expect(res.ok).toBe(true);
+		expect(removeHook).toHaveBeenCalledOnce();
+		const s = getSettings(settingsFile);
+		expect(s.autoSync?.enabled).toBe(false);
+		expect(s.autoSync?.frequencyHours).toBe(6);
+	});
+
+	test("flips the flag even when the hook cannot be removed", () => {
+		saveSettings(
+			{ autoSync: { enabled: true, frequencyHours: 24 } },
+			settingsFile,
+		);
+		const res = disableAutoSync({
+			settingsFile,
+			removeHook: () => ({ ok: false, message: "bad json" }),
+		});
+		expect(res.ok).toBe(false);
+		expect(getSettings(settingsFile).autoSync?.enabled).toBe(false);
+		expect(res.message).toContain("nothing will publish");
+	});
+});

--- a/packages/cli/src/autosync/optin.ts
+++ b/packages/cli/src/autosync/optin.ts
@@ -1,0 +1,125 @@
+// The auto-sync opt-in (#62, map #60).
+//
+// This ask is the PRIMARY post-sync ask: it runs first, and the connect-claude
+// upsell yields to a later sync (at most one ask per sync, each asked once,
+// each persisted). Any explicit answer persists to
+// ~/.config/aistack/settings.json; ctrl-C is not an answer and the question
+// returns on the next sync.
+
+import * as p from "@clack/prompts";
+import {
+	DEFAULT_FREQUENCY_HOURS,
+	getSettings,
+	saveSettings,
+} from "../config.js";
+import { dim, limeBold } from "../theme.js";
+import {
+	type HookResult,
+	installAutoSyncHook,
+	removeAutoSyncHook,
+} from "./hook.js";
+
+export interface EnableDeps {
+	settingsFile?: string;
+	installHook?: () => HookResult;
+	removeHook?: () => HookResult;
+}
+
+/**
+ * Turn the standing opt-in on: persist the flag, write the SessionStart hook.
+ * When the hook write fails, the flag is NOT persisted — a half-enabled state
+ * (flag on, no hook) would claim a freshness the machine cannot deliver.
+ */
+export function enableAutoSync(
+	frequencyHours: number = DEFAULT_FREQUENCY_HOURS,
+	deps: EnableDeps = {},
+): HookResult {
+	const install = deps.installHook ?? installAutoSyncHook;
+	const result = install();
+	if (!result.ok) return result;
+	saveSettings(
+		{
+			autoSyncAnswered: true,
+			autoSync: { enabled: true, frequencyHours },
+		},
+		deps.settingsFile,
+	);
+	return {
+		ok: true,
+		message: `Auto-sync is on — about every ${frequencyHours}h when a Claude Code session starts. Turn it off any time: npx @use-aistack/cli sync --auto off`,
+	};
+}
+
+/**
+ * Revoke: remove the hook AND flip the flag. The flag flips even when the
+ * hook file cannot be edited, because `sync --auto` gates on the flag — a
+ * stale hook without the flag publishes nothing.
+ */
+export function disableAutoSync(deps: EnableDeps = {}): HookResult {
+	const remove = deps.removeHook ?? removeAutoSyncHook;
+	const settings = getSettings(deps.settingsFile);
+	saveSettings(
+		{
+			autoSyncAnswered: true,
+			autoSync: {
+				enabled: false,
+				frequencyHours:
+					settings.autoSync?.frequencyHours ?? DEFAULT_FREQUENCY_HOURS,
+			},
+		},
+		deps.settingsFile,
+	);
+	const result = remove();
+	if (!result.ok) {
+		return {
+			ok: false,
+			message: `Auto-sync is off (nothing will publish), but the hook could not be removed: ${result.message}`,
+		};
+	}
+	return { ok: true, message: "Auto-sync is off. The hook was removed." };
+}
+
+/**
+ * The post-sync ask. Returns true when it asked (so the caller skips the
+ * connect upsell this sync), false when it had nothing to ask.
+ */
+export async function offerAutoSyncOptIn(): Promise<boolean> {
+	if (getSettings().autoSyncAnswered === true) return false;
+
+	const answer = await p.select({
+		message: "Keep this stack fresh automatically?",
+		options: [
+			{
+				value: "later",
+				label: "Not now",
+				hint: "this question will not come back",
+			},
+			{
+				value: "enable",
+				label: "Enable",
+				hint: "a silent daily sync when a Claude Code session starts",
+			},
+		],
+		initialValue: "later",
+	});
+
+	if (p.isCancel(answer)) return true;
+
+	if (answer === "enable") {
+		const result = enableAutoSync();
+		if (result.ok) {
+			p.log.success(result.message);
+		} else {
+			p.log.error(result.message);
+		}
+		return true;
+	}
+
+	saveSettings({ autoSyncAnswered: true });
+	p.log.message(
+		`If you change your mind: ${limeBold("npx @use-aistack/cli sync --auto on")} ${dim(
+			"(and --auto off to revoke)",
+		)}`,
+	);
+	return true;
+}

--- a/packages/cli/src/autosync/run.test.ts
+++ b/packages/cli/src/autosync/run.test.ts
@@ -1,0 +1,266 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { getSettings, saveSettings } from "../config.js";
+import type { StagedSend } from "../sync/stage.js";
+import { appendLogLine, runAutoSync, SYNC_LOG_MAX_LINES } from "./run.js";
+
+/**
+ * The silent background run — wayfinder #62 (map #60).
+ *
+ * The properties these tests pin: no opt-in means no publish (the hard gate),
+ * a fresh run exits without work, every real run leaves one log line, and the
+ * escalation fires once per failure streak.
+ */
+
+let dir: string;
+let settingsFile: string;
+let logFile: string;
+
+const NOW = 1_800_000_000_000;
+const HOUR = 3_600_000;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "aistack-auto-"));
+	settingsFile = join(dir, "settings.json");
+	logFile = join(dir, "sync.log");
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+function stagedOk(): StagedSend {
+	return {
+		id: "abc",
+		bodyJson: '{"x":1}',
+		body: {} as StagedSend["body"],
+		keptPrivate: {} as StagedSend["keptPrivate"],
+		summary: "",
+		dialog: "",
+		config: {} as StagedSend["config"],
+		token: "tok",
+		stagedAt: NOW,
+		blockedReason: null,
+	};
+}
+
+function publishOk() {
+	return Promise.resolve({
+		receivedAt: NOW,
+		url: "https://aistack.to/s/me",
+		stackSlug: "me",
+		keptPrivate: { stored: 0, refused: false },
+	});
+}
+
+function deps(over: Partial<Parameters<typeof runAutoSync>[0]> = {}) {
+	return {
+		baseUrl: "https://aistack.to",
+		now: () => NOW,
+		settingsFile,
+		logFile,
+		emit: vi.fn(),
+		stageImpl: vi.fn(async () => stagedOk()),
+		publishImpl: vi.fn(publishOk),
+		...over,
+	};
+}
+
+function logLines(): string[] {
+	return existsSync(logFile)
+		? readFileSync(logFile, "utf-8").split("\n").filter(Boolean)
+		: [];
+}
+
+describe("the opt-in gate", () => {
+	test("no settings at all: nothing is staged, nothing published", async () => {
+		const d = deps();
+		await runAutoSync(d);
+		expect(d.stageImpl).not.toHaveBeenCalled();
+		expect(d.publishImpl).not.toHaveBeenCalled();
+		expect(logLines()[0]).toContain("not enabled");
+	});
+
+	test("enabled: false blocks the same way", async () => {
+		saveSettings(
+			{ autoSync: { enabled: false, frequencyHours: 24 } },
+			settingsFile,
+		);
+		const d = deps();
+		await runAutoSync(d);
+		expect(d.publishImpl).not.toHaveBeenCalled();
+	});
+});
+
+describe("the freshness gate", () => {
+	test("a run inside the frequency window exits with no work and no log line", async () => {
+		saveSettings(
+			{
+				autoSync: { enabled: true, frequencyHours: 24 },
+				autoSyncState: { lastRunAt: NOW - 2 * HOUR },
+			},
+			settingsFile,
+		);
+		const d = deps();
+		await runAutoSync(d);
+		expect(d.stageImpl).not.toHaveBeenCalled();
+		expect(logLines()).toHaveLength(0);
+	});
+
+	test("a run past the window proceeds", async () => {
+		saveSettings(
+			{
+				autoSync: { enabled: true, frequencyHours: 24 },
+				autoSyncState: { lastRunAt: NOW - 25 * HOUR },
+			},
+			settingsFile,
+		);
+		const d = deps();
+		await runAutoSync(d);
+		expect(d.publishImpl).toHaveBeenCalledOnce();
+	});
+
+	test("the window keys on the last attempt, so failures also back off", async () => {
+		saveSettings(
+			{
+				autoSync: { enabled: true, frequencyHours: 24 },
+				autoSyncState: { lastRunAt: NOW - 2 * HOUR, consecutiveFailures: 1 },
+			},
+			settingsFile,
+		);
+		const d = deps({
+			stageImpl: vi.fn(async () => ({
+				...stagedOk(),
+				blockedReason: "not linked",
+			})),
+		});
+		await runAutoSync(d);
+		expect(d.stageImpl).not.toHaveBeenCalled();
+	});
+});
+
+describe("a successful run", () => {
+	beforeEach(() => {
+		saveSettings(
+			{ autoSync: { enabled: true, frequencyHours: 24 } },
+			settingsFile,
+		);
+	});
+
+	test("publishes the staged bytes and logs one ok line", async () => {
+		const d = deps();
+		await runAutoSync(d);
+		expect(d.publishImpl).toHaveBeenCalledWith("tok", '{"x":1}');
+		const lines = logLines();
+		expect(lines).toHaveLength(1);
+		expect(lines[0]).toContain("ok — published");
+	});
+
+	test("records state and resets the failure streak", async () => {
+		saveSettings(
+			{ autoSyncState: { consecutiveFailures: 2, failureWarned: true } },
+			settingsFile,
+		);
+		await runAutoSync(deps());
+		const state = getSettings(settingsFile).autoSyncState;
+		expect(state?.lastRunAt).toBe(NOW);
+		expect(state?.lastSuccessAt).toBe(NOW);
+		expect(state?.consecutiveFailures).toBe(0);
+		expect(state?.failureWarned).toBe(false);
+		expect(state?.lastResult).toContain("ok");
+	});
+});
+
+describe("a failing run", () => {
+	beforeEach(() => {
+		saveSettings(
+			{ autoSync: { enabled: true, frequencyHours: 24 } },
+			settingsFile,
+		);
+	});
+
+	test("a blockedReason counts as a failure and is logged", async () => {
+		const d = deps({
+			stageImpl: vi.fn(async () => ({
+				...stagedOk(),
+				blockedReason: "This machine is not linked.",
+			})),
+		});
+		await runAutoSync(d);
+		expect(d.publishImpl).not.toHaveBeenCalled();
+		expect(logLines()[0]).toContain("not linked");
+		expect(getSettings(settingsFile).autoSyncState?.consecutiveFailures).toBe(
+			1,
+		);
+	});
+
+	test("a thrown publish error is caught, logged, and counted", async () => {
+		const d = deps({
+			publishImpl: vi.fn(() => Promise.reject(new Error("HTTP 500"))),
+		});
+		await runAutoSync(d);
+		expect(logLines()[0]).toContain("HTTP 500");
+		expect(getSettings(settingsFile).autoSyncState?.lastResult).toContain(
+			"HTTP 500",
+		);
+	});
+
+	test("failures 1 and 2 stay silent, failure 3 emits one systemMessage", async () => {
+		const d = deps({
+			publishImpl: vi.fn(() => Promise.reject(new Error("HTTP 500"))),
+		});
+		for (let i = 0; i < 3; i++) {
+			saveSettings(
+				{
+					autoSyncState: {
+						...getSettings(settingsFile).autoSyncState,
+						lastRunAt: 0,
+					},
+				},
+				settingsFile,
+			);
+			await runAutoSync(d);
+		}
+		expect(d.emit).toHaveBeenCalledOnce();
+		const payload = JSON.parse(
+			(d.emit as ReturnType<typeof vi.fn>).mock.calls[0][0],
+		);
+		expect(payload.systemMessage).toContain("3 times");
+		expect(payload.systemMessage).toContain("npx @use-aistack/cli sync");
+	});
+
+	test("failure 4 does not repeat the warning", async () => {
+		saveSettings(
+			{
+				autoSyncState: {
+					consecutiveFailures: 3,
+					failureWarned: true,
+					lastRunAt: 0,
+				},
+			},
+			settingsFile,
+		);
+		const d = deps({
+			publishImpl: vi.fn(() => Promise.reject(new Error("HTTP 500"))),
+		});
+		await runAutoSync(d);
+		expect(d.emit).not.toHaveBeenCalled();
+		expect(getSettings(settingsFile).autoSyncState?.consecutiveFailures).toBe(
+			4,
+		);
+	});
+});
+
+describe("appendLogLine", () => {
+	test("caps the log at the newest lines", () => {
+		for (let i = 0; i < SYNC_LOG_MAX_LINES + 50; i++) {
+			appendLogLine(logFile, `line ${i}`);
+		}
+		const lines = logLines();
+		expect(lines).toHaveLength(SYNC_LOG_MAX_LINES);
+		expect(lines[0]).toBe("line 50");
+		expect(lines[lines.length - 1]).toBe(`line ${SYNC_LOG_MAX_LINES + 49}`);
+	});
+});

--- a/packages/cli/src/autosync/run.ts
+++ b/packages/cli/src/autosync/run.ts
@@ -1,0 +1,147 @@
+// `sync --auto` — the silent background run (#62, map #60).
+//
+// The tenets from map #29 hold: passive analysis, never passive publish. The
+// standing opt-in (`autoSync.enabled` in ~/.config/aistack/settings.json) is
+// the ONLY thing that lets this path publish, and the user can revoke it with
+// one command. No prompts, no upsells, no email, no dialogs. The escalation
+// ladder is: one log line per run → the next interactive sync reports the last
+// result → after 3 consecutive failures, one visible systemMessage line.
+//
+// This function never sets a nonzero exit code. The hook command falls back to
+// the npx cache on `||`, and a nonzero exit from a mere sync failure would
+// fire that fallback and run the whole sync twice.
+
+import {
+	appendFileSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { syncPublish } from "../api.js";
+import {
+	type AutoSyncState,
+	DEFAULT_FREQUENCY_HOURS,
+	getSettings,
+	saveSettings,
+} from "../config.js";
+import { stageSync } from "../sync/stage.js";
+
+export const SYNC_LOG_FILE = join(homedir(), ".config", "aistack", "sync.log");
+
+/** The log stays small: newest 200 lines, older lines fall off. */
+export const SYNC_LOG_MAX_LINES = 200;
+
+/** The one-line fix, named in the escalation message and nowhere vaguer. */
+const FIX_COMMAND = "npx @use-aistack/cli sync";
+
+export type AutoSyncDeps = {
+	baseUrl: string;
+	now?: () => number;
+	settingsFile?: string;
+	logFile?: string;
+	stageImpl?: typeof stageSync;
+	publishImpl?: typeof syncPublish;
+	/** Where the systemMessage JSON goes. Defaults to stdout. */
+	emit?: (line: string) => void;
+};
+
+export function appendLogLine(file: string, line: string): void {
+	mkdirSync(dirname(file), { recursive: true });
+	appendFileSync(file, `${line}\n`);
+	const lines = readFileSync(file, "utf-8").split("\n").filter(Boolean);
+	if (lines.length > SYNC_LOG_MAX_LINES) {
+		writeFileSync(file, `${lines.slice(-SYNC_LOG_MAX_LINES).join("\n")}\n`);
+	}
+}
+
+export async function runAutoSync(deps: AutoSyncDeps): Promise<void> {
+	const now = (deps.now ?? Date.now)();
+	const settingsFile = deps.settingsFile;
+	const logFile = deps.logFile ?? SYNC_LOG_FILE;
+	const emit =
+		deps.emit ?? ((line: string) => process.stdout.write(`${line}\n`));
+	const stamp = new Date(now).toISOString();
+
+	const settings = getSettings(settingsFile);
+	const config = settings.autoSync;
+
+	// The hard gate. A hook left behind after a revoke publishes nothing.
+	if (config?.enabled !== true) {
+		appendLogLine(logFile, `${stamp} skipped — auto-sync is not enabled`);
+		return;
+	}
+
+	// The freshness gate keys on the last ATTEMPT, not the last success. A
+	// broken setup then retries once per frequency window, not once per
+	// session start, and still reaches the 3-failure escalation.
+	const frequencyHours = config.frequencyHours || DEFAULT_FREQUENCY_HOURS;
+	const state: AutoSyncState = settings.autoSyncState ?? {};
+	const lastRunAt = state.lastRunAt ?? 0;
+	if (now - lastRunAt < frequencyHours * 3_600_000) return;
+
+	const stage = deps.stageImpl ?? stageSync;
+	const publish = deps.publishImpl ?? syncPublish;
+
+	let failure: string | null = null;
+	let url: string | undefined;
+	try {
+		const staged = await stage({ baseUrl: deps.baseUrl, now: () => now });
+		if (staged.blockedReason !== null) {
+			failure = staged.blockedReason;
+		} else {
+			const res = await publish(staged.token as string, staged.bodyJson);
+			url = res.url;
+		}
+	} catch (e) {
+		failure = e instanceof Error ? e.message : String(e);
+	}
+
+	if (failure === null) {
+		saveSettings(
+			{
+				autoSyncState: {
+					lastRunAt: now,
+					lastSuccessAt: now,
+					lastResult: `ok — published at ${stamp}`,
+					consecutiveFailures: 0,
+					failureWarned: false,
+				},
+			},
+			settingsFile,
+		);
+		appendLogLine(logFile, `${stamp} ok — published${url ? ` ${url}` : ""}`);
+		return;
+	}
+
+	const consecutiveFailures = (state.consecutiveFailures ?? 0) + 1;
+	const shouldWarn = consecutiveFailures >= 3 && state.failureWarned !== true;
+	saveSettings(
+		{
+			autoSyncState: {
+				...state,
+				lastRunAt: now,
+				lastResult: `failed at ${stamp} — ${failure}`,
+				consecutiveFailures,
+				failureWarned: state.failureWarned === true || shouldWarn,
+			},
+		},
+		settingsFile,
+	);
+	appendLogLine(
+		logFile,
+		`${stamp} fail (${consecutiveFailures} in a row) — ${failure}`,
+	);
+
+	// One visible line, once per failure streak. SessionStart hook JSON:
+	// Claude Code shows `systemMessage` to the user when the async hook lands.
+	if (shouldWarn) {
+		emit(
+			JSON.stringify({
+				systemMessage: `aistack auto-sync failed ${consecutiveFailures} times in a row (${failure}). Run \`${FIX_COMMAND}\` in a terminal to fix it, or \`${FIX_COMMAND} --auto off\` to stop these runs.`,
+			}),
+		);
+	}
+}

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -11,12 +11,67 @@
 
 import * as p from "@clack/prompts";
 import { BASE_URL, syncPublish } from "../api.js";
+import {
+	disableAutoSync,
+	enableAutoSync,
+	offerAutoSyncOptIn,
+} from "../autosync/optin.js";
+import { runAutoSync } from "../autosync/run.js";
+import { DEFAULT_FREQUENCY_HOURS, getSettings } from "../config.js";
 import { stageSync } from "../sync/stage.js";
 import { dim, intro, lime, outro, outroCancel, outroError } from "../theme.js";
 import { offerConnectUpsell } from "./connect.js";
 
-export async function syncCommand(): Promise<void> {
+export interface SyncOptions {
+	/** `--auto` → true, `--auto on` → "on", `--auto off` → "off". */
+	auto?: boolean | string;
+	/** `--every <hours>`, applied with `--auto on`. */
+	every?: string;
+}
+
+export async function syncCommand(options: SyncOptions = {}): Promise<void> {
+	// The silent path (#62): no TTY, no prompts, no upsells. Publishes only
+	// under the standing opt-in and always exits 0 — the hook command's `||`
+	// offline fallback must never fire on a mere sync failure.
+	if (options.auto === true) {
+		await runAutoSync({ baseUrl: BASE_URL });
+		return;
+	}
+
+	if (options.auto === "on" || options.auto === "off") {
+		intro("sync");
+		const result =
+			options.auto === "on"
+				? enableAutoSync(
+						options.every
+							? Number.parseInt(options.every, 10) || DEFAULT_FREQUENCY_HOURS
+							: DEFAULT_FREQUENCY_HOURS,
+					)
+				: disableAutoSync();
+		if (result.ok) {
+			p.log.success(result.message);
+			outro("done");
+		} else {
+			outroError(result.message);
+			process.exitCode = 1;
+		}
+		return;
+	}
+	if (options.auto !== undefined) {
+		intro("sync");
+		outroError(`unknown --auto value "${options.auto}" — use on or off`);
+		process.exitCode = 1;
+		return;
+	}
+
 	intro("sync");
+
+	// The interactive surface is where a silent failure becomes visible (#62):
+	// report the last auto-sync outcome, whatever it was.
+	const lastAuto = getSettings().autoSyncState?.lastResult;
+	if (lastAuto !== undefined) {
+		p.log.message(dim(`auto-sync: ${lastAuto}`));
+	}
 
 	// The whole premise of this channel is a human at a terminal. A pipe or a
 	// model-launched Bash call has no TTY, and a gate that cannot ask must not
@@ -85,7 +140,10 @@ export async function syncCommand(): Promise<void> {
 			);
 		}
 		p.log.message(lines.join("\n"));
-		await offerConnectUpsell();
+		// At most one ask per sync (#62): the auto-sync opt-in is the primary
+		// ask; the connect upsell yields and waits for a later sync.
+		const asked = await offerAutoSyncOptIn();
+		if (!asked) await offerConnectUpsell();
 		outro("done");
 	} catch (e) {
 		s.stop("Publish failed");

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -1,0 +1,106 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { clearToken, getToken, saveToken } from "./config.js";
+
+/**
+ * Credentials keyed by server URL — wayfinder #61 (map #60).
+ *
+ * The file holds the only plaintext copy of each token (#52 hashed the server
+ * side). The old flat form let a localhost login destroy the prod token. These
+ * tests pin the map form, the legacy migration, and the do-not-clobber rules.
+ */
+
+const PROD = "https://aistack.to";
+const LOCAL = "http://localhost:3019";
+
+let dir: string;
+let file: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "aistack-config-"));
+	file = join(dir, "credentials.json");
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("saveToken / getToken", () => {
+	test("round-trips a token for one server", () => {
+		saveToken("tok-prod", "user-1", PROD, file);
+		expect(getToken(PROD, file)).toBe("tok-prod");
+	});
+
+	test("a localhost login does not clobber the prod token", () => {
+		saveToken("tok-prod", "user-1", PROD, file);
+		saveToken("tok-local", "user-1", LOCAL, file);
+		expect(getToken(PROD, file)).toBe("tok-prod");
+		expect(getToken(LOCAL, file)).toBe("tok-local");
+	});
+
+	test("returns null for a server with no entry", () => {
+		saveToken("tok-prod", "user-1", PROD, file);
+		expect(getToken(LOCAL, file)).toBeNull();
+	});
+
+	test("returns null when the file does not exist", () => {
+		expect(getToken(PROD, file)).toBeNull();
+	});
+
+	test("a re-login for the same server replaces only that entry", () => {
+		saveToken("tok-old", "user-1", PROD, file);
+		saveToken("tok-local", "user-1", LOCAL, file);
+		saveToken("tok-new", "user-1", PROD, file);
+		expect(getToken(PROD, file)).toBe("tok-new");
+		expect(getToken(LOCAL, file)).toBe("tok-local");
+	});
+});
+
+describe("legacy flat-form migration", () => {
+	test("reads a legacy flat file as the current server's token", () => {
+		writeFileSync(file, JSON.stringify({ token: "tok-flat", userId: "u1" }));
+		expect(getToken(PROD, file)).toBe("tok-flat");
+	});
+
+	test("rewrites the flat form to the map on first read", () => {
+		writeFileSync(file, JSON.stringify({ token: "tok-flat", userId: "u1" }));
+		getToken(PROD, file);
+		const raw = JSON.parse(readFileSync(file, "utf-8"));
+		expect(raw.token).toBeUndefined();
+		expect(raw.servers[PROD]).toEqual({ token: "tok-flat", userId: "u1" });
+	});
+
+	test("a login on top of a legacy file keeps the migrated entry", () => {
+		writeFileSync(file, JSON.stringify({ token: "tok-flat" }));
+		saveToken("tok-local", "user-1", LOCAL, file);
+		expect(getToken(PROD, file)).toBe("tok-flat");
+		expect(getToken(LOCAL, file)).toBe("tok-local");
+	});
+
+	test("a cleared legacy file ({}) reads as empty", () => {
+		writeFileSync(file, "{}");
+		expect(getToken(PROD, file)).toBeNull();
+	});
+
+	test("does not rewrite an unreadable file", () => {
+		writeFileSync(file, "not json {");
+		expect(getToken(PROD, file)).toBeNull();
+		expect(readFileSync(file, "utf-8")).toBe("not json {");
+	});
+});
+
+describe("clearToken", () => {
+	test("removes only the current server's entry", () => {
+		saveToken("tok-prod", "user-1", PROD, file);
+		saveToken("tok-local", "user-1", LOCAL, file);
+		clearToken(LOCAL, file);
+		expect(getToken(LOCAL, file)).toBeNull();
+		expect(getToken(PROD, file)).toBe("tok-prod");
+	});
+
+	test("is a no-op when the file does not exist", () => {
+		expect(() => clearToken(PROD, file)).not.toThrow();
+	});
+});

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -109,26 +109,54 @@ const SETTINGS_FILE = join(CONFIG_DIR, "settings.json");
  * login overwrite never resets an answered upsell, and clearing settings never
  * touches the token.
  */
+export interface AutoSyncConfig {
+	/** The standing opt-in. `sync --auto` publishes nothing when false. */
+	enabled: boolean;
+	/** Minimum hours between auto-sync attempts. Default 24. */
+	frequencyHours: number;
+}
+
+/** Bookkeeping the `sync --auto` runs write. Separate from the opt-in. */
+export interface AutoSyncState {
+	/** Epoch ms of the last attempt (success or failure). The freshness gate. */
+	lastRunAt?: number;
+	lastSuccessAt?: number;
+	/** One line about the last run, shown on the next interactive sync. */
+	lastResult?: string;
+	consecutiveFailures?: number;
+	/** The 3-failure systemMessage went out. Reset on success. */
+	failureWarned?: boolean;
+}
+
+export const DEFAULT_FREQUENCY_HOURS = 24;
+
 export interface Settings {
 	/** The post-sync connect-claude upsell was answered (either way). */
 	connectClaudeAnswered?: boolean;
+	/** The post-sync auto-sync ask was answered (either way). */
+	autoSyncAnswered?: boolean;
+	autoSync?: AutoSyncConfig;
+	autoSyncState?: AutoSyncState;
 }
 
-export function getSettings(): Settings {
-	if (!existsSync(SETTINGS_FILE)) return {};
+export function getSettings(file: string = SETTINGS_FILE): Settings {
+	if (!existsSync(file)) return {};
 	try {
-		const raw = JSON.parse(readFileSync(SETTINGS_FILE, "utf-8"));
+		const raw = JSON.parse(readFileSync(file, "utf-8"));
 		return raw && typeof raw === "object" ? (raw as Settings) : {};
 	} catch {
 		return {};
 	}
 }
 
-export function saveSettings(patch: Partial<Settings>): void {
-	mkdirSync(CONFIG_DIR, { recursive: true });
+export function saveSettings(
+	patch: Partial<Settings>,
+	file: string = SETTINGS_FILE,
+): void {
+	mkdirSync(dirname(file), { recursive: true });
 	writeFileSync(
-		SETTINGS_FILE,
-		JSON.stringify({ ...getSettings(), ...patch }, null, 2),
+		file,
+		JSON.stringify({ ...getSettings(file), ...patch }, null, 2),
 	);
 }
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,36 +1,105 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { BASE_URL } from "./api.js";
 
 const CONFIG_DIR = join(homedir(), ".config", "aistack");
 const CREDENTIALS_FILE = join(CONFIG_DIR, "credentials.json");
 
-interface Credentials {
+interface ServerCredentials {
 	token: string;
 	userId?: string;
 }
 
-export function getToken(): string | null {
-	if (!existsSync(CREDENTIALS_FILE)) return null;
+/**
+ * Credentials keyed by server URL (#61). Since hash-at-rest (#52) the server
+ * stores only a hash, so this file holds the only plaintext copy of each
+ * token. The old flat `{token, userId}` form let a localhost login overwrite
+ * the prod token, which was unrecoverable. The map keeps one entry per server.
+ */
+interface CredentialsFile {
+	servers: Record<string, ServerCredentials>;
+}
+
+/** Where a legacy flat token is assumed to come from. */
+const DEFAULT_SERVER_URL = "https://aistack.to";
+
+/**
+ * Read the credentials file and lift the legacy flat form into the map.
+ *
+ * A legacy token carries no record of which server issued it. It is assigned
+ * to the default prod URL, not the caller's current server: every real flat
+ * token came from prod, and keying it under a localhost caller would put it
+ * exactly where the next localhost login overwrites it.
+ */
+function readCredentials(file: string): {
+	data: CredentialsFile;
+	legacy: boolean;
+} {
+	const empty = { data: { servers: {} }, legacy: false };
+	if (!existsSync(file)) return empty;
 	try {
-		const data = JSON.parse(
-			readFileSync(CREDENTIALS_FILE, "utf-8"),
-		) as Credentials;
-		return data.token ?? null;
+		const raw = JSON.parse(readFileSync(file, "utf-8"));
+		if (!raw || typeof raw !== "object") return empty;
+		if (raw.servers && typeof raw.servers === "object") {
+			return {
+				data: { servers: raw.servers as Record<string, ServerCredentials> },
+				legacy: false,
+			};
+		}
+		if (typeof raw.token === "string" && raw.token) {
+			return {
+				data: {
+					servers: {
+						[DEFAULT_SERVER_URL]: { token: raw.token, userId: raw.userId },
+					},
+				},
+				legacy: true,
+			};
+		}
+		// A cleared legacy file is `{}` — empty, but safe to rewrite.
+		return { data: { servers: {} }, legacy: true };
 	} catch {
-		return null;
+		// Do not rewrite an unreadable file. It may still hold a token that a
+		// human can recover, and this file holds the only plaintext copy.
+		return empty;
 	}
 }
 
-export function saveToken(token: string, userId?: string): void {
-	mkdirSync(CONFIG_DIR, { recursive: true });
-	writeFileSync(CREDENTIALS_FILE, JSON.stringify({ token, userId }, null, 2));
+function writeCredentials(file: string, data: CredentialsFile): void {
+	mkdirSync(dirname(file), { recursive: true });
+	writeFileSync(file, JSON.stringify(data, null, 2));
 }
 
-export function clearToken(): void {
-	if (existsSync(CREDENTIALS_FILE)) {
-		writeFileSync(CREDENTIALS_FILE, "{}");
-	}
+export function getToken(
+	serverUrl: string = BASE_URL,
+	file: string = CREDENTIALS_FILE,
+): string | null {
+	const { data, legacy } = readCredentials(file);
+	if (legacy) writeCredentials(file, data);
+	return data.servers[serverUrl]?.token ?? null;
+}
+
+export function saveToken(
+	token: string,
+	userId?: string,
+	serverUrl: string = BASE_URL,
+	file: string = CREDENTIALS_FILE,
+): void {
+	const { data } = readCredentials(file);
+	data.servers[serverUrl] = { token, userId };
+	writeCredentials(file, data);
+}
+
+/** Remove only the current server's entry. Other servers keep their tokens. */
+export function clearToken(
+	serverUrl: string = BASE_URL,
+	file: string = CREDENTIALS_FILE,
+): void {
+	if (!existsSync(file)) return;
+	const { data } = readCredentials(file);
+	delete data.servers[serverUrl];
+	writeCredentials(file, data);
 }
 
 const SETTINGS_FILE = join(CONFIG_DIR, "settings.json");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -47,7 +47,15 @@ program
 program
 	.command("sync")
 	.description("Scan, preview, and publish measured usage (rolling 30 days)")
-	.action(syncCommand);
+	.option(
+		"--auto [state]",
+		"silent background sync; 'on' enables the SessionStart hook, 'off' revokes it",
+	)
+	.option(
+		"--every <hours>",
+		"with --auto on: hours between auto-syncs (default 24)",
+	)
+	.action((options) => syncCommand(options));
 
 program
 	.command("connect")


### PR DESCRIPTION
Closes #62 (map #60).

## What this adds

- `sync --auto`: the silent background run. No prompts, no upsells. It publishes only when the standing opt-in (`autoSync.enabled` in `~/.config/aistack/settings.json`) is true. It always exits 0, so the hook's offline fallback never fires on a sync failure.
- Freshness gate: the run keys on the last attempt and skips inside the configured window (`frequencyHours`, default 24). The common case costs one settings read.
- The opt-in ask is now the primary post-sync ask. The connect-claude upsell yields and returns on a later sync. At most one ask per sync, each asked once, each persisted. Ctrl-C is not an answer.
- Enabling writes a `SessionStart` hook (`async: true`) into `~/.claude/settings.json`: `npx -y @use-aistack/cli@latest sync --auto || npx -y --prefer-offline @use-aistack/cli sync --auto`. Unattended machines self-update through `@latest`. `sync --auto off` removes the hook and revokes the flag.
- Escalation ladder: one line per run in a capped `~/.config/aistack/sync.log` (200 lines) → the next interactive sync reports the last result → after 3 consecutive failures, one visible `systemMessage` line that names the fix. No email, no dialogs.

## Safety properties

- The hook installer never rewrites a `~/.claude/settings.json` it cannot parse, and never touches foreign hooks.
- Enable is flag-plus-hook or neither. Disable flips the flag even when the hook file resists, because the flag is the publish gate.
- A stale hook after a revoke publishes nothing.

## Tests

28 new tests across `autosync/hook`, `autosync/run`, `autosync/optin`. Full CLI suite: 267 passed. Smoke-tested the enable → fail ×3 → systemMessage → disable loop against a built binary in an isolated `$HOME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACnuEAMo6TFJSgdNeDCoYX