### PR TITLE
feat(instrumentation): views, activity events and product events (#78)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,10 +18,23 @@ GOOGLE_OAUTH_CLIENT_SECRET=
 GITHUB_OAUTH_CLIENT_ID=
 GITHUB_OAUTH_CLIENT_SECRET=
 
-# Posthog
-VITE_PUBLIC_POSTHOG_KEY= 
+# Posthog — browser
+VITE_PUBLIC_POSTHOG_KEY=
 VITE_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 VITE_PUBLIC_POSTHOG_HOST_UI=https://eu.posthog.com
+
+# Posthog — server capture (#78). Set these on the CONVEX deployment, not on the
+# web app: four of the seven product events fire from Convex, because the browser
+# cannot honestly observe a signup, a CLI token exchange, a first sync or an
+# auto-sync opt-in. Unset means those four are logged and dropped.
+POSTHOG_PROJECT_API_KEY=
+POSTHOG_HOST=https://eu.i.posthog.com
+
+# View counting (#78). The HMAC key for the daily visitor pseudonym. Set on the
+# WEB app — the raw IP never leaves the web server. Production without it counts
+# no views rather than storing a guessable hash. Any long random string works;
+# rotating it resets that day's dedupe and nothing else.
+VIEW_HASH_SECRET=
 
 # Resend
 RESEND_API_KEY= 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,7 +8,9 @@
  * @module
  */
 
+import type * as activity from "../activity.js";
 import type * as admin from "../admin.js";
+import type * as analytics from "../analytics.js";
 import type * as auth from "../auth.js";
 import type * as bundles from "../bundles.js";
 import type * as cliSessions from "../cliSessions.js";
@@ -57,6 +59,7 @@ import type * as seeds_stacks from "../seeds/stacks.js";
 import type * as seeds_tools from "../seeds/tools.js";
 import type * as stacks from "../stacks.js";
 import type * as tools from "../tools.js";
+import type * as views from "../views.js";
 import type * as waitlist from "../waitlist.js";
 
 import type {
@@ -66,7 +69,9 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  activity: typeof activity;
   admin: typeof admin;
+  analytics: typeof analytics;
   auth: typeof auth;
   bundles: typeof bundles;
   cliSessions: typeof cliSessions;
@@ -115,6 +120,7 @@ declare const fullApi: ApiFromModules<{
   "seeds/tools": typeof seeds_tools;
   stacks: typeof stacks;
   tools: typeof tools;
+  views: typeof views;
   waitlist: typeof waitlist;
 }>;
 

--- a/convex/activity.test.ts
+++ b/convex/activity.test.ts
@@ -1,0 +1,507 @@
+/// <reference types="vite/client" />
+import { convexTest } from 'convex-test'
+import { expect, test } from 'vitest'
+import schema from './schema'
+import { api, internal } from './_generated/api'
+import type { MutationCtx } from './_generated/server'
+import type { Doc, Id } from './_generated/dataModel'
+
+const modules = import.meta.glob('./**/*.{js,ts}')
+
+async function seedCreator(
+  t: ReturnType<typeof convexTest>,
+  opts: { userId: string; slug: string },
+): Promise<{ creatorId: Id<'creators'>; asCreator: ReturnType<typeof t.withIdentity> }> {
+  const creatorId = await t.run(async (ctx: MutationCtx) =>
+    ctx.db.insert('creators', {
+      name: `Creator ${opts.userId}`,
+      slug: opts.slug,
+      userId: opts.userId,
+      verified: false,
+      personalPages: [],
+      projectPages: [],
+      createdAt: Date.now(),
+    }),
+  )
+  return {
+    creatorId,
+    asCreator: t.withIdentity({ tokenIdentifier: `convex|${opts.userId}` }),
+  }
+}
+
+async function seedTool(
+  t: ReturnType<typeof convexTest>,
+  slug: string,
+  name: string,
+): Promise<void> {
+  await t.run(async (ctx: MutationCtx) => {
+    await ctx.db.insert('tools', {
+      name,
+      slug,
+      shortId: slug.slice(0, 6),
+      categories: [],
+      tiers: [],
+      reviewStatus: 'approved',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    })
+  })
+}
+
+function toolSub(slug: string) {
+  return {
+    toolSlug: slug,
+    kind: 'main' as const,
+    primaryUsageLabel: 'coding',
+    price: { pricingType: 'fixed' as const },
+    priceKind: 'regular' as const,
+  }
+}
+
+async function events(
+  t: ReturnType<typeof convexTest>,
+): Promise<Doc<'activityEvents'>[]> {
+  return await t.run((ctx: MutationCtx) => ctx.db.query('activityEvents').collect())
+}
+
+// ---------------------------------------------------------------------------
+// stack.published
+// ---------------------------------------------------------------------------
+
+test('creating a stack already public emits stack.published', async () => {
+  const t = convexTest(schema, modules)
+  const { asCreator } = await seedCreator(t, { userId: 'a1', slug: 'creator-a1' })
+  await seedTool(t, 'claude-code', 'Claude Code')
+
+  await asCreator.mutation(api.stacks.create, {
+    name: 'S',
+    oneLiner: 'o',
+    toolSubscriptions: [toolSub('claude-code')],
+    published: true,
+  })
+
+  const rows = await events(t)
+  expect(rows).toHaveLength(1)
+  expect(rows[0].event).toEqual({ type: 'stack.published', toolCount: 1 })
+})
+
+test('creating a draft emits nothing', async () => {
+  const t = convexTest(schema, modules)
+  const { asCreator } = await seedCreator(t, { userId: 'a2', slug: 'creator-a2' })
+
+  await asCreator.mutation(api.stacks.create, {
+    name: 'S',
+    oneLiner: 'o',
+    toolSubscriptions: [],
+    published: false,
+  })
+
+  expect(await events(t)).toHaveLength(0)
+})
+
+test('publishing a draft emits stack.published', async () => {
+  const t = convexTest(schema, modules)
+  const { asCreator } = await seedCreator(t, { userId: 'a3', slug: 'creator-a3' })
+  await seedTool(t, 'cursor', 'Cursor')
+  const created = await asCreator.mutation(api.stacks.create, {
+    name: 'S',
+    oneLiner: 'o',
+    toolSubscriptions: [toolSub('cursor')],
+    published: false,
+  })
+
+  await asCreator.mutation(api.stacks.update, {
+    stackId: created._id,
+    published: true,
+  })
+
+  const rows = await events(t)
+  expect(rows).toHaveLength(1)
+  expect(rows[0].event).toEqual({ type: 'stack.published', toolCount: 1 })
+})
+
+test('publishing a draft that also changes composition emits ONLY stack.published', async () => {
+  const t = convexTest(schema, modules)
+  const { asCreator } = await seedCreator(t, { userId: 'a4', slug: 'creator-a4' })
+  await seedTool(t, 'cursor', 'Cursor')
+  await seedTool(t, 'zed', 'Zed')
+  const created = await asCreator.mutation(api.stacks.create, {
+    name: 'S',
+    oneLiner: 'o',
+    toolSubscriptions: [toolSub('cursor')],
+    published: false,
+  })
+
+  await asCreator.mutation(api.stacks.update, {
+    stackId: created._id,
+    published: true,
+    toolSubscriptions: [toolSub('cursor'), toolSub('zed')],
+  })
+
+  const rows = await events(t)
+  expect(rows).toHaveLength(1)
+  expect(rows[0].event.type).toBe('stack.published')
+})
+
+test('re-saving an already public stack does not re-emit stack.published', async () => {
+  const t = convexTest(schema, modules)
+  const { asCreator } = await seedCreator(t, { userId: 'a5', slug: 'creator-a5' })
+  const created = await asCreator.mutation(api.stacks.create, {
+    name: 'S',
+    oneLiner: 'o',
+    toolSubscriptions: [],
+    published: true,
+  })
+
+  await asCreator.mutation(api.stacks.update, {
+    stackId: created._id,
+    published: true,
+    oneLiner: 'edited',
+  })
+
+  const rows = await events(t)
+  expect(rows).toHaveLength(1)
+})
+
+// ---------------------------------------------------------------------------
+// stack.composition_changed
+// ---------------------------------------------------------------------------
+
+test('adding and removing tools on a public stack emits the diff with frozen names', async () => {
+  const t = convexTest(schema, modules)
+  const { asCreator } = await seedCreator(t, { userId: 'b1', slug: 'creator-b1' })
+  await seedTool(t, 'cursor', 'Cursor')
+  await seedTool(t, 'zed', 'Zed')
+  const created = await asCreator.mutation(api.stacks.create, {
+    name: 'S',
+    oneLiner: 'o',
+    toolSubscriptions: [toolSub('cursor')],
+    published: true,
+  })
+
+  await asCreator.mutation(api.stacks.update, {
+    stackId: created._id,
+    toolSubscriptions: [toolSub('zed')],
+  })
+
+  const rows = await events(t)
+  expect(rows).toHaveLength(2)
+  expect(rows[1].event).toEqual({
+    type: 'stack.composition_changed',
+    added: [{ kind: 'tool', slug: 'zed', name: 'Zed' }],
+    removed: [{ kind: 'tool', slug: 'cursor', name: 'Cursor' }],
+  })
+})
+
+test('a prose-only edit emits nothing', async () => {
+  const t = convexTest(schema, modules)
+  const { asCreator } = await seedCreator(t, { userId: 'b2', slug: 'creator-b2' })
+  await seedTool(t, 'cursor', 'Cursor')
+  const created = await asCreator.mutation(api.stacks.create, {
+    name: 'S',
+    oneLiner: 'o',
+    toolSubscriptions: [toolSub('cursor')],
+    published: true,
+  })
+
+  await asCreator.mutation(api.stacks.update, {
+    stackId: created._id,
+    oneLiner: 'a better line',
+    description: 'prose',
+    toolSubscriptions: [toolSub('cursor')],
+  })
+
+  expect(await events(t)).toHaveLength(1)
+})
+
+test('a composition change on a DRAFT emits nothing', async () => {
+  const t = convexTest(schema, modules)
+  const { asCreator } = await seedCreator(t, { userId: 'b3', slug: 'creator-b3' })
+  await seedTool(t, 'cursor', 'Cursor')
+  const created = await asCreator.mutation(api.stacks.create, {
+    name: 'S',
+    oneLiner: 'o',
+    toolSubscriptions: [],
+    published: false,
+  })
+
+  await asCreator.mutation(api.stacks.update, {
+    stackId: created._id,
+    toolSubscriptions: [toolSub('cursor')],
+  })
+
+  expect(await events(t)).toHaveLength(0)
+})
+
+test('an update that unpublishes while changing composition emits nothing — the gate reads resulting state', async () => {
+  const t = convexTest(schema, modules)
+  const { asCreator } = await seedCreator(t, { userId: 'b4', slug: 'creator-b4' })
+  await seedTool(t, 'cursor', 'Cursor')
+  await seedTool(t, 'zed', 'Zed')
+  const created = await asCreator.mutation(api.stacks.create, {
+    name: 'S',
+    oneLiner: 'o',
+    toolSubscriptions: [toolSub('cursor')],
+    published: true,
+  })
+
+  await asCreator.mutation(api.stacks.update, {
+    stackId: created._id,
+    published: false,
+    toolSubscriptions: [toolSub('zed')],
+  })
+
+  const rows = await events(t)
+  expect(rows).toHaveLength(1)
+  expect(rows[0].event.type).toBe('stack.published')
+})
+
+test('a model or bundle change is a composition change too', async () => {
+  const t = convexTest(schema, modules)
+  const { asCreator } = await seedCreator(t, { userId: 'b5', slug: 'creator-b5' })
+  await t.run(async (ctx: MutationCtx) => {
+    await ctx.db.insert('models', {
+      name: 'Opus 5',
+      slug: 'opus-5',
+      shortId: 'opus5',
+      provider: 'anthropic',
+      category: 'coding',
+      reviewStatus: 'approved',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    })
+  })
+  const created = await asCreator.mutation(api.stacks.create, {
+    name: 'S',
+    oneLiner: 'o',
+    toolSubscriptions: [],
+    published: true,
+  })
+
+  await asCreator.mutation(api.stacks.update, {
+    stackId: created._id,
+    modelSubscriptions: [{ modelSlug: 'opus-5', role: 'primary' }],
+  })
+
+  const rows = await events(t)
+  expect(rows).toHaveLength(2)
+  expect(rows[1].event).toEqual({
+    type: 'stack.composition_changed',
+    added: [{ kind: 'model', slug: 'opus-5', name: 'Opus 5' }],
+    removed: [],
+  })
+})
+
+test('a slug with no catalog row keeps the slug as its name rather than vanishing', async () => {
+  const t = convexTest(schema, modules)
+  const { asCreator } = await seedCreator(t, { userId: 'b6', slug: 'creator-b6' })
+  const created = await asCreator.mutation(api.stacks.create, {
+    name: 'S',
+    oneLiner: 'o',
+    toolSubscriptions: [],
+    published: true,
+  })
+
+  await asCreator.mutation(api.stacks.update, {
+    stackId: created._id,
+    toolSubscriptions: [toolSub('ghost-tool')],
+  })
+
+  const rows = await events(t)
+  expect(rows[1].event).toMatchObject({
+    added: [{ kind: 'tool', slug: 'ghost-tool', name: 'ghost-tool' }],
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sync.landed
+// ---------------------------------------------------------------------------
+
+function payload(harness: string, tokens: number) {
+  return {
+    schemaVersion: 1,
+    capturedAt: Date.now(),
+    window: { days: 30, from: '2026-07-01', to: '2026-07-31' },
+    harness: { name: harness, version: '1.0.0' },
+    pricingTable: null,
+    activity: {
+      sessions: 3,
+      activeDays: 2,
+      projects: 1,
+      totalTokens: tokens,
+      cacheHitShare: 0.5,
+      subagentShare: 0,
+    },
+    models: [],
+    inventory: {
+      builtinTools: [],
+      mcpServers: [],
+      skills: [],
+      subagents: [],
+      slashCommands: [],
+      withheld: {
+        builtinTools: 0,
+        mcpServers: 0,
+        skills: 0,
+        subagents: 0,
+        slashCommands: 0,
+      },
+    },
+    coverage: { filesScanned: 1, filesUnreadable: 0, linesParsed: 10, linesFailed: 0 },
+    excludedTokens: { unpriced: 0, synthetic: 0 },
+  }
+}
+
+async function seedTokenFor(
+  t: ReturnType<typeof convexTest>,
+  stackId: Id<'stacks'>,
+  userId: string,
+): Promise<Id<'cliTokens'>> {
+  return await t.run(async (ctx: MutationCtx) =>
+    ctx.db.insert('cliTokens', {
+      tokenHash: `hash-${userId}`,
+      userId,
+      scopes: ['collect', 'sync'],
+      stackId,
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 1000,
+      lastUsedAt: Date.now(),
+    }),
+  )
+}
+
+test('a batch of two harnesses lands ONE sync.landed summarizing both', async () => {
+  const t = convexTest(schema, modules)
+  const { asCreator } = await seedCreator(t, { userId: 'c1', slug: 'creator-c1' })
+  const created = await asCreator.mutation(api.stacks.create, {
+    name: 'S',
+    oneLiner: 'o',
+    toolSubscriptions: [],
+    published: true,
+  })
+  const tokenId = await seedTokenFor(t, created._id, 'c1')
+
+  await t.mutation(internal.measured.publishForToken, {
+    tokenId,
+    payloads: [payload('claude-code', 1000), payload('codex', 500)],
+  })
+
+  const rows = await events(t)
+  const syncs = rows.filter((r) => r.event.type === 'sync.landed')
+  expect(syncs).toHaveLength(1)
+  expect(syncs[0].event).toEqual({
+    type: 'sync.landed',
+    harnesses: [
+      {
+        harness: 'claude-code',
+        windowDays: 30,
+        sessions: 3,
+        activeDays: 2,
+        projects: 1,
+        totalTokens: 1000,
+      },
+      {
+        harness: 'codex',
+        windowDays: 30,
+        sessions: 3,
+        activeDays: 2,
+        projects: 1,
+        totalTokens: 500,
+      },
+    ],
+  })
+})
+
+test('a sync to a DRAFT stack lands the snapshot but no feed event', async () => {
+  const t = convexTest(schema, modules)
+  const { asCreator } = await seedCreator(t, { userId: 'c2', slug: 'creator-c2' })
+  const created = await asCreator.mutation(api.stacks.create, {
+    name: 'S',
+    oneLiner: 'o',
+    toolSubscriptions: [],
+    published: false,
+  })
+  const tokenId = await seedTokenFor(t, created._id, 'c2')
+
+  const result = await t.mutation(internal.measured.publishForToken, {
+    tokenId,
+    payloads: [payload('claude-code', 1000)],
+  })
+
+  expect(result.snapshotIds).toHaveLength(1)
+  expect(await events(t)).toHaveLength(0)
+})
+
+test('the second sync emits a second event — there is no read-time collapsing to work around', async () => {
+  const t = convexTest(schema, modules)
+  const { asCreator } = await seedCreator(t, { userId: 'c3', slug: 'creator-c3' })
+  const created = await asCreator.mutation(api.stacks.create, {
+    name: 'S',
+    oneLiner: 'o',
+    toolSubscriptions: [],
+    published: true,
+  })
+  const tokenId = await seedTokenFor(t, created._id, 'c3')
+
+  await t.mutation(internal.measured.publishForToken, {
+    tokenId,
+    payloads: [payload('claude-code', 1000)],
+  })
+  await t.mutation(internal.measured.publishForToken, {
+    tokenId,
+    payloads: [payload('claude-code', 2000)],
+  })
+
+  const rows = await events(t)
+  expect(rows.filter((r) => r.event.type === 'sync.landed')).toHaveLength(2)
+})
+
+// ---------------------------------------------------------------------------
+// The auto-sync opt-in the sync reports
+// ---------------------------------------------------------------------------
+
+test('the reported auto-sync state is stored on the token', async () => {
+  const t = convexTest(schema, modules)
+  const { asCreator } = await seedCreator(t, { userId: 'd1', slug: 'creator-d1' })
+  const created = await asCreator.mutation(api.stacks.create, {
+    name: 'S',
+    oneLiner: 'o',
+    toolSubscriptions: [],
+    published: true,
+  })
+  const tokenId = await seedTokenFor(t, created._id, 'd1')
+
+  await t.mutation(internal.measured.publishForToken, {
+    tokenId,
+    payloads: [payload('claude-code', 1)],
+    autoSync: { enabled: true, frequencyHours: 24 },
+  })
+
+  const token = await t.run((ctx: MutationCtx) => ctx.db.get(tokenId))
+  expect(token?.autoSync).toEqual({ enabled: true, frequencyHours: 24 })
+})
+
+test('a sync that reports nothing leaves the stored state alone', async () => {
+  const t = convexTest(schema, modules)
+  const { asCreator } = await seedCreator(t, { userId: 'd2', slug: 'creator-d2' })
+  const created = await asCreator.mutation(api.stacks.create, {
+    name: 'S',
+    oneLiner: 'o',
+    toolSubscriptions: [],
+    published: true,
+  })
+  const tokenId = await seedTokenFor(t, created._id, 'd2')
+
+  await t.mutation(internal.measured.publishForToken, {
+    tokenId,
+    payloads: [payload('claude-code', 1)],
+    autoSync: { enabled: true, frequencyHours: 12 },
+  })
+  await t.mutation(internal.measured.publishForToken, {
+    tokenId,
+    payloads: [payload('claude-code', 2)],
+  })
+
+  const token = await t.run((ctx: MutationCtx) => ctx.db.get(tokenId))
+  expect(token?.autoSync).toEqual({ enabled: true, frequencyHours: 12 })
+})

--- a/convex/activity.ts
+++ b/convex/activity.ts
@@ -1,0 +1,108 @@
+// The activity-feed write side (#77, map #76).
+//
+// Events are written at the moment things happen, inside the same mutation as
+// the thing they record, so a failed write cannot produce a phantom event.
+// Nothing here reads the table — the feed's read path is a separate ticket.
+
+import type { Infer } from 'convex/values'
+import type { Id } from './_generated/dataModel'
+import type { MutationCtx } from './_generated/server'
+import type { ActivityAtom, ActivityEvent } from './schema'
+
+export type ActivityAtomValue = Infer<typeof ActivityAtom>
+export type ActivityEventValue = Infer<typeof ActivityEvent>
+
+/**
+ * Append one event.
+ *
+ * `createdAt` is set here rather than left to `_creationTime`, so a launch-time
+ * backfill from existing snapshots can carry the time the thing actually
+ * happened instead of the time the row was inserted.
+ */
+export async function emitActivityEvent(
+  ctx: MutationCtx,
+  stackId: Id<'stacks'>,
+  event: ActivityEventValue,
+  now: number = Date.now()
+): Promise<void> {
+  await ctx.db.insert('activityEvents', { stackId, createdAt: now, event })
+}
+
+/** What a stack is composed of, flattened to comparable atoms. */
+export interface StackComposition {
+  toolSubscriptions?: readonly { toolSlug: string }[]
+  modelSubscriptions?: readonly { modelSlug: string }[]
+  bundleSubscriptions?: readonly { bundleSlug: string }[]
+}
+
+interface SlugSet {
+  tool: string[]
+  model: string[]
+  bundle: string[]
+}
+
+function slugsOf(composition: StackComposition): SlugSet {
+  return {
+    tool: (composition.toolSubscriptions ?? []).map((s) => s.toolSlug),
+    model: (composition.modelSubscriptions ?? []).map((s) => s.modelSlug),
+    bundle: (composition.bundleSubscriptions ?? []).map((s) => s.bundleSlug),
+  }
+}
+
+const CATALOG_TABLE = {
+  tool: 'tools',
+  model: 'models',
+  bundle: 'bundles',
+} as const
+
+/**
+ * Resolve display names for a set of slugs, ONCE, at write time.
+ *
+ * The stored name is the name at the moment of the change, which is both the
+ * cheap answer (no per-row catalog lookup on the read path) and the correct
+ * one: the feed is a historical record. A slug with no catalog row keeps the
+ * slug as its name rather than dropping the atom — a change the owner made is
+ * still a change that happened.
+ */
+async function toAtoms(
+  ctx: MutationCtx,
+  kind: 'tool' | 'model' | 'bundle',
+  slugs: readonly string[]
+): Promise<ActivityAtomValue[]> {
+  const atoms: ActivityAtomValue[] = []
+  for (const slug of slugs) {
+    const row = await ctx.db
+      .query(CATALOG_TABLE[kind])
+      .withIndex('by_slug', (q) => q.eq('slug', slug))
+      .first()
+    atoms.push({ kind, slug, name: row?.name ?? slug })
+  }
+  return atoms
+}
+
+/**
+ * Diff two compositions on SLUG and return the atoms added and removed.
+ *
+ * Prose edits are excluded by construction: only the subscription slug sets are
+ * compared. That keeps authoring noise out of a feed that will be thin at
+ * launch, and it produces exactly the row the churn framing will later need.
+ */
+export async function diffComposition(
+  ctx: MutationCtx,
+  before: StackComposition,
+  after: StackComposition
+): Promise<{ added: ActivityAtomValue[]; removed: ActivityAtomValue[] }> {
+  const from = slugsOf(before)
+  const to = slugsOf(after)
+  const added: ActivityAtomValue[] = []
+  const removed: ActivityAtomValue[] = []
+
+  for (const kind of ['tool', 'model', 'bundle'] as const) {
+    const had = new Set(from[kind])
+    const has = new Set(to[kind])
+    added.push(...(await toAtoms(ctx, kind, [...has].filter((s) => !had.has(s)))))
+    removed.push(...(await toAtoms(ctx, kind, [...had].filter((s) => !has.has(s)))))
+  }
+
+  return { added, removed }
+}

--- a/convex/analytics.test.ts
+++ b/convex/analytics.test.ts
@@ -1,0 +1,125 @@
+/// <reference types="vite/client" />
+import { convexTest } from 'convex-test'
+import { expect, test } from 'vitest'
+import schema from './schema'
+import { internal } from './_generated/api'
+import { signupMethodFromPath } from './analytics'
+import type { MutationCtx } from './_generated/server'
+import type { Id } from './_generated/dataModel'
+
+const modules = import.meta.glob('./**/*.{js,ts}')
+
+// ---------------------------------------------------------------------------
+// Naming the signup method
+// ---------------------------------------------------------------------------
+
+test('the signup method is read from the better-auth request path', () => {
+  expect(signupMethodFromPath('/sign-up/email')).toBe('email')
+  expect(signupMethodFromPath('/callback/google')).toBe('google')
+  expect(signupMethodFromPath('/callback/github')).toBe('github')
+  expect(signupMethodFromPath('/magic-link/verify')).toBe('magic-link')
+})
+
+test('an unrecognized path reports unknown rather than guessing', () => {
+  expect(signupMethodFromPath('/something/else')).toBe('unknown')
+  expect(signupMethodFromPath(undefined)).toBe('unknown')
+  expect(signupMethodFromPath('')).toBe('unknown')
+})
+
+// ---------------------------------------------------------------------------
+// The capture seam
+// ---------------------------------------------------------------------------
+
+test('a scheduled capture without PostHog configured does not fail the caller', async () => {
+  const t = convexTest(schema, modules)
+
+  await expect(
+    t.mutation(internal.analytics.recordSignup, {
+      userId: 'user-1',
+      method: 'email',
+    }),
+  ).resolves.toBeNull()
+})
+
+test('cli_login_completed fires on the token exchange, not on gate approval', async () => {
+  const t = convexTest(schema, modules)
+  const sessionId = await t.run(async (ctx: MutationCtx) =>
+    ctx.db.insert('cliSessions', {
+      userCode: 'ABCD-EFGH',
+      secretId: 'secret-1',
+      status: 'approved',
+      userId: 'user-2',
+      cliVersion: '0.6.3',
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+    }),
+  )
+
+  const result = await t.mutation(internal.cliSessions.issueTokenAndDeleteSession, {
+    sessionId,
+    tokenHash: 'digest',
+    userId: 'user-2',
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 1000,
+    lastUsedAt: Date.now(),
+  })
+
+  expect(result).toEqual({ issued: true })
+  // The session is consumed, which is what "the CLI came back for its token"
+  // means — a browser approval alone leaves the row in place.
+  const left = await t.run((ctx: MutationCtx) =>
+    ctx.db.get(sessionId as Id<'cliSessions'>),
+  )
+  expect(left).toBeNull()
+})
+
+test('a session that was never approved issues nothing and fires nothing', async () => {
+  const t = convexTest(schema, modules)
+  const sessionId = await t.run(async (ctx: MutationCtx) =>
+    ctx.db.insert('cliSessions', {
+      userCode: 'IJKL-MNOP',
+      secretId: 'secret-2',
+      status: 'pending',
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+    }),
+  )
+
+  const result = await t.mutation(internal.cliSessions.issueTokenAndDeleteSession, {
+    sessionId,
+    tokenHash: 'digest',
+    userId: 'user-3',
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 1000,
+    lastUsedAt: Date.now(),
+  })
+
+  expect(result).toBeNull()
+  const tokens = await t.run((ctx: MutationCtx) => ctx.db.query('cliTokens').collect())
+  expect(tokens).toHaveLength(0)
+})
+
+test('a login from an older CLI that names no version still links the machine', async () => {
+  const t = convexTest(schema, modules)
+  const sessionId = await t.run(async (ctx: MutationCtx) =>
+    ctx.db.insert('cliSessions', {
+      userCode: 'QRST-UVWX',
+      secretId: 'secret-3',
+      status: 'approved',
+      userId: 'user-4',
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+    }),
+  )
+
+  const result = await t.mutation(internal.cliSessions.issueTokenAndDeleteSession, {
+    sessionId,
+    tokenHash: 'digest-4',
+    userId: 'user-4',
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 1000,
+    lastUsedAt: Date.now(),
+  })
+
+  expect(result).toEqual({ issued: true })
+})

--- a/convex/analytics.ts
+++ b/convex/analytics.ts
@@ -1,0 +1,165 @@
+// Server-side PostHog capture (#77, map #76).
+//
+// Four of the seven product events fire on transitions the browser cannot
+// honestly observe — a signup completing, a CLI storing a token, a first sync
+// landing, a machine turning auto-sync on. Keeping them client-side would ship
+// four wrong numbers, and a funnel with a wrong number is worse than a funnel
+// with fewer steps.
+//
+// The CLI gets no PostHog SDK. It reports state to the aistack backend, which
+// it already talks to, and Convex emits the event. One network destination.
+//
+// Convex mutations are deterministic and cannot call `fetch`, so a mutation
+// SCHEDULES the capture rather than performing it. Nothing here is ever read
+// back by the app: PostHog is the funnel, not a data source.
+
+import { v } from 'convex/values'
+import { internalAction, internalMutation } from './_generated/server'
+import { internal } from './_generated/api'
+import type { MutationCtx } from './_generated/server'
+
+/**
+ * The four events the server owns. Closed on purpose — the three client events
+ * (`stack_created`, `stack_published`, `leaderboard_stack_clicked`) go through
+ * posthog-js in the browser and never reach here.
+ */
+export const ServerEvent = v.union(
+  v.literal('signup_completed'),
+  v.literal('cli_login_completed'),
+  v.literal('first_sync_completed'),
+  v.literal('auto_sync_enabled')
+)
+
+export type ServerEventName =
+  | 'signup_completed'
+  | 'cli_login_completed'
+  | 'first_sync_completed'
+  | 'auto_sync_enabled'
+
+const PropertyValue = v.union(
+  v.string(),
+  v.number(),
+  v.boolean(),
+  v.null(),
+  v.array(v.string())
+)
+
+const Properties = v.record(v.string(), PropertyValue)
+
+export type EventProperties = Record<
+  string,
+  string | number | boolean | null | string[]
+>
+
+/**
+ * Fire a product event from inside a mutation.
+ *
+ * `distinctId` MUST be the same user id posthog-js identifies the browser with,
+ * or the funnel breaks into two strangers. The web calls
+ * `posthog.identify(userId)` once authenticated, which aliases the pre-signup
+ * anonymous id, and every server capture reuses that id.
+ *
+ * Scheduled at delay 0, so it rides the mutation's transaction: a mutation that
+ * throws never emits, and a mutation that commits always does.
+ */
+export async function captureServerEvent(
+  ctx: MutationCtx,
+  event: ServerEventName,
+  distinctId: string,
+  properties: EventProperties = {}
+): Promise<void> {
+  await ctx.scheduler.runAfter(0, internal.analytics.capture, {
+    event,
+    distinctId,
+    properties,
+  })
+}
+
+/**
+ * Signup, from the better-auth user-create hook.
+ *
+ * A mutation and not a direct capture, because the hook holds an auth context
+ * rather than a Convex mutation context — this is the seam that turns one into
+ * the other.
+ *
+ * `method` is derived from the request path, so a provider added later reports
+ * its own name without a code change here.
+ */
+export const recordSignup = internalMutation({
+  args: { userId: v.string(), method: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await captureServerEvent(ctx, 'signup_completed', args.userId, {
+      method: args.method,
+    })
+    return null
+  },
+})
+
+/**
+ * Name the signup method from the better-auth request path.
+ *
+ * `/sign-up/email` → `email`, `/callback/google` → `google`,
+ * `/magic-link/verify` → `magic-link`. An unrecognized path reports `unknown`
+ * rather than guessing, because a wrong label in a funnel is worse than a
+ * missing one.
+ */
+export function signupMethodFromPath(path: string | undefined): string {
+  if (!path) return 'unknown'
+  const segments = path.split('/').filter(Boolean)
+  if (segments[0] === 'sign-up' && segments[1]) return segments[1]
+  if (segments[0] === 'callback' && segments[1]) return segments[1]
+  if (segments[0] === 'sign-in' && segments[1]) return segments[1]
+  if (segments[0] === 'magic-link') return 'magic-link'
+  return 'unknown'
+}
+
+/**
+ * POST one event to PostHog.
+ *
+ * A failure LOGS and returns. It never throws, because a dropped analytics
+ * event must not retry-loop a scheduled function, and the mutation that
+ * scheduled it has already committed — there is nothing left to undo.
+ */
+export const capture = internalAction({
+  args: {
+    event: ServerEvent,
+    distinctId: v.string(),
+    properties: Properties,
+  },
+  returns: v.null(),
+  handler: async (_ctx, args) => {
+    const key = process.env.POSTHOG_PROJECT_API_KEY
+    const host = process.env.POSTHOG_HOST
+    if (!key || !host) {
+      // Not configured — local dev and the test backend both land here. Say so
+      // once per event rather than failing a real user action over telemetry.
+      console.log(
+        `[analytics] POSTHOG_PROJECT_API_KEY/POSTHOG_HOST unset, dropping ${args.event}`
+      )
+      return null
+    }
+
+    try {
+      const response = await fetch(`${host.replace(/\/+$/, '')}/i/v0/e/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          api_key: key,
+          event: args.event,
+          distinct_id: args.distinctId,
+          properties: args.properties,
+          timestamp: new Date().toISOString(),
+        }),
+      })
+      if (!response.ok) {
+        console.error(
+          `[analytics] PostHog rejected ${args.event}: ${response.status}`
+        )
+      }
+    } catch (err) {
+      console.error(`[analytics] PostHog capture failed for ${args.event}:`, err)
+    }
+    return null
+  },
+})

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -14,7 +14,8 @@ import { ResetPasswordEmail } from '../src/emails/ResetPasswordEmail'
 import { MagicLinkEmail } from '../src/emails/MagicLinkEmail'
 
 // @ts-ignore - components will be generated after convex dev restarts
-import { components } from './_generated/api'
+import { components, internal } from './_generated/api'
+import { signupMethodFromPath } from './analytics'
 
 const appUrl = process.env.APP_URL || process.env.BETTER_AUTH_URL!
 
@@ -25,6 +26,39 @@ export const createAuth = (ctx: GenericCtx<DataModel>) => {
     baseURL: appUrl,
     trustedOrigins: [process.env.APP_URL || process.env.BETTER_AUTH_URL || 'http://localhost:3019'],
     database: authComponent.adapter(ctx),
+    databaseHooks: {
+      user: {
+        create: {
+          /**
+           * `signup_completed` (#77, map #76). Server-side, because the browser
+           * cannot honestly observe this transition — an OAuth callback and a
+           * magic-link verify both create the user without the app ever seeing
+           * a "signup succeeded" moment it could trust.
+           *
+           * The user id becomes the PostHog `distinct_id`, which is the same id
+           * posthog-js identifies the browser with once authenticated. That is
+           * what keeps the client and server halves of the funnel one person.
+           *
+           * Fails SILENTLY. A telemetry seam must never be able to fail a
+           * signup, and by the time this runs the user row already exists.
+           */
+          after: async (user, context) => {
+            try {
+              const runMutation = (
+                ctx as { runMutation?: (ref: unknown, args: unknown) => Promise<unknown> }
+              ).runMutation
+              if (typeof runMutation !== 'function') return
+              await runMutation(internal.analytics.recordSignup, {
+                userId: user.id,
+                method: signupMethodFromPath(context?.path ?? undefined),
+              })
+            } catch (err) {
+              console.error('[auth] signup_completed capture failed:', err)
+            }
+          },
+        },
+      },
+    },
     emailAndPassword: {
       enabled: true,
       requireEmailVerification: true,
@@ -110,6 +144,24 @@ export const getCurrentUser = query({
   args: {},
   handler: async (ctx) => {
     return await authComponent.getAuthUser(ctx)
+  },
+})
+
+/**
+ * The viewer's user id — the SAME string every server-side capture uses as its
+ * PostHog `distinct_id` (#77).
+ *
+ * It has to be this exact value and not the creator profile id: the four
+ * server events are keyed on `tokenIdentifier.split('|')[1]`, and a browser
+ * identified under any other id splits the funnel into two strangers.
+ */
+export const getViewerId = query({
+  args: {},
+  returns: v.union(v.string(), v.null()),
+  handler: async (ctx) => {
+    const user = await ctx.auth.getUserIdentity()
+    if (!user) return null
+    return user.tokenIdentifier.split('|')[1] ?? null
   },
 })
 

--- a/convex/cliSessions.ts
+++ b/convex/cliSessions.ts
@@ -2,6 +2,7 @@ import { internalMutation, internalQuery, mutation, query } from './_generated/s
 import { v } from 'convex/values'
 import { isDisplaySafeName } from './lib/names'
 import { FULL_CLI_TOKEN_SCOPES } from './lib/cliScopes'
+import { captureServerEvent } from './analytics'
 
 export const getByUserCode = internalQuery({
   args: { userCode: v.string() },
@@ -163,6 +164,7 @@ export const createSession = internalMutation({
     secretId: v.string(),
     status: v.union(v.literal('pending'), v.literal('approved'), v.literal('expired')),
     machineName: v.optional(v.string()),
+    cliVersion: v.optional(v.string()),
     createdAt: v.number(),
     expiresAt: v.number(),
   },
@@ -173,6 +175,7 @@ export const createSession = internalMutation({
       secretId: args.secretId,
       status: args.status,
       machineName: args.machineName,
+      cliVersion: args.cliVersion,
       createdAt: args.createdAt,
       expiresAt: args.expiresAt,
     })
@@ -266,6 +269,14 @@ export const issueTokenAndDeleteSession = internalMutation({
     })
 
     await ctx.db.delete(args.sessionId)
+
+    // HERE, and not on gate approval (#77). Approving the page in a browser does
+    // not mean the CLI ever came back for the token — this is the first moment a
+    // machine is actually linked.
+    await captureServerEvent(ctx, 'cli_login_completed', args.userId, {
+      cliVersion: session.cliVersion ?? null,
+    })
+
     return { issued: true as const }
   },
 })

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -39,4 +39,10 @@ crons.daily(
   internal.measured.gcSnapshots,
 )
 
+// Hourly view-dedupe cleanup (#77, map #76). The markers exist only to make a
+// visitor count once per target per UTC day, so they are dead the moment the
+// day closes. Keeping today and yesterday means a delayed retry crossing
+// midnight cannot double-count. `viewCounters` is permanent and is NOT touched.
+crons.interval('view-dedupe-cleanup', { hours: 1 }, internal.views.gcDedupe)
+
 export default crons

--- a/convex/httpCli.ts
+++ b/convex/httpCli.ts
@@ -258,11 +258,22 @@ export const authStart = httpAction(async (ctx, request) => {
   const now = Date.now()
 
   let machineName: string | undefined
+  let cliVersion: string | undefined
   try {
-    const body = (await request.json()) as { machineName?: unknown }
+    const body = (await request.json()) as {
+      machineName?: unknown
+      cliVersion?: unknown
+    }
     if (typeof body?.machineName === 'string') {
       const trimmed = body.machineName.trim()
       if (isDisplaySafeName(trimmed)) machineName = trimmed
+    }
+    // Carried to the token exchange, where `cli_login_completed` reports it
+    // (#77). Bounded and dropped when malformed, like the name above: a version
+    // string must never be able to fail a login.
+    if (typeof body?.cliVersion === 'string') {
+      const trimmed = body.cliVersion.trim()
+      if (trimmed.length > 0 && trimmed.length <= 32) cliVersion = trimmed
     }
   } catch {
     // No body, or not JSON — an older CLI. Proceed nameless.
@@ -273,6 +284,7 @@ export const authStart = httpAction(async (ctx, request) => {
     secretId,
     status: 'pending',
     machineName,
+    cliVersion,
     createdAt: now,
     expiresAt: now + 15 * 60 * 1000,
   })
@@ -398,6 +410,24 @@ const EMPTY_OPT_INS = {
 }
 
 /**
+ * Read the auto-sync half of a sync body.
+ *
+ * A malformed value is DROPPED, not rejected. Refusing the whole sync because a
+ * telemetry field is the wrong shape would cost the owner the one thing they
+ * approved, over a field nothing user-facing reads.
+ */
+function parseAutoSync(
+  raw: unknown,
+): { enabled: boolean; frequencyHours: number } | undefined {
+  if (typeof raw !== 'object' || raw === null) return undefined
+  const value = raw as { enabled?: unknown; frequencyHours?: unknown }
+  if (typeof value.enabled !== 'boolean') return undefined
+  if (typeof value.frequencyHours !== 'number') return undefined
+  if (!Number.isFinite(value.frequencyHours)) return undefined
+  return { enabled: value.enabled, frequencyHours: value.frequencyHours }
+}
+
+/**
  * POST /api/cli/sync — publish one approved measured-layer snapshot.
  *
  * Wayfinder ticket #38 (map #29). The destination is the stack bound to the
@@ -414,7 +444,12 @@ export const syncPublish = httpAction(async (ctx, request) => {
   if (authResult instanceof Response) return authResult
   const { tokenId } = authResult
 
-  let body: { payload?: unknown; payloads?: unknown; keptPrivate?: unknown }
+  let body: {
+    payload?: unknown
+    payloads?: unknown
+    keptPrivate?: unknown
+    autoSync?: unknown
+  }
   try {
     body = await request.json()
   } catch {
@@ -439,6 +474,9 @@ export const syncPublish = httpAction(async (ctx, request) => {
       payload: body.payload as any,
       payloads: body.payloads as any,
       keptPrivate: body.keptPrivate as any,
+      // Additive and optional (#77): an installed CLI sends nothing here and
+      // keeps working, which reads as "this machine has never told us".
+      autoSync: parseAutoSync(body.autoSync),
     })
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)

--- a/convex/measured.ts
+++ b/convex/measured.ts
@@ -8,10 +8,13 @@ import {
   query,
 } from './_generated/server'
 import {
+  AutoSyncState,
   MeasuredPayload,
   PublishedNameCategory,
   ReconcileAtomKind,
 } from './schema'
+import { captureServerEvent } from './analytics'
+import { emitActivityEvent } from './activity'
 import { extractShortId } from './lib/ids'
 import {
   MODEL_ID_MAX,
@@ -1687,6 +1690,12 @@ export const publishForToken = internalMutation({
      * before this half exists on the machine.
      */
     keptPrivate: v.optional(KeptPrivateNames),
+    /**
+     * The machine's standing auto-sync opt-in, as it currently stands (#77).
+     * Optional: the opt-in lives in `~/.config/aistack/settings.json` and older
+     * clients report nothing, which reads as "never told us".
+     */
+    autoSync: v.optional(AutoSyncState),
   },
   returns: v.object({
     snapshotIds: v.array(v.id('measuredSnapshots')),
@@ -1728,12 +1737,68 @@ export const publishForToken = internalMutation({
       throw new Error('Token is no longer authorized for its linked stack')
     }
 
+    // Asked BEFORE the inserts, or every sync looks like the first one.
+    const priorSnapshot = await ctx.db
+      .query('measuredSnapshots')
+      .withIndex('by_stack_capturedAt', (q) => q.eq('stackId', stack._id))
+      .first()
+    const isFirstSync = priorSnapshot === null
+
     const snapshotIds: Id<'measuredSnapshots'>[] = []
     let receivedAt = 0
     for (const payload of payloads) {
       const inserted = await insertSnapshot(ctx, stack._id, payload)
       snapshotIds.push(inserted.snapshotId)
       receivedAt = inserted.receivedAt
+    }
+
+    // ONE event per approved sync, never one per snapshot: this mutation lands
+    // up to 8 payloads atomically, so a per-snapshot emit would fire 8 times for
+    // one sync (#77). Summarizing the whole batch is also what lets the read
+    // path drop its broken cross-page dedupe.
+    //
+    // Skipped for a draft. Visibility is re-checked at read time — this gate
+    // only stops a week of drafting from filling the table with rows that can
+    // never be shown.
+    if (stack.published) {
+      await emitActivityEvent(
+        ctx,
+        stack._id,
+        {
+          type: 'sync.landed',
+          harnesses: payloads.map((p) => ({
+            harness: p.harness.name,
+            windowDays: p.window.days,
+            sessions: p.activity.sessions,
+            activeDays: p.activity.activeDays,
+            projects: p.activity.projects,
+            totalTokens: p.activity.totalTokens,
+          })),
+        },
+        receivedAt,
+      )
+    }
+
+    if (isFirstSync) {
+      await captureServerEvent(ctx, 'first_sync_completed', token.userId, {
+        harnesses: payloads.map((p) => p.harness.name),
+        windowDays: payloads[0]?.window.days ?? 0,
+      })
+    }
+
+    // The transition from unknown-or-off to on, as the BACKEND sees it — so it
+    // fires once and not on every subsequent sync.
+    if (args.autoSync?.enabled && token.autoSync?.enabled !== true) {
+      await captureServerEvent(ctx, 'auto_sync_enabled', token.userId, {
+        frequencyHours: args.autoSync.frequencyHours,
+      })
+    }
+    if (
+      args.autoSync !== undefined &&
+      (token.autoSync?.enabled !== args.autoSync.enabled ||
+        token.autoSync?.frequencyHours !== args.autoSync.frequencyHours)
+    ) {
+      await ctx.db.patch(token._id, { autoSync: args.autoSync })
     }
 
     // The switch is not client-side-only. A client that sends the half anyway —

--- a/convex/rateLimit.ts
+++ b/convex/rateLimit.ts
@@ -41,7 +41,7 @@ type RateLimitResult = {
  * `key` is opaque and namespaced by its caller (`ip:1.2.3.4`,
  * `cli-token:<id>`), so two kinds of caller can never collide in one bucket.
  */
-async function consume(
+export async function consume(
   ctx: MutationCtx,
   key: string,
   maxRequests: number,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -166,6 +166,91 @@ export const PublishedNameCategory = v.union(
   v.literal('slashCommands')
 )
 
+// ---------------------------------------------------------------------------
+// Instrumentation — the three signal families (#77, map #76).
+// ---------------------------------------------------------------------------
+
+/**
+ * What a view counter counts. Polymorphic on purpose: all three kinds exist on
+ * day one, and `aggregate` has no document to type against at all — typed
+ * optional columns would force its row to carry every id field absent.
+ */
+export const ViewTargetKind = v.union(
+  v.literal('stack'),
+  v.literal('creator'),
+  v.literal('aggregate')
+)
+
+/**
+ * Where a session came from, decided ONCE per session from `document.referrer`
+ * and carried on every later page as `internal` (#77). `ai` is split out of
+ * `search` because "did an assistant send someone here" is the question the
+ * aggregate page exists to answer, and it cannot be added retroactively.
+ */
+export const ReferrerBucket = v.union(
+  v.literal('direct'),
+  v.literal('search'),
+  v.literal('ai'),
+  v.literal('social'),
+  v.literal('internal'),
+  v.literal('other')
+)
+
+/**
+ * A tool, model or bundle named in a composition change, with its display name
+ * FROZEN at write time. The feed is a historical record, so the name at the
+ * moment of the change is the correct value — and freezing it also kills a
+ * per-row catalog lookup on the read path.
+ */
+export const ActivityAtom = v.object({
+  kind: v.union(v.literal('tool'), v.literal('model'), v.literal('bundle')),
+  slug: v.string(),
+  name: v.string(),
+})
+
+/**
+ * ONE discriminated union, not a top-level `type` plus a separate payload
+ * validator (#77). Two independent discriminators make a mismatched row legal,
+ * and a reader switching on `type` then gets the wrong payload shape.
+ *
+ * There is no cost field. `apiEquivalentUSD` is stored PER MODEL and is absent
+ * when a model is unpriced, so there is no snapshot-level total to copy —
+ * summing the model values would present a partial sum as a total. Adding cost
+ * later needs a `costComplete` flag alongside it.
+ */
+export const ActivityEvent = v.union(
+  v.object({
+    type: v.literal('stack.published'),
+    toolCount: v.number(),
+  }),
+  v.object({
+    type: v.literal('stack.composition_changed'),
+    added: v.array(ActivityAtom),
+    removed: v.array(ActivityAtom),
+  }),
+  v.object({
+    type: v.literal('sync.landed'),
+    // The WHOLE batch. `publishForToken` lands up to 8 payloads in one atomic
+    // mutation, so a per-snapshot event would fire up to 8 times for one sync.
+    harnesses: v.array(
+      v.object({
+        harness: v.string(),
+        windowDays: v.number(),
+        sessions: v.number(),
+        activeDays: v.number(),
+        projects: v.number(),
+        totalTokens: v.number(),
+      })
+    ),
+  })
+)
+
+/** What the CLI reports about its standing auto-sync opt-in (#77). */
+export const AutoSyncState = v.object({
+  enabled: v.boolean(),
+  frequencyHours: v.number(),
+})
+
 const ResourceOwner = v.union(
   v.object({ kind: v.literal('creator'), id: v.id('creators') }),
   v.object({ kind: v.literal('github'), handle: v.string() }),
@@ -469,6 +554,14 @@ export default defineSchema({
     // always one the user saw and could overwrite. Optional permanently: an
     // older CLI sends nothing, and the user may clear the field.
     machineName: v.optional(v.string()),
+    // What the CLI calls itself, carried from `authStart` to the token exchange
+    // so `cli_login_completed` can report it (#77). Optional permanently: an
+    // older CLI sends nothing, and the login must still work.
+    //
+    // Recorded HERE and not on the poll, because the poll is a bare GET with a
+    // secretId — adding a query parameter to it would be a second wire change
+    // for a field the session already had a place to hold.
+    cliVersion: v.optional(v.string()),
     createdAt: v.number(),
     expiresAt: v.number(),
   })
@@ -525,6 +618,14 @@ export default defineSchema({
     // this. An absent array would otherwise read as full access forever, which
     // is a permanent bypass rather than a migration step.
     scopes: v.array(CliTokenScope),
+    // The last auto-sync opt-in state this machine reported (#77). The opt-in
+    // itself lives in `~/.config/aistack/settings.json` and the backend never
+    // learned about it, so `auto_sync_enabled` had nothing to fire on.
+    //
+    // Held per TOKEN and not per stack, because the opt-in is a property of a
+    // machine. Absent means "never reported", which is what makes the
+    // unknown-or-off → on transition detectable exactly once.
+    autoSync: v.optional(AutoSyncState),
     createdAt: v.number(),
     expiresAt: v.number(),
     lastUsedAt: v.number(),
@@ -714,4 +815,61 @@ export default defineSchema({
     .index('by_stack', ['stackId'])
     // The expiry sweep's index. Age is the only thing it asks about.
     .index('by_stagedAt', ['stagedAt']),
+
+  // -------------------------------------------------------------------------
+  // Views (#77). Two tables: a PERMANENT counter and a DISPOSABLE marker.
+  //
+  // Deduping one visitor per target per day already forces one marker row per
+  // (visitor, target, day), so a counter saves no rows. What it buys is the
+  // right to throw the markers away after a day — which keeps the permanent
+  // table bounded by `targets x days x buckets` instead of by traffic, and
+  // keeps the visitor hash out of the permanent record entirely.
+  // -------------------------------------------------------------------------
+  viewCounters: defineTable({
+    targetKind: ViewTargetKind,
+    // The DOCUMENT id, never the slug, so a rename does not orphan history.
+    // The aggregate page has no document and uses the sentinel `'global'`.
+    targetId: v.string(),
+    /** UTC midnight of the day being counted. */
+    dayStartMs: v.number(),
+    referrerBucket: ReferrerBucket,
+    count: v.number(),
+  }).index('by_target_day', ['targetKind', 'targetId', 'dayStartMs']),
+
+  // The dedupe marker. Names its target in real columns rather than burying it
+  // in an opaque digest, so the query semantics are visible in the index.
+  //
+  // `visitorHash` is HMAC(secret, ip + userAgent + target + day) computed in the
+  // web server. The raw IP never reaches Convex.
+  viewDedupe: defineTable({
+    targetKind: ViewTargetKind,
+    targetId: v.string(),
+    dayStartMs: v.number(),
+    visitorHash: v.string(),
+  })
+    .index('by_target_day_hash', ['targetKind', 'targetId', 'dayStartMs', 'visitorHash'])
+    // The hourly GC's index. Age is the only thing it asks about.
+    .index('by_day', ['dayStartMs']),
+
+  // -------------------------------------------------------------------------
+  // The activity feed (#77). Append-only, written at the moment things happen —
+  // NOT derived at read time from `measuredSnapshots`/`stacks`, because
+  // derivation gets expensive and cannot express "tool X added" at all.
+  //
+  // Visibility is enforced at READ time, which is the only place it can be
+  // correct: a stack can be unpublished after the event is written and this
+  // table never mutates. The write side still gates on drafts, so a week of
+  // drafting cannot fill the table with rows that can never be shown.
+  // -------------------------------------------------------------------------
+  activityEvents: defineTable({
+    stackId: v.id('stacks'),
+    // EXPLICIT, not Convex's implicit `_creationTime`: seeding the feed from
+    // existing snapshots is likely, and backfilled rows would all carry today's
+    // insert time and sort wrong.
+    createdAt: v.number(),
+    event: ActivityEvent,
+  })
+    // The feed's only query. `by_stack_createdAt` is deliberately NOT built —
+    // nothing on this map reads per-stack activity. Add it when something does.
+    .index('by_createdAt', ['createdAt']),
 })

--- a/convex/stacks.ts
+++ b/convex/stacks.ts
@@ -10,6 +10,7 @@ import { resolveLinkedResources, upsertResourcesForOwner } from './lib/resourceL
 import { normalizeProjectUrl } from './projects'
 import { assertValidAccentPreset } from './lib/iconUrl'
 import { resolveCreatorAvatarUrl } from './lib/avatar'
+import { diffComposition, emitActivityEvent } from './activity'
 
 type ToolSubscriptionLike = {
   price: {
@@ -420,6 +421,19 @@ export const create = mutation({
       updatedAt: now,
     })
 
+    // `stack.published` fires from create as well as update: this mutation takes
+    // `published` as an argument and writes it directly, so stacks are NOT
+    // always created as drafts and a flip-only fire point would miss every
+    // stack created public (#77).
+    if (args.published) {
+      await emitActivityEvent(
+        ctx,
+        id,
+        { type: 'stack.published', toolCount: args.toolSubscriptions.length },
+        now,
+      )
+    }
+
     if (args.resources !== undefined) {
       await upsertResourcesForOwner(ctx, {
         addedBy: creator._id,
@@ -499,6 +513,43 @@ export const update = mutation({
 
     await ctx.db.patch(args.stackId, patch)
 
+    // THE DRAFT GATE READS RESULTING STATE, not the pre-mutation value (#77).
+    // Reading the old value has a live bug: one update that changes composition
+    // and sets `published: false` would write an event the reader hides, and a
+    // republish months later would surface that stale event as current public
+    // activity.
+    const willBePublished = args.published ?? stack.published
+    if (willBePublished) {
+      if (!stack.published) {
+        // Publishing a draft emits ONLY this, even when the same call also
+        // changed composition. The publish already tells the reader everything.
+        await emitActivityEvent(ctx, args.stackId, {
+          type: 'stack.published',
+          toolCount: subs.length,
+        })
+      } else {
+        // Composition only — a tool, model or bundle added or removed. Prose
+        // edits are excluded, which keeps authoring noise out of a feed that
+        // will be thin at launch.
+        const { added, removed } = await diffComposition(
+          ctx,
+          stack,
+          {
+            toolSubscriptions: subs,
+            modelSubscriptions: args.modelSubscriptions ?? stack.modelSubscriptions,
+            bundleSubscriptions: bSubs,
+          },
+        )
+        if (added.length > 0 || removed.length > 0) {
+          await emitActivityEvent(ctx, args.stackId, {
+            type: 'stack.composition_changed',
+            added,
+            removed,
+          })
+        }
+      }
+    }
+
     if (args.resources !== undefined) {
       await upsertResourcesForOwner(ctx, {
         addedBy: stack.creatorId,
@@ -526,6 +577,7 @@ export const getForEdit = query({
       fixedTotal: v.optional(MoneyValidator),
       hasUsageComponent: v.boolean(),
       published: v.boolean(),
+      publishCost: v.optional(v.boolean()),
       accentPreset: v.optional(v.string()),
 
       toolSubscriptions: v.array(v.object({
@@ -669,6 +721,9 @@ export const getForEdit = query({
       fixedTotal: pricing.fixedTotal,
       hasUsageComponent: pricing.hasUsageComponent,
       published: stack.published,
+      // Carried so `stack_published` can report it (#77). Absent reads as opted
+      // IN — the field only ever records a refusal.
+      publishCost: stack.publishCost,
       accentPreset: stack.accentPreset,
       toolSubscriptions: toolSubs,
       bundleSubscriptions: bundleSubs,

--- a/convex/views.test.ts
+++ b/convex/views.test.ts
@@ -1,0 +1,309 @@
+/// <reference types="vite/client" />
+import { convexTest } from 'convex-test'
+import { expect, test } from 'vitest'
+import schema from './schema'
+import { api, internal } from './_generated/api'
+import type { MutationCtx } from './_generated/server'
+import type { Id } from './_generated/dataModel'
+
+const modules = import.meta.glob('./**/*.{js,ts}')
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+function today(): number {
+  return Math.floor(Date.now() / DAY_MS) * DAY_MS
+}
+
+async function seedStack(
+  t: ReturnType<typeof convexTest>,
+  opts: { userId: string; slug: string; published?: boolean },
+): Promise<{ stackId: Id<'stacks'>; creatorId: Id<'creators'> }> {
+  return await t.run(async (ctx: MutationCtx) => {
+    const creatorId = await ctx.db.insert('creators', {
+      name: `Creator ${opts.userId}`,
+      slug: opts.slug,
+      userId: opts.userId,
+      verified: false,
+      personalPages: [],
+      projectPages: [],
+      createdAt: Date.now(),
+    })
+    const stackId = await ctx.db.insert('stacks', {
+      name: 'Stack',
+      slug: opts.slug,
+      shortId: opts.slug.slice(0, 6),
+      creatorId,
+      oneLiner: 'one',
+      toolSubscriptions: [],
+      hasUsageComponent: false,
+      published: opts.published ?? true,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    })
+    return { stackId, creatorId }
+  })
+}
+
+const baseArgs = {
+  targetKind: 'stack' as const,
+  visitorHash: 'hash-a',
+  rateKey: 'rate-a',
+  referrerBucket: 'search' as const,
+}
+
+// ---------------------------------------------------------------------------
+// Counting and dedupe
+// ---------------------------------------------------------------------------
+
+test('a first view counts and files one counter row in its referrer bucket', async () => {
+  const t = convexTest(schema, modules)
+  const { stackId } = await seedStack(t, { userId: 'u1', slug: 'creator-one' })
+
+  const result = await t.mutation(api.views.record, {
+    ...baseArgs,
+    targetId: stackId,
+  })
+
+  expect(result.counted).toBe(true)
+  const counters = await t.run((ctx: MutationCtx) =>
+    ctx.db.query('viewCounters').collect(),
+  )
+  expect(counters).toHaveLength(1)
+  expect(counters[0]).toMatchObject({
+    targetKind: 'stack',
+    targetId: stackId,
+    dayStartMs: today(),
+    referrerBucket: 'search',
+    count: 1,
+  })
+})
+
+test('the same visitor hash on the same day counts once', async () => {
+  const t = convexTest(schema, modules)
+  const { stackId } = await seedStack(t, { userId: 'u2', slug: 'creator-two' })
+
+  const first = await t.mutation(api.views.record, { ...baseArgs, targetId: stackId })
+  const second = await t.mutation(api.views.record, { ...baseArgs, targetId: stackId })
+
+  expect(first.counted).toBe(true)
+  expect(second.counted).toBe(false)
+  const counters = await t.run((ctx: MutationCtx) =>
+    ctx.db.query('viewCounters').collect(),
+  )
+  expect(counters).toHaveLength(1)
+  expect(counters[0].count).toBe(1)
+})
+
+test('a different visitor hash counts again in the same bucket', async () => {
+  const t = convexTest(schema, modules)
+  const { stackId } = await seedStack(t, { userId: 'u3', slug: 'creator-three' })
+
+  await t.mutation(api.views.record, { ...baseArgs, targetId: stackId })
+  await t.mutation(api.views.record, {
+    ...baseArgs,
+    targetId: stackId,
+    visitorHash: 'hash-b',
+  })
+
+  const counters = await t.run((ctx: MutationCtx) =>
+    ctx.db.query('viewCounters').collect(),
+  )
+  expect(counters).toHaveLength(1)
+  expect(counters[0].count).toBe(2)
+})
+
+test('two referrer buckets on one target-day are two counter rows', async () => {
+  const t = convexTest(schema, modules)
+  const { stackId } = await seedStack(t, { userId: 'u4', slug: 'creator-four' })
+
+  await t.mutation(api.views.record, { ...baseArgs, targetId: stackId })
+  await t.mutation(api.views.record, {
+    ...baseArgs,
+    targetId: stackId,
+    visitorHash: 'hash-b',
+    referrerBucket: 'ai',
+  })
+
+  const counters = await t.run((ctx: MutationCtx) =>
+    ctx.db.query('viewCounters').collect(),
+  )
+  expect(counters).toHaveLength(2)
+  expect(counters.map((c) => c.referrerBucket).sort()).toEqual(['ai', 'search'])
+})
+
+// ---------------------------------------------------------------------------
+// Owner exclusion — the identity is derived, never an argument
+// ---------------------------------------------------------------------------
+
+test('the authenticated owner of a stack does not count as a view', async () => {
+  const t = convexTest(schema, modules)
+  const { stackId } = await seedStack(t, { userId: 'owner-1', slug: 'creator-own' })
+  const asOwner = t.withIdentity({ tokenIdentifier: 'convex|owner-1' })
+
+  const result = await asOwner.mutation(api.views.record, {
+    ...baseArgs,
+    targetId: stackId,
+  })
+
+  expect(result.counted).toBe(false)
+  const counters = await t.run((ctx: MutationCtx) =>
+    ctx.db.query('viewCounters').collect(),
+  )
+  expect(counters).toHaveLength(0)
+})
+
+test('a different authenticated user counts normally', async () => {
+  const t = convexTest(schema, modules)
+  const { stackId } = await seedStack(t, { userId: 'owner-2', slug: 'creator-own2' })
+  const asStranger = t.withIdentity({ tokenIdentifier: 'convex|stranger' })
+
+  const result = await asStranger.mutation(api.views.record, {
+    ...baseArgs,
+    targetId: stackId,
+  })
+
+  expect(result.counted).toBe(true)
+})
+
+test('the owner of a creator profile does not count as a view of it', async () => {
+  const t = convexTest(schema, modules)
+  const { creatorId } = await seedStack(t, { userId: 'owner-3', slug: 'creator-own3' })
+  const asOwner = t.withIdentity({ tokenIdentifier: 'convex|owner-3' })
+
+  const result = await asOwner.mutation(api.views.record, {
+    ...baseArgs,
+    targetKind: 'creator',
+    targetId: creatorId,
+  })
+
+  expect(result.counted).toBe(false)
+})
+
+// ---------------------------------------------------------------------------
+// Targets
+// ---------------------------------------------------------------------------
+
+test('a target id that resolves to nothing is not counted', async () => {
+  const t = convexTest(schema, modules)
+  await seedStack(t, { userId: 'u5', slug: 'creator-five' })
+
+  const result = await t.mutation(api.views.record, {
+    ...baseArgs,
+    targetId: 'not-an-id',
+  })
+
+  expect(result.counted).toBe(false)
+})
+
+test("the aggregate page counts under the 'global' sentinel and nothing else", async () => {
+  const t = convexTest(schema, modules)
+
+  const good = await t.mutation(api.views.record, {
+    ...baseArgs,
+    targetKind: 'aggregate',
+    targetId: 'global',
+  })
+  const bad = await t.mutation(api.views.record, {
+    ...baseArgs,
+    targetKind: 'aggregate',
+    targetId: 'something-else',
+    visitorHash: 'hash-b',
+  })
+
+  expect(good.counted).toBe(true)
+  expect(bad.counted).toBe(false)
+})
+
+test('a signed-in user counts on the aggregate page — it has no owner', async () => {
+  const t = convexTest(schema, modules)
+  const asSomeone = t.withIdentity({ tokenIdentifier: 'convex|anyone' })
+
+  const result = await asSomeone.mutation(api.views.record, {
+    ...baseArgs,
+    targetKind: 'aggregate',
+    targetId: 'global',
+  })
+
+  expect(result.counted).toBe(true)
+})
+
+// ---------------------------------------------------------------------------
+// Rate limit
+// ---------------------------------------------------------------------------
+
+test('one address is capped per minute, and the cap does not spill onto another address', async () => {
+  const t = convexTest(schema, modules)
+  const { stackId } = await seedStack(t, { userId: 'u6', slug: 'creator-six' })
+
+  let refused = 0
+  for (let i = 0; i < 130; i++) {
+    const r = await t.mutation(api.views.record, {
+      ...baseArgs,
+      targetId: stackId,
+      visitorHash: `hash-${i}`,
+    })
+    if (!r.counted) refused++
+  }
+  expect(refused).toBe(10)
+
+  const other = await t.mutation(api.views.record, {
+    ...baseArgs,
+    targetId: stackId,
+    visitorHash: 'hash-other',
+    rateKey: 'rate-b',
+  })
+  expect(other.counted).toBe(true)
+})
+
+// ---------------------------------------------------------------------------
+// Retention
+// ---------------------------------------------------------------------------
+
+test('the GC drops markers older than yesterday and keeps today and yesterday', async () => {
+  const t = convexTest(schema, modules)
+  const dayStart = today()
+  await t.run(async (ctx: MutationCtx) => {
+    for (const [offset, hash] of [
+      [0, 'today'],
+      [-DAY_MS, 'yesterday'],
+      [-2 * DAY_MS, 'older'],
+      [-9 * DAY_MS, 'oldest'],
+    ] as const) {
+      await ctx.db.insert('viewDedupe', {
+        targetKind: 'stack',
+        targetId: 'x',
+        dayStartMs: dayStart + offset,
+        visitorHash: hash,
+      })
+    }
+  })
+
+  const result = await t.mutation(internal.views.gcDedupe, {})
+
+  expect(result.deleted).toBe(2)
+  const left = await t.run((ctx: MutationCtx) =>
+    ctx.db.query('viewDedupe').collect(),
+  )
+  expect(left.map((r) => r.visitorHash).sort()).toEqual(['today', 'yesterday'])
+})
+
+test('the GC never touches viewCounters', async () => {
+  const t = convexTest(schema, modules)
+  await t.run(async (ctx: MutationCtx) => {
+    await ctx.db.insert('viewCounters', {
+      targetKind: 'stack',
+      targetId: 'x',
+      dayStartMs: today() - 30 * DAY_MS,
+      referrerBucket: 'direct',
+      count: 7,
+    })
+  })
+
+  await t.mutation(internal.views.gcDedupe, {})
+
+  const counters = await t.run((ctx: MutationCtx) =>
+    ctx.db.query('viewCounters').collect(),
+  )
+  expect(counters).toHaveLength(1)
+  expect(counters[0].count).toBe(7)
+})

--- a/convex/views.ts
+++ b/convex/views.ts
@@ -1,0 +1,187 @@
+// The view-counting write side (#77, map #76).
+//
+// What the number means: `IP + User-Agent` merges people behind one NAT and
+// splits one person across networks. Every surface calls this **deduped daily
+// visitors** — approximate browser and network combinations per UTC day. It is
+// never presented as people, and never as impressions.
+
+import { v } from 'convex/values'
+import { internalMutation, mutation } from './_generated/server'
+import type { MutationCtx } from './_generated/server'
+import { ReferrerBucket, ViewTargetKind } from './schema'
+import { consume } from './rateLimit'
+import type { Infer } from 'convex/values'
+
+type ViewTargetKindValue = Infer<typeof ViewTargetKind>
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/** UTC midnight of the day `ms` falls in. */
+export function utcDayStart(ms: number): number {
+  return Math.floor(ms / DAY_MS) * DAY_MS
+}
+
+/** The one target id the aggregate page uses. It has no document. */
+export const AGGREGATE_TARGET_ID = 'global'
+
+/**
+ * Views one address may file per minute.
+ *
+ * Set well above real reading speed and well below what a loop can do. It does
+ * not stop a determined inflater — they can vary `visitorHash` freely within
+ * the cap — it stops one from filling the table.
+ */
+const VIEWS_PER_MINUTE = 120
+
+/**
+ * The user who owns this target, or `null` when nobody does.
+ *
+ * The aggregate counter has no owner, so it is admin-only on the read side.
+ * "Owner-private" is a per-target rule here, not a global one.
+ */
+async function ownerOf(
+  ctx: MutationCtx,
+  targetKind: ViewTargetKindValue,
+  targetId: string
+): Promise<{ exists: boolean; userId: string | null }> {
+  if (targetKind === 'aggregate') {
+    return { exists: targetId === AGGREGATE_TARGET_ID, userId: null }
+  }
+  if (targetKind === 'creator') {
+    const creatorId = ctx.db.normalizeId('creators', targetId)
+    if (!creatorId) return { exists: false, userId: null }
+    const creator = await ctx.db.get(creatorId)
+    return { exists: creator !== null, userId: creator?.userId ?? null }
+  }
+  const stackId = ctx.db.normalizeId('stacks', targetId)
+  if (!stackId) return { exists: false, userId: null }
+  const stack = await ctx.db.get(stackId)
+  if (!stack) return { exists: false, userId: null }
+  const creator = await ctx.db.get(stack.creatorId)
+  return { exists: true, userId: creator?.userId ?? null }
+}
+
+/**
+ * Count one view.
+ *
+ * THE VIEWER IDENTITY IS NEVER AN ARGUMENT. A public mutation taking a
+ * `viewerUserId` would let any caller suppress a competitor's views or
+ * attribute their own — the same shape as this repo's existing
+ * public-function auth gap. The identity is read from the authenticated
+ * session the web server forwards, and from nowhere else.
+ *
+ * `dayStartMs` is likewise derived here rather than accepted, so a caller
+ * cannot backdate a view into a closed day. The web server's own notion of the
+ * day still rides inside `visitorHash`, which is what rotates the hash daily.
+ *
+ * `visitorHash` IS an argument, because computing it needs the raw IP and the
+ * raw IP must not reach Convex. A caller who invents hashes can inflate their
+ * own target's counter. That is accepted: the number is private to the owner
+ * and ranks nothing, and the alternative is shipping IP addresses into the
+ * database to defend a dashboard against its own owner.
+ */
+export const record = mutation({
+  args: {
+    targetKind: ViewTargetKind,
+    targetId: v.string(),
+    visitorHash: v.string(),
+    /**
+     * A per-address pseudonym — HMAC over the client IP alone, with no target
+     * and no day in it, so one caller shares one bucket across every page.
+     * Bounds row growth from a loop that varies `visitorHash` on every call.
+     */
+    rateKey: v.string(),
+    referrerBucket: ReferrerBucket,
+  },
+  returns: v.object({ counted: v.boolean() }),
+  handler: async (ctx, args) => {
+    const rl = await consume(ctx, `view:${args.rateKey}`, VIEWS_PER_MINUTE)
+    if (!rl.allowed) return { counted: false }
+
+    const target = await ownerOf(ctx, args.targetKind, args.targetId)
+    if (!target.exists) return { counted: false }
+
+    // A signed-out owner cannot be recognized, which is why every surface says
+    // "authenticated owner views excluded" and not "your own views excluded".
+    const identity = await ctx.auth.getUserIdentity()
+    const viewerId = identity?.tokenIdentifier.split('|')[1] ?? null
+    if (viewerId !== null && viewerId === target.userId) {
+      return { counted: false }
+    }
+
+    const dayStartMs = utcDayStart(Date.now())
+
+    const seen = await ctx.db
+      .query('viewDedupe')
+      .withIndex('by_target_day_hash', (q) =>
+        q
+          .eq('targetKind', args.targetKind)
+          .eq('targetId', args.targetId)
+          .eq('dayStartMs', dayStartMs)
+          .eq('visitorHash', args.visitorHash)
+      )
+      .first()
+    if (seen) return { counted: false }
+
+    await ctx.db.insert('viewDedupe', {
+      targetKind: args.targetKind,
+      targetId: args.targetId,
+      dayStartMs,
+      visitorHash: args.visitorHash,
+    })
+
+    const bucketRow = await ctx.db
+      .query('viewCounters')
+      .withIndex('by_target_day', (q) =>
+        q
+          .eq('targetKind', args.targetKind)
+          .eq('targetId', args.targetId)
+          .eq('dayStartMs', dayStartMs)
+      )
+      .filter((q) => q.eq(q.field('referrerBucket'), args.referrerBucket))
+      .first()
+
+    if (bucketRow) {
+      await ctx.db.patch(bucketRow._id, { count: bucketRow.count + 1 })
+    } else {
+      await ctx.db.insert('viewCounters', {
+        targetKind: args.targetKind,
+        targetId: args.targetId,
+        dayStartMs,
+        referrerBucket: args.referrerBucket,
+        count: 1,
+      })
+    }
+
+    return { counted: true }
+  },
+})
+
+/** One sweep's ceiling, so a backlog drains over several runs instead of
+ * blowing one transaction. */
+const GC_BATCH = 1000
+
+/**
+ * Delete spent dedupe markers.
+ *
+ * TODAY AND YESTERDAY SURVIVE. A marker only has to outlive the day it guards,
+ * but keeping one extra day means a delayed retry crossing UTC midnight cannot
+ * double-count. `viewCounters` is permanent and never downsampled — it grows
+ * with `targets x active days x buckets used`, not with traffic.
+ */
+export const gcDedupe = internalMutation({
+  args: {},
+  returns: v.object({ deleted: v.number() }),
+  handler: async (ctx) => {
+    const cutoff = utcDayStart(Date.now()) - DAY_MS
+    const stale = await ctx.db
+      .query('viewDedupe')
+      .withIndex('by_day', (q) => q.lt('dayStartMs', cutoff))
+      .take(GC_BATCH)
+
+    for (const row of stale) {
+      await ctx.db.delete(row._id)
+    }
+    return { deleted: stale.length }
+  },
+})

--- a/docs/direction.md
+++ b/docs/direction.md
@@ -1,6 +1,8 @@
 # AI Stack — Direction
 
-*The canonical product direction, produced by the [wayfinder map #3](https://github.com/alp82/aistack/issues/3) (closed 2026-07-22). Every bet links back to the ticket that decided it. Future execution maps amend this doc.*
+*The durable product direction, produced by the [wayfinder map #3](https://github.com/alp82/aistack/issues/3) (closed 2026-07-22). Every bet links back to the ticket that decided it.*
+
+*Slimmed 2026-08-03 at the [map #76](https://github.com/alp82/aistack/issues/76) charting. **Wayfinder maps own roadmap sequencing and the hand-off ledger** — the last ticket of every map charts the next map and carries everything it inherits. This doc keeps only what outlives any single map: the USP, the identity, the standing constraints, the success signals, and the parking lot. Amend it when a durable tenet changes, not when a map reorders work.*
 
 ## USP
 
@@ -24,38 +26,34 @@ Consultant marketplace: **parked** (P3), as a measured "available for hire" affo
 
 ### Auto-sync (the core mechanism)
 
-The evidence engine behind face 1, decided in [#8](https://github.com/alp82/aistack/issues/8) and [#13](https://github.com/alp82/aistack/issues/13): a **Claude-Code-first Skill** that analyzes transcripts **locally**, computes usage-share + recency + cost **deterministically** (measured, not claimed; an LLM only drafts qualitative what-for notes), and sends **only user-approved derived aggregates** through an explicit local approve-gate into an editable web draft. Capture-not-carry: the old CLI's config-carry job is retired. Atomic unit: the `(user, tool)` pair; the stack is a derived rollup. Pluggable per-agent adapter seam; Claude Code is the beachhead.
+The evidence engine behind face 1, decided in [#8](https://github.com/alp82/aistack/issues/8) and [#13](https://github.com/alp82/aistack/issues/13): a terminal command that analyzes transcripts **locally**, computes usage-share + recency + cost **deterministically** (measured, not claimed; an LLM only drafts qualitative what-for notes), and sends **only user-approved derived aggregates** through an explicit local approve-gate into an editable web draft. Capture-not-carry: the old CLI's config-carry job is retired. Atomic unit: the `(user, tool)` pair; the stack is a derived rollup. A pluggable per-harness adapter seam carries Claude Code and Codex, and each harness publishes its own snapshots.
 
-Channel mix, decided 2026-07-31 in [#56](https://github.com/alp82/aistack/issues/56): the terminal command `npx @use-aistack/cli sync` is the primary surface. The in-session MCP+Skill flow is an opt-in convenience, offered once after a successful sync and installed via `aistack connect claude`. Auto-sync (the fast-follow) is silent background re-sync under one standing, revocable opt-in — no session greetings, no per-send dialogs; frequency is configurable, **default once per day** (amended 2026-08-01 at the [map #60](https://github.com/alp82/aistack/issues/60) charting; [#56](https://github.com/alp82/aistack/issues/56) sketched weekly). Fail-closed name filtering is what makes the unattended repeat sync safe: it can only refresh data the user already approved.
+Channel mix, decided 2026-07-31 in [#56](https://github.com/alp82/aistack/issues/56): the terminal command `npx @use-aistack/cli sync` is the primary surface. The in-session MCP+Skill flow is an opt-in convenience, offered once after a successful sync and installed via `aistack connect claude`. Background re-sync is silent, under one standing revocable opt-in — no session greetings, no per-send dialogs; frequency is configurable, **default once per day**. Fail-closed name filtering is what makes the unattended repeat sync safe: it can only refresh data the user already approved.
 
-## Roadmap
+## Where the work is
 
-### P0 — the USP gate (strictly sequenced)
+The live map is always the open issue labelled `wayfinder:map`. Shipped so far:
 
-1. **Profile-first decoupling migration** ([#16](https://github.com/alp82/aistack/issues/16)) — **SHIPPED 2026-07-24** ([map #20](https://github.com/alp82/aistack/issues/20)). Decouple the person (profile) from the stack (an artifact on the profile), N stacks per profile. Fixes the live identity confusions (self-promo "stacks", stack image/name doubling as profile image/name). **Must land before auto-sync** — capture keys to a stack, and decoupling afterwards would force a second migration of captured data.
-2. **Auto-sync** ([#8](https://github.com/alp82/aistack/issues/8), [#13](https://github.com/alp82/aistack/issues/13)) — **SHIPPED 2026-07-30** ([map #29](https://github.com/alp82/aistack/issues/29)): living stacks 1/1 on prod after the first real sync ([#53](https://github.com/alp82/aistack/issues/53)). The Skill above. P0 capture set: inventory + usage-share + recency + cost + one-line authored what-for. Skills/MCP invocation counts are the first extension after.
+- **Profile-first decoupling** ([map #20](https://github.com/alp82/aistack/issues/20), 2026-07-24) — the person (profile) decoupled from the stack, N stacks per profile.
+- **Auto-sync** ([map #29](https://github.com/alp82/aistack/issues/29), 2026-07-30) — first living stack on prod.
+- **Sync follow-ups and Codex** ([map #60](https://github.com/alp82/aistack/issues/60), 2026-08-03) — silent background re-sync, credential and secret hardening, Codex as the second harness behind the adapter seam, two external-user live tests passed.
 
-P0 is deliberately two items, and both have shipped. The channel-mix thread (#54/#55/#56) resolved terminal-first and [map #29](https://github.com/alp82/aistack/issues/29) is closed; its follow-up ledger stays the canonical hand-off list. The sync follow-ups (background re-sync, credential hardening, Codex as the second harness, two external-user live tests) are charted as [map #60](https://github.com/alp82/aistack/issues/60) and run **before** P1.
+## Parking lot
 
-### P1 — one map, after map #60
-
-Reordered 2026-08-01 at the [map #60](https://github.com/alp82/aistack/issues/60) charting: the weekly digest moved to P2 (not ready), and the remaining four items fold into **one map**, charted after map #60 ships. It also takes the minimal event instrumentation ([#5](https://github.com/alp82/aistack/issues/5)).
-
-1. **Owner-private view analytics** ([#14](https://github.com/alp82/aistack/issues/14)) — rides the profile-first migration as a profile-level surface. Private creator dashboard of own page/stack views — motivates publishing and sharing; not a public number.
-2. **Live stack-page stats** ([#15](https://github.com/alp82/aistack/issues/15)) — auto-sync-gated. The living-page payoff: the moment capture ships, pages visibly move.
-3. **Aggregate spend/usage surface** ([#15](https://github.com/alp82/aistack/issues/15)) — auto-sync-gated. Cross-creator spend/usage charts; absorbs the aggregate inventory chart (build the shell early, launch when usage-share + cost make it non-sparse) and ships public + linkable + structured-data-ready as the citable source.
-4. **Follow + activity feed** ([#14](https://github.com/alp82/aistack/issues/14)) — auto-sync-gated *and* needs churn data accumulated over time, so structurally last despite being the strongest return trigger. Per-person "what builders are adopting/dropping this week"; carries basic creator contactability.
+Nothing here is scheduled. A bet leaves the parking lot when a map picks it up.
 
 ### P2 — demand-driven, unordered
 
-- **Weekly digest** ([#17](https://github.com/alp82/aistack/issues/17)) — moved from P1 head on 2026-08-01 (not ready yet). Auto-sync-independent, so it can start any time demand justifies it. The only bet that manufactures *new* audience. Semi-automatic pipeline (owner sources → cron collector → bits inbox → compose UI); every issue a public on-site archive page (linkable, freshness/AEO signal) with email as push.
-- **Per-tool what-for** ([#16](https://github.com/alp82/aistack/issues/16)) — field already ships; auto-sync drafts into it.
+- **Weekly digest** ([#17](https://github.com/alp82/aistack/issues/17)) — the only bet that manufactures *new* audience. Semi-automatic pipeline (owner sources → cron collector → bits inbox → compose UI); every issue a public on-site archive page (linkable, freshness/AEO signal) with email as push.
+- **Follow + notifications** ([#14](https://github.com/alp82/aistack/issues/14)) — moved here 2026-08-03 at the [map #76](https://github.com/alp82/aistack/issues/76) charting, as one bundle: the follow graph, the "following" filter on the activity feed, and email or push on followed-person activity. The **global** activity feed does not need any of it and ships in map #76.
+- **Per-tool what-for** ([#16](https://github.com/alp82/aistack/issues/16)) — field already ships; auto-sync drafts into it. Carries the LLM-drafted notes ruled out of v1 by [#34](https://github.com/alp82/aistack/issues/34).
+- **Skills and MCP invocation counts** — the wire format publishes *shares* precisely to leave this headroom unspent ([#33](https://github.com/alp82/aistack/issues/33)).
 - **Projects** ([#16](https://github.com/alp82/aistack/issues/16)) — the stale-resistant *authored* credibility anchor; the human counterweight to the measured face.
-- **Threaded comments** ([#18](https://github.com/alp82/aistack/issues/18)) — after profile-first and follow+feed, so threads attach to final entity shapes and reuse notification plumbing.
-- **Discord bot** ([#18](https://github.com/alp82/aistack/issues/18)) — distribution, not discussion: `/aistack` slash command posts a stack-card embed in any server. After profile-first.
-- **Programmatic price-comparison pages** ([#17](https://github.com/alp82/aistack/issues/17)) — auto-sync-gated: "listed price vs what builders actually pay."
-- **Skills provenance surface** ([#17](https://github.com/alp82/aistack/issues/17)) — gated on the skills/MCP invocation-count extension: resources enriched with used-by-N / invoked-X.
-- **Profile integrations** ([#19](https://github.com/alp82/aistack/issues/19)) — cursor and further harnesses via the adapter seam; external sources (openusage, vendor dashboards) after auto-sync's own cost extraction shows its gaps. **Codex pulled forward** into [map #60](https://github.com/alp82/aistack/issues/60) on 2026-08-01 as the seam-proving second harness.
+- **Threaded comments** ([#18](https://github.com/alp82/aistack/issues/18)) — after follow + notifications, so threads attach to final entity shapes and reuse notification plumbing.
+- **Discord bot** ([#18](https://github.com/alp82/aistack/issues/18)) — distribution, not discussion: `/aistack` posts a stack-card embed in any server.
+- **Programmatic price-comparison pages** ([#17](https://github.com/alp82/aistack/issues/17)) — "listed price vs what builders actually pay."
+- **Skills provenance surface** ([#17](https://github.com/alp82/aistack/issues/17)) — gated on the invocation-count extension: resources enriched with used-by-N / invoked-X.
+- **Profile integrations** ([#19](https://github.com/alp82/aistack/issues/19)) — cursor and further harnesses via the adapter seam; external sources (openusage, vendor dashboards) after auto-sync's own cost extraction shows its gaps.
 
 ### P3 — parked, not rejected
 
@@ -68,19 +66,18 @@ Reordered 2026-08-01 at the [map #60](https://github.com/alp82/aistack/issues/60
 
 ## Success signals
 
-**North star: living stacks — stacks auto-synced within the last 7 days.** The USP made measurable; countable straight from Convex once auto-sync lands. Every bet either creates living stacks (P0), makes them visible (live stats, aggregate surface), or turns them into return visits (digest, feed).
+**North star: living stacks — stacks auto-synced within the last 7 days.** The USP made measurable; countable straight from Convex. Every bet either creates living stacks, makes them visible (live stats, aggregate surface), or turns them into return visits (feed, digest).
 
 | Bet | Signal |
 |---|---|
-| Profile-first migration | none — prerequisite, done-or-not |
-| Auto-sync | first approve-and-sends (**first: 2026-07-30**); **repeat sync in a later week** (the direct staleness-treadmill test, still open) |
-| Weekly digest | new signups attributable to digest issues |
-| View analytics | creators who view their dashboard, then edit/share |
+| Auto-sync | first approve-and-sends (**first: 2026-07-30**); repeat sync in a later week — the direct staleness-treadmill test |
 | Live stack-page stats | creator return visits to their own stack page |
 | Aggregate spend/usage surface | external referrals/citations to the spend page |
-| Follow + activity feed | feed-driven return sessions |
+| View analytics | creators who view their dashboard, then edit/share |
+| Activity feed | feed-driven return sessions |
+| Weekly digest | new signups attributable to digest issues |
 
-P2/P3 bets define their signal when promoted — no upfront fake precision. Signals ride the ~6-event instrumentation handed to the execution map (today: PostHog autocapture + Convex DB only).
+Parked bets define their signal when a map picks them up — no upfront fake precision.
 
 ## Non-goals
 
@@ -88,21 +85,13 @@ P2/P3 bets define their signal when promoted — no upfront fake precision. Sign
 
 1. **Never sell placement or ranking.** Sponsored money never affects what surfaces where. ([#19](https://github.com/alp82/aistack/issues/19))
 2. **Raw data never leaves the machine.** Transcripts, prompts, paths, repo names stay local; only user-approved derived aggregates are sent. ([#8](https://github.com/alp82/aistack/issues/8), [#13](https://github.com/alp82/aistack/issues/13))
+3. **Positive claims only.** No surface may say a listed thing went unused until the adapter seam covers every harness the user runs. ([#40](https://github.com/alp82/aistack/issues/40))
 
 **Scope non-goals** — this roadmap won't do these; a future map could revisit:
 
-3. Editorial comparison content at volume — no 553-page fight with aicoolies; hand-written tables ride the staleness treadmill. ([#17](https://github.com/alp82/aistack/issues/17))
-4. Two-way Discord sync — superseded by native comments. ([#18](https://github.com/alp82/aistack/issues/18))
-5. Reddit as a built surface — stays a manual channel. ([#18](https://github.com/alp82/aistack/issues/18))
-6. CLI config-carry as a product — retired; dotfiles/git own that job. ([#8](https://github.com/alp82/aistack/issues/8))
+4. Editorial comparison content at volume — no 553-page fight with aicoolies; hand-written tables ride the staleness treadmill. ([#17](https://github.com/alp82/aistack/issues/17))
+5. Two-way Discord sync — superseded by native comments. ([#18](https://github.com/alp82/aistack/issues/18))
+6. Reddit as a built surface — stays a manual channel. ([#18](https://github.com/alp82/aistack/issues/18))
+7. CLI config-carry as a product — retired; dotfiles/git own that job. ([#8](https://github.com/alp82/aistack/issues/8))
 
 Absence from this list is not endorsement, and P3 parking is not rejection: consultant marketplace and monetization are parked, not non-goals.
-
-## Execution-map hand-offs
-
-Parked work the follow-up *execution* map inherits:
-
-- **Minimal event instrumentation** — ~6 custom events + per-stack view counters (from the [analytics ticket #5](https://github.com/alp82/aistack/issues/5)).
-- **aicoolies counter-moves, remainder** — tool↔stack↔person cross-link surfaces ("N stacks use this" + avatars); llms.txt + Graveyard-style freshness/AEO signals (from [#9](https://github.com/alp82/aistack/issues/9)). The third counter-move (aggregate spend page) graduated into P1.
-- **Hero subline swap** — DONE 2026-07-30 ([#47](https://github.com/alp82/aistack/issues/47)).
-- **Auto-sync build details** deferred by [#13](https://github.com/alp82/aistack/issues/13) — mostly closed by [map #29](https://github.com/alp82/aistack/issues/29): wire format ([#33](https://github.com/alp82/aistack/issues/33)), review UI (the reconcile page, [#43](https://github.com/alp82/aistack/issues/43)). Background auto-resync (reshaped by [#56](https://github.com/alp82/aistack/issues/56) — silent, no session prompts, daily default) and the adapter interface shape are now charted in [map #60](https://github.com/alp82/aistack/issues/60). Still open: zero-install web upload (undecided).

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "decode-ico": "^0.4.1",
     "framer-motion": "^12.34.2",
     "gsap": "^3.14.2",
+    "isbot": "^5.2.1",
     "lowlight": "^3.3.0",
     "lucide-react": "^0.561.0",
     "motion": "^12.23.26",

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,3 +1,5 @@
+import { CLI_VERSION } from "./version.js";
+
 export const BASE_URL = process.env.AISTACK_URL || "https://aistack.to";
 
 async function request(
@@ -56,7 +58,14 @@ export async function authStart(machineName?: string): Promise<{
 }> {
 	const res = await request("/api/cli/auth/start", {
 		method: "POST",
-		body: JSON.stringify(machineName ? { machineName } : {}),
+		// `cliVersion` rides along so `cli_login_completed` can report which
+		// version linked the machine (#78). The server carries it on the pending
+		// session and reads it at the token exchange.
+		body: JSON.stringify(
+			machineName
+				? { machineName, cliVersion: CLI_VERSION }
+				: { cliVersion: CLI_VERSION },
+		),
 	});
 	if (!res.ok) throw failure("Auth start failed", res);
 	return res.json();

--- a/packages/cli/src/harness/shared/payload.ts
+++ b/packages/cli/src/harness/shared/payload.ts
@@ -418,6 +418,15 @@ export function buildPayload(input: BuildPayloadInput): BuiltPayload {
 export type SyncBody = {
 	payloads: MeasuredPayload[];
 	keptPrivate?: Record<NameCategory, KeptPrivateAtom[]>;
+	/**
+	 * The machine's standing auto-sync opt-in (#78). Not measurement and not a
+	 * name — it is the one bit of local state the backend cannot otherwise see,
+	 * and `auto_sync_enabled` has nothing to fire on without it.
+	 *
+	 * It rides BESIDE the payloads, never inside one: the payload validator is
+	 * closed, and that closedness is the privacy claim.
+	 */
+	autoSync?: { enabled: boolean; frequencyHours: number };
 };
 
 /**
@@ -462,11 +471,13 @@ export function mergeKeptPrivate(
 export function buildSyncBody(
 	built: readonly BuiltPayload[],
 	syncConfig: SyncConfig,
+	autoSync?: { enabled: boolean; frequencyHours: number },
 ): SyncBody {
 	const payloads = built.map((b) => b.payload);
-	if (!syncConfig.reviewKeptPrivate) return { payloads };
+	const base: SyncBody = autoSync ? { payloads, autoSync } : { payloads };
+	if (!syncConfig.reviewKeptPrivate) return base;
 	return {
-		payloads,
+		...base,
 		keptPrivate: mergeKeptPrivate(built.map((b) => b.keptPrivate)),
 	};
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,13 +6,14 @@ import { createCommand } from "./commands/create.js";
 import { loginCommand } from "./commands/login.js";
 import { syncCommand } from "./commands/sync.js";
 import { runStdioSyncServer } from "./sync/server.js";
+import { CLI_VERSION } from "./version.js";
 
 const program = new Command();
 
 program
 	.name("aistack")
 	.description("Measure and share your AI stack from your terminal")
-	.version("0.5.0");
+	.version(CLI_VERSION);
 
 program
 	.command("login")

--- a/packages/cli/src/sync/stage.ts
+++ b/packages/cli/src/sync/stage.ts
@@ -13,7 +13,7 @@
 // union is one list because consent is per name, not per harness.
 
 import { createHash } from "node:crypto";
-import { getToken } from "../config.js";
+import { getSettings, getToken, type Settings } from "../config.js";
 import { detectedAdapters } from "../harness/index.js";
 import {
 	type KeptPrivateAtom,
@@ -67,6 +67,7 @@ export type StageDeps = {
 	}) => Promise<LoadedSyncConfig>;
 	/** Override the adapter set. Tests only. */
 	adaptersImpl?: () => Promise<HarnessAdapter[]>;
+	getSettingsImpl?: () => Settings;
 	windowDays?: number;
 };
 
@@ -106,7 +107,11 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 		);
 	}
 
-	const body = buildSyncBody(built, config);
+	// The opt-in the machine currently holds, read at stage time so the gate's
+	// bytes are the bytes sent (#78). Absent from the settings file means this
+	// machine has never answered, which the backend reads as "never told us".
+	const settings = (deps.getSettingsImpl ?? getSettings)();
+	const body = buildSyncBody(built, config, settings.autoSync);
 	const bodyJson = JSON.stringify(body);
 	const keptPrivate = mergeKeptPrivate(built.map((b) => b.keptPrivate));
 

--- a/packages/cli/src/sync/summary.ts
+++ b/packages/cli/src/sync/summary.ts
@@ -305,6 +305,16 @@ export function buildGateSummary(ctx: GateContext): string {
 		}
 	}
 
+	// Named at the gate because it is in the bytes (#78). It is not measurement
+	// and not a name, but the rule is that the preview describes what goes, so a
+	// field nobody can see in the preview does not get to ride along.
+	if (body.autoSync !== undefined) {
+		out.push("");
+		out.push(
+			`auto-sync ${body.autoSync.enabled ? `on, about every ${body.autoSync.frequencyHours}h` : "off"}`,
+		);
+	}
+
 	if (source === "bundled") {
 		out.push("");
 		out.push(

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,11 @@
+// The one place the CLI's version string lives.
+//
+// `tsup` replaces `__AISTACK_CLI_VERSION__` at build time with the version in
+// `package.json`, so a release cannot ship a stale number. The fallback covers
+// running from source (tests, `tsx src/index.ts`), where no define happens.
+declare const __AISTACK_CLI_VERSION__: string | undefined;
+
+export const CLI_VERSION: string =
+	typeof __AISTACK_CLI_VERSION__ === "string"
+		? __AISTACK_CLI_VERSION__
+		: "0.0.0-dev";

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'tsup'
+import pkg from './package.json' with { type: 'json' }
 
 export default defineConfig({
   entry: ['src/index.ts'],
@@ -8,4 +9,7 @@ export default defineConfig({
   banner: { js: '#!/usr/bin/env node' },
   splitting: false,
   sourcemap: true,
+  // One source of truth for the version the CLI reports (#78): `--version` and
+  // the login call both read src/version.ts, which this replaces at build time.
+  define: { __AISTACK_CLI_VERSION__: JSON.stringify(pkg.version) },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@convex-dev/better-auth':
         specifier: ^0.10.9
-        version: 0.10.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.4))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@standard-schema/spec@1.1.0)(better-auth@1.4.10(@tanstack/react-start@1.145.3(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)))(better-call@1.1.7(zod@4.3.4))(convex@1.32.0(react@19.2.3))(nanostores@1.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 0.10.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.4))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@standard-schema/spec@1.1.0)(better-auth@1.4.10(@tanstack/react-start@1.145.3(crossws@0.4.10(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(better-call@1.1.7(zod@4.3.4))(convex@1.32.0(react@19.2.3))(nanostores@1.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       '@convex-dev/react-query':
         specifier: 0.1.0
         version: 0.1.0(@tanstack/react-query@5.90.16(react@19.2.3))(convex@1.32.0(react@19.2.3))
@@ -43,7 +43,7 @@ importers:
         version: 9.5.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.183.0)
       '@tailwindcss/vite':
         specifier: ^4.0.6
-        version: 4.1.18(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 4.1.18(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       '@takumi-rs/core-linux-x64-gnu':
         specifier: ^0.70.4
         version: 0.70.4
@@ -55,7 +55,7 @@ importers:
         version: 0.7.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)
       '@tanstack/react-form':
         specifier: ^1.0.0
-        version: 1.27.7(@tanstack/react-start@1.145.3(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 1.27.7(@tanstack/react-start@1.145.3(crossws@0.4.10(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-query':
         specifier: ^5.66.5
         version: 5.90.16(react@19.2.3)
@@ -73,13 +73,13 @@ importers:
         version: 1.144.0(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@tanstack/router-core@1.144.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-start':
         specifier: ^1.132.0
-        version: 1.145.3(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 1.145.3(crossws@0.4.10(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/react-virtual':
         specifier: ^3.13.16
         version: 3.13.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/router-plugin':
         specifier: ^1.132.0
-        version: 1.145.2(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 1.145.2(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       '@tiptap/core':
         specifier: ^3.20.0
         version: 3.20.0(@tiptap/pm@3.20.0)
@@ -175,7 +175,7 @@ importers:
         version: 0.183.0
       better-auth:
         specifier: 1.4.10
-        version: 1.4.10(@tanstack/react-start@1.145.3(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 1.4.10(@tanstack/react-start@1.145.3(crossws@0.4.10(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -194,6 +194,9 @@ importers:
       gsap:
         specifier: ^3.14.2
         version: 3.14.2
+      isbot:
+        specifier: ^5.2.1
+        version: 5.2.1
       lowlight:
         specifier: ^3.3.0
         version: 3.3.0
@@ -205,7 +208,7 @@ importers:
         version: 12.23.26(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nitro:
         specifier: latest
-        version: 3.0.260603-beta(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 3.0.260610-beta(chokidar@4.0.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       posthog-js:
         specifier: ^1.313.0
         version: 1.313.0
@@ -250,7 +253,7 @@ importers:
         version: 13.0.0
       vite-tsconfig-paths:
         specifier: ^6.0.2
-        version: 6.0.3(typescript@5.9.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 6.0.3(typescript@5.9.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       zod:
         specifier: ^4.1.11
         version: 4.3.4
@@ -263,7 +266,7 @@ importers:
         version: 5.0.0
       '@tanstack/devtools-vite':
         specifier: ^0.3.11
-        version: 0.3.12(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 0.3.12(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.1
@@ -287,7 +290,7 @@ importers:
         version: 11.0.0
       '@vitejs/plugin-react':
         specifier: ^5.0.4
-        version: 5.1.2(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 5.1.2(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       convex-test:
         specifier: ^0.0.51
         version: 0.0.51(convex@1.32.0(react@19.2.3))
@@ -302,10 +305,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.1.7
-        version: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)
+        version: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: ^3.0.5
-        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)
+        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
       web-vitals:
         specifier: ^5.1.0
         version: 5.1.0
@@ -3278,8 +3281,8 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  crossws@0.4.5:
-    resolution: {integrity: sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA==}
+  crossws@0.4.10:
+    resolution: {integrity: sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==}
     peerDependencies:
       srvx: '>=0.11.5'
     peerDependenciesMeta:
@@ -3453,19 +3456,22 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
-  env-runner@0.1.9:
-    resolution: {integrity: sha512-W9AiZlPx0uXtghAJiTBkeZOgyQdecVvoln3cHoOEZswPq0cVMi+WBhUQjdUn+JcZFAFgOt+i5fcO7C2zniZoCg==}
+  env-runner@0.1.16:
+    resolution: {integrity: sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA==}
     hasBin: true
     peerDependencies:
       '@netlify/runtime': ^4.1.23
-      '@vercel/queue': ^0.2.0
+      '@vercel/queue': '>=0.2.0'
       miniflare: ^4.20260515.0
+      wrangler: ^4.0.0
     peerDependenciesMeta:
       '@netlify/runtime':
         optional: true
       '@vercel/queue':
         optional: true
       miniflare:
+        optional: true
+      wrangler:
         optional: true
 
   es-module-lexer@1.7.0:
@@ -3513,6 +3519,9 @@ packages:
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
+  exsolve@1.1.1:
+    resolution: {integrity: sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -3667,8 +3676,8 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  httpxy@0.5.3:
-    resolution: {integrity: sha512-SMS9V6Sn7VWaS11lYhoAr0ceoaiolTWf4jYdJn0NJhCdKMu9R2H9Fh0LBDWBHQF6HRLI1PmaePYsjanSpE5PEw==}
+  httpxy@0.5.5:
+    resolution: {integrity: sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -3751,6 +3760,10 @@ packages:
 
   isbot@5.1.32:
     resolution: {integrity: sha512-VNfjM73zz2IBZmdShMfAUg10prm6t7HFUQmNAEOAVS4YH92ZrZcvkMcGX6cIgBJAzWDzPent/EeAtYEHNPNPBQ==}
+    engines: {node: '>=18'}
+
+  isbot@5.2.1:
+    resolution: {integrity: sha512-dJ+LpKyClQZ7NG+j3OensC/mAZkGpukE9YUrgPYvAZj2doVL0edfDgywTUh5CXa0o+nW9a1V9e5+CJTX8+SxRw==}
     engines: {node: '>=18'}
 
   isexe@2.0.0:
@@ -4162,16 +4175,16 @@ packages:
   nf3@0.3.17:
     resolution: {integrity: sha512-N9zEWySuJFw+gR0lhS5863YsvNeudOdqRyFvNb+jMXbeTJOdrjDqkCpDginIZfUm0LzT1t1nCRiDeqQm/8kirQ==}
 
-  nitro@3.0.260603-beta:
-    resolution: {integrity: sha512-ffaSHK00a7YDlDizoEHwcxPwpQpdBRRA8k42ymTsRnfl3ipGeKgv4gnPr6DgmCNTo4tYVPK3bHBEv1gNhWpo/A==}
+  nitro@3.0.260610-beta:
+    resolution: {integrity: sha512-KPb4L5yaF/Rx/xoGMpgHRJvZhbhGiqbRKOwwPLCH9jKTKTsEUHLjnJas85AeCzaswqa8Wi52eQBtRsODC4PS0Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@vercel/queue': ^0.2.0
+      '@vercel/queue': ^0.3.0
       dotenv: '*'
       giget: '*'
       jiti: ^2.7.0
-      rollup: ^4.60.4
+      rollup: ^4.61.1
       vite: ^7 || ^8
       xml2js: ^0.6.2
       zephyr-agent: ^0.2.0
@@ -4207,8 +4220,8 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
-  ocache@0.1.4:
-    resolution: {integrity: sha512-e7geNdWjxSnvsSgvLuPvgKgu7ubM10ZmTPOgpr7mz2BXYtvjMKTiLhjFi/gWU8chkuP6hNkZBsa9LzOusyaqkQ==}
+  ocache@0.1.5:
+    resolution: {integrity: sha512-kNNnkkVQup/QDvmTz8Q84wc2ntiyoVHDxa6eHWKt5qdGAmFRBIxy83rxgCYEjW0x06UJ9E3P6VgM2yY4rOBH4w==}
 
   ofetch@2.0.0-alpha.3:
     resolution: {integrity: sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==}
@@ -4672,6 +4685,11 @@ packages:
 
   srvx@0.11.16:
     resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
+  srvx@0.11.22:
+    resolution: {integrity: sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==}
     engines: {node: '>=20.16.0'}
     hasBin: true
 
@@ -5496,14 +5514,14 @@ snapshots:
       nanostores: 1.1.0
       zod: 4.3.4
 
-  '@better-auth/passkey@1.4.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.4))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.10(@tanstack/react-start@1.145.3(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)))(better-call@1.1.7(zod@4.3.4))(nanostores@1.1.0)':
+  '@better-auth/passkey@1.4.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.4))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.10(@tanstack/react-start@1.145.3(crossws@0.4.10(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(better-call@1.1.7(zod@4.3.4))(nanostores@1.1.0)':
     dependencies:
       '@better-auth/core': 1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.4))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0)
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.2.2
       '@simplewebauthn/server': 13.2.2
-      better-auth: 1.4.10(@tanstack/react-start@1.145.3(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0))
+      better-auth: 1.4.10(@tanstack/react-start@1.145.3(crossws@0.4.10(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       better-call: 1.1.7(zod@4.3.4)
       nanostores: 1.1.0
       zod: 4.3.4
@@ -5568,11 +5586,11 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@convex-dev/better-auth@0.10.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.4))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@standard-schema/spec@1.1.0)(better-auth@1.4.10(@tanstack/react-start@1.145.3(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)))(better-call@1.1.7(zod@4.3.4))(convex@1.32.0(react@19.2.3))(nanostores@1.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)':
+  '@convex-dev/better-auth@0.10.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.4))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@standard-schema/spec@1.1.0)(better-auth@1.4.10(@tanstack/react-start@1.145.3(crossws@0.4.10(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(better-call@1.1.7(zod@4.3.4))(convex@1.32.0(react@19.2.3))(nanostores@1.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)':
     dependencies:
-      '@better-auth/passkey': 1.4.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.4))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.10(@tanstack/react-start@1.145.3(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)))(better-call@1.1.7(zod@4.3.4))(nanostores@1.1.0)
+      '@better-auth/passkey': 1.4.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.4))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.10(@tanstack/react-start@1.145.3(crossws@0.4.10(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(better-call@1.1.7(zod@4.3.4))(nanostores@1.1.0)
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.4.10(@tanstack/react-start@1.145.3(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0))
+      better-auth: 1.4.10(@tanstack/react-start@1.145.3(crossws@0.4.10(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       common-tags: 1.8.2
       convex: 1.32.0(react@19.2.3)
       convex-helpers: 0.1.108(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(zod@4.3.4)
@@ -6996,12 +7014,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
 
-  '@tailwindcss/vite@4.1.18(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@tailwindcss/vite@4.1.18(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
 
   '@takumi-rs/core-darwin-arm64@0.70.4':
     optional: true
@@ -7074,7 +7092,7 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/devtools-vite@0.3.12(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@tanstack/devtools-vite@0.3.12(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/generator': 7.28.5
@@ -7086,7 +7104,7 @@ snapshots:
       chalk: 5.6.2
       launch-editor: 2.12.0
       picomatch: 4.0.3
-      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -7135,13 +7153,13 @@ snapshots:
       - solid-js
       - utf-8-validate
 
-  '@tanstack/react-form@1.27.7(@tanstack/react-start@1.145.3(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@tanstack/react-form@1.27.7(@tanstack/react-start@1.145.3(crossws@0.4.10(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@tanstack/form-core': 1.27.7
       '@tanstack/react-store': 0.8.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
     optionalDependencies:
-      '@tanstack/react-start': 1.145.3(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@tanstack/react-start': 1.145.3(crossws@0.4.10(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - react-dom
 
@@ -7200,31 +7218,31 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/react-start-server@1.145.3(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@tanstack/react-start-server@1.145.3(crossws@0.4.10(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@tanstack/history': 1.141.0
       '@tanstack/react-router': 1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/router-core': 1.144.0
       '@tanstack/start-client-core': 1.145.0
-      '@tanstack/start-server-core': 1.145.3(crossws@0.4.5(srvx@0.11.16))
+      '@tanstack/start-server-core': 1.145.3(crossws@0.4.10(srvx@0.11.16))
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.145.3(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@tanstack/react-start@1.145.3(crossws@0.4.10(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-start-client': 1.145.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/react-start-server': 1.145.3(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@tanstack/react-start-server': 1.145.3(crossws@0.4.10(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/router-utils': 1.143.11
       '@tanstack/start-client-core': 1.145.0
-      '@tanstack/start-plugin-core': 1.145.3(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(crossws@0.4.5(srvx@0.11.16))(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))
-      '@tanstack/start-server-core': 1.145.3(crossws@0.4.5(srvx@0.11.16))
+      '@tanstack/start-plugin-core': 1.145.3(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(crossws@0.4.10(srvx@0.11.16))(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
+      '@tanstack/start-server-core': 1.145.3(crossws@0.4.10(srvx@0.11.16))
       pathe: 2.0.3
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@rsbuild/core'
       - crossws
@@ -7278,7 +7296,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.145.2(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@tanstack/router-plugin@1.145.2(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
@@ -7296,7 +7314,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7328,7 +7346,7 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.143.8': {}
 
-  '@tanstack/start-plugin-core@1.145.3(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(crossws@0.4.5(srvx@0.11.16))(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@tanstack/start-plugin-core@1.145.3(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(crossws@0.4.10(srvx@0.11.16))(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.28.5
@@ -7336,10 +7354,10 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.40
       '@tanstack/router-core': 1.144.0
       '@tanstack/router-generator': 1.145.2
-      '@tanstack/router-plugin': 1.145.2(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@tanstack/router-plugin': 1.145.2(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/router-utils': 1.143.11
       '@tanstack/start-client-core': 1.145.0
-      '@tanstack/start-server-core': 1.145.3(crossws@0.4.5(srvx@0.11.16))
+      '@tanstack/start-server-core': 1.145.3(crossws@0.4.10(srvx@0.11.16))
       babel-dead-code-elimination: 1.0.11
       cheerio: 1.1.2
       exsolve: 1.0.8
@@ -7347,8 +7365,8 @@ snapshots:
       srvx: 0.10.0
       tinyglobby: 0.2.15
       ufo: 1.6.1
-      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)
-      vitefu: 1.1.1(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))
+      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
+      vitefu: 1.1.1(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       xmlbuilder2: 4.0.3
       zod: 3.25.76
     transitivePeerDependencies:
@@ -7359,13 +7377,13 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
-  '@tanstack/start-server-core@1.145.3(crossws@0.4.5(srvx@0.11.16))':
+  '@tanstack/start-server-core@1.145.3(crossws@0.4.10(srvx@0.11.16))':
     dependencies:
       '@tanstack/history': 1.141.0
       '@tanstack/router-core': 1.144.0
       '@tanstack/start-client-core': 1.145.0
       '@tanstack/start-storage-context': 1.144.0
-      h3-v2: h3@2.0.1-rc.7(crossws@0.4.5(srvx@0.11.16))
+      h3-v2: h3@2.0.1-rc.7(crossws@0.4.10(srvx@0.11.16))
       seroval: 1.4.2
       tiny-invariant: 1.3.3
     transitivePeerDependencies:
@@ -7779,7 +7797,7 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.3
 
-  '@vitejs/plugin-react@5.1.2(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitejs/plugin-react@5.1.2(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -7787,7 +7805,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.53
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7799,13 +7817,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -7895,7 +7913,7 @@ snapshots:
 
   baseline-browser-mapping@2.9.11: {}
 
-  better-auth@1.4.10(@tanstack/react-start@1.145.3(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)):
+  better-auth@1.4.10(@tanstack/react-start@1.145.3(crossws@0.4.10(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@better-auth/core': 1.4.10(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.4))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.10(@better-auth/core@1.4.10(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.4))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0))
@@ -7910,11 +7928,11 @@ snapshots:
       nanostores: 1.1.0
       zod: 4.3.4
     optionalDependencies:
-      '@tanstack/react-start': 1.145.3(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@tanstack/react-start': 1.145.3(crossws@0.4.10(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       solid-js: 1.9.10
-      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
 
   better-call@1.1.7(zod@4.3.4):
     dependencies:
@@ -8090,9 +8108,13 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  crossws@0.4.5(srvx@0.11.16):
+  crossws@0.4.10(srvx@0.11.16):
     optionalDependencies:
       srvx: 0.11.16
+
+  crossws@0.4.10(srvx@0.11.22):
+    optionalDependencies:
+      srvx: 0.11.22
 
   css-select@5.2.2:
     dependencies:
@@ -8227,12 +8249,12 @@ snapshots:
 
   entities@6.0.1: {}
 
-  env-runner@0.1.9:
+  env-runner@0.1.16:
     dependencies:
-      crossws: 0.4.5(srvx@0.11.16)
-      exsolve: 1.0.8
-      httpxy: 0.5.3
-      srvx: 0.11.16
+      crossws: 0.4.10(srvx@0.11.22)
+      exsolve: 1.1.1
+      httpxy: 0.5.5
+      srvx: 0.11.22
 
   es-module-lexer@1.7.0: {}
 
@@ -8314,6 +8336,8 @@ snapshots:
 
   exsolve@1.0.8: {}
 
+  exsolve@1.1.1: {}
+
   extend@3.0.2: {}
 
   fast-equals@5.4.0: {}
@@ -8390,19 +8414,19 @@ snapshots:
 
   gsap@3.14.2: {}
 
-  h3@2.0.1-rc.22(crossws@0.4.5(srvx@0.11.16)):
+  h3@2.0.1-rc.22(crossws@0.4.10(srvx@0.11.16)):
     dependencies:
       rou3: 0.8.1
       srvx: 0.11.16
     optionalDependencies:
-      crossws: 0.4.5(srvx@0.11.16)
+      crossws: 0.4.10(srvx@0.11.16)
 
-  h3@2.0.1-rc.7(crossws@0.4.5(srvx@0.11.16)):
+  h3@2.0.1-rc.7(crossws@0.4.10(srvx@0.11.16)):
     dependencies:
       rou3: 0.7.12
       srvx: 0.10.0
     optionalDependencies:
-      crossws: 0.4.5(srvx@0.11.16)
+      crossws: 0.4.10(srvx@0.11.16)
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
@@ -8478,7 +8502,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  httpxy@0.5.3: {}
+  httpxy@0.5.5: {}
 
   iconv-lite@0.6.3:
     dependencies:
@@ -8540,6 +8564,8 @@ snapshots:
       is-inside-container: 1.0.0
 
   isbot@5.1.32: {}
+
+  isbot@5.2.1: {}
 
   isexe@2.0.0: {}
 
@@ -9149,24 +9175,24 @@ snapshots:
 
   nf3@0.3.17: {}
 
-  nitro@3.0.260603-beta(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)):
+  nitro@3.0.260610-beta(chokidar@4.0.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       consola: 3.4.2
-      crossws: 0.4.5(srvx@0.11.16)
+      crossws: 0.4.10(srvx@0.11.16)
       db0: 0.3.4
-      env-runner: 0.1.9
-      h3: 2.0.1-rc.22(crossws@0.4.5(srvx@0.11.16))
+      env-runner: 0.1.16
+      h3: 2.0.1-rc.22(crossws@0.4.10(srvx@0.11.16))
       hookable: 6.1.1
       nf3: 0.3.17
-      ocache: 0.1.4
+      ocache: 0.1.5
       ofetch: 2.0.0-alpha.3
       ohash: 2.0.11
       rolldown: 1.1.0
       srvx: 0.11.16
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(db0@0.3.4)(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(chokidar@4.0.3)(db0@0.3.4)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
-      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9197,6 +9223,7 @@ snapshots:
       - mysql2
       - sqlite3
       - uploadthing
+      - wrangler
 
   node-releases@2.0.27: {}
 
@@ -9208,7 +9235,7 @@ snapshots:
 
   object-assign@4.1.1: {}
 
-  ocache@0.1.4:
+  ocache@0.1.5:
     dependencies:
       ohash: 2.0.11
 
@@ -9747,6 +9774,8 @@ snapshots:
 
   srvx@0.11.16: {}
 
+  srvx@0.11.22: {}
+
   stackback@0.0.2: {}
 
   standardwebhooks@1.0.0:
@@ -10033,8 +10062,9 @@ snapshots:
       picomatch: 4.0.3
       webpack-virtual-modules: 0.6.2
 
-  unstorage@2.0.0-alpha.7(db0@0.3.4)(ofetch@2.0.0-alpha.3):
+  unstorage@2.0.0-alpha.7(chokidar@4.0.3)(db0@0.3.4)(ofetch@2.0.0-alpha.3):
     optionalDependencies:
+      chokidar: 4.0.3
       db0: 0.3.4
       ofetch: 2.0.0-alpha.3
 
@@ -10083,13 +10113,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0):
+  vite-node@3.2.4(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -10104,18 +10134,18 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@6.0.3(typescript@5.9.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)):
+  vite-tsconfig-paths@6.0.3(typescript@5.9.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:
-      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0):
+  vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -10128,16 +10158,17 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.30.2
       tsx: 4.21.0
+      yaml: 2.9.0
 
-  vitefu@1.1.1(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)):
+  vitefu@1.1.1(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
 
-  vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0):
+  vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -10155,8 +10186,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)
-      vite-node: 3.2.4(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 5.0.0

--- a/src/components/StackEditor.tsx
+++ b/src/components/StackEditor.tsx
@@ -32,6 +32,7 @@ import type {
 	StackEditorMode,
 } from "@/features/stack-editor/types";
 import { accentClassFor } from "@/features/stack-view/accentPresets";
+import { captureStackCreated, captureStackPublished } from "@/lib/analytics";
 import { resolveAvatarForSave } from "@/lib/resolveAvatarForSave";
 import {
 	buildManualStableKey,
@@ -310,6 +311,20 @@ export function StackEditor({
 
 			if (mode === "create") {
 				const result = await createStack(payload);
+				// After the mutation resolves, never before: an event fired on intent
+				// counts attempts, not stacks.
+				captureStackCreated({
+					toolCount: payload.toolSubscriptions.length,
+					published: payload.published,
+				});
+				if (payload.published) {
+					// A new stack cannot set the cost toggle, so it is always the
+					// default here: opted in.
+					captureStackPublished({
+						toolCount: payload.toolSubscriptions.length,
+						publishCost: true,
+					});
+				}
 				localStorage.removeItem(getDraftKey(undefined, creatorId));
 				navigate({ to: "/stacks/$slug", params: { slug: result.slug } });
 				return;
@@ -320,6 +335,14 @@ export function StackEditor({
 					stackId: initialValue._id,
 					...payload,
 				});
+				// Only the TRANSITION from draft to published. An edit to a stack that
+				// was already public is not a publish.
+				if (payload.published && !initialValue.published) {
+					captureStackPublished({
+						toolCount: payload.toolSubscriptions.length,
+						publishCost: initialValue.publishCost ?? true,
+					});
+				}
 				localStorage.removeItem(getDraftKey(initialValue.slug));
 				if (publish) {
 					navigate({

--- a/src/features/stack-editor/types.ts
+++ b/src/features/stack-editor/types.ts
@@ -109,6 +109,8 @@ type StackEditorInitialValue = {
 	resources?: Resource[];
 	teamSize?: number;
 	published: boolean;
+	/** Absent reads as opted IN — the field only ever records a refusal (#33). */
+	publishCost?: boolean;
 	toolSubscriptions: ToolSubscriptionEntry[];
 	bundleSubscriptions: BundleSubscriptionEntry[];
 	modelSubscriptions: ModelSubscriptionEntry[];

--- a/src/integrations/posthog/IdentifyUser.tsx
+++ b/src/integrations/posthog/IdentifyUser.tsx
@@ -1,0 +1,25 @@
+import { useQuery } from "convex/react";
+import { useEffect } from "react";
+import { api } from "../../../convex/_generated/api";
+import { identifyUser } from "../../lib/analytics";
+
+/**
+ * Bind the browser to the viewer's user id, once they are authenticated.
+ *
+ * Renders nothing. It exists as a component only because it needs the Convex
+ * auth context, and it sits INSIDE the PostHog provider so the SDK has mounted
+ * by the time it fires.
+ *
+ * This is the join between the two halves of the funnel: client events carry
+ * the anonymous id until this runs, server events always carry the user id, and
+ * posthog-js aliases the two on identify.
+ */
+export function IdentifyUser() {
+	const viewerId = useQuery(api.auth.getViewerId);
+
+	useEffect(() => {
+		identifyUser(viewerId);
+	}, [viewerId]);
+
+	return null;
+}

--- a/src/integrations/posthog/provider.tsx
+++ b/src/integrations/posthog/provider.tsx
@@ -1,5 +1,6 @@
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { type FC, type ReactNode, useEffect, useState } from "react";
+import { IdentifyUser } from "./IdentifyUser";
 
 interface PosthogProviderProps {
 	children: ReactNode;
@@ -48,6 +49,7 @@ const PosthogProvider: FC<PosthogProviderProps> = ({ children }) => {
 				debug: import.meta.env.MODE === "development",
 			}}
 		>
+			<IdentifyUser />
 			{children}
 		</PHProvider>
 	);

--- a/src/lib/__tests__/referrer.test.ts
+++ b/src/lib/__tests__/referrer.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { classifyReferrer, sessionReferrerBucket } from "../referrer";
+
+const HERE = "https://aistack.to";
+
+describe("classifyReferrer", () => {
+	it("calls an empty referrer direct", () => {
+		expect(classifyReferrer("", HERE)).toBe("direct");
+	});
+
+	it("calls a same-origin referrer internal", () => {
+		expect(classifyReferrer(`${HERE}/stacks`, HERE)).toBe("internal");
+	});
+
+	it("puts assistants in their own bucket, not in search", () => {
+		expect(classifyReferrer("https://chatgpt.com/c/123", HERE)).toBe("ai");
+		expect(classifyReferrer("https://claude.ai/chat/1", HERE)).toBe("ai");
+		expect(classifyReferrer("https://www.perplexity.ai/search", HERE)).toBe(
+			"ai",
+		);
+		expect(classifyReferrer("https://gemini.google.com/app", HERE)).toBe("ai");
+	});
+
+	it("recognizes search engines, including country domains", () => {
+		expect(classifyReferrer("https://www.google.com/search?q=x", HERE)).toBe(
+			"search",
+		);
+		expect(classifyReferrer("https://google.de/search?q=x", HERE)).toBe(
+			"search",
+		);
+		expect(classifyReferrer("https://duckduckgo.com/", HERE)).toBe("search");
+	});
+
+	it("recognizes social and community sources", () => {
+		expect(classifyReferrer("https://x.com/someone/status/1", HERE)).toBe(
+			"social",
+		);
+		expect(
+			classifyReferrer("https://news.ycombinator.com/item?id=1", HERE),
+		).toBe("social");
+		expect(classifyReferrer("https://www.reddit.com/r/x", HERE)).toBe("social");
+	});
+
+	it("falls back to other for an unknown site", () => {
+		expect(classifyReferrer("https://some-blog.example/post", HERE)).toBe(
+			"other",
+		);
+	});
+
+	it("falls back to other for an unparseable referrer rather than throwing", () => {
+		expect(classifyReferrer("not a url", HERE)).toBe("other");
+	});
+
+	it("prefers gemini.google.com over the google search rule", () => {
+		expect(classifyReferrer("https://gemini.google.com/", HERE)).toBe("ai");
+	});
+});
+
+describe("sessionReferrerBucket", () => {
+	beforeEach(() => {
+		window.sessionStorage.clear();
+	});
+
+	it("decides once and holds the answer for the rest of the session", () => {
+		Object.defineProperty(document, "referrer", {
+			value: "https://news.ycombinator.com/",
+			configurable: true,
+		});
+		expect(sessionReferrerBucket()).toBe("social");
+
+		// A later page in the same session has a same-origin referrer, which would
+		// classify as `internal` — the stored first touch must win.
+		Object.defineProperty(document, "referrer", {
+			value: window.location.origin,
+			configurable: true,
+		});
+		expect(sessionReferrerBucket()).toBe("social");
+	});
+
+	it("classifies a fresh session from its own first referrer", () => {
+		Object.defineProperty(document, "referrer", {
+			value: "https://chatgpt.com/",
+			configurable: true,
+		});
+		expect(sessionReferrerBucket()).toBe("ai");
+	});
+});

--- a/src/lib/__tests__/view-hash.test.ts
+++ b/src/lib/__tests__/view-hash.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+	delimitedJoin,
+	isCountableRequest,
+	rateKeyFor,
+	visitorHashFor,
+} from "../view-hash";
+
+describe("delimitedJoin", () => {
+	it("keeps two different tuples apart that raw concatenation would collide", () => {
+		expect(delimitedJoin(["ab", "c"])).not.toBe(delimitedJoin(["a", "bc"]));
+	});
+
+	it("is stable for the same input", () => {
+		expect(delimitedJoin(["a", "b"])).toBe(delimitedJoin(["a", "b"]));
+	});
+});
+
+describe("visitorHashFor", () => {
+	const base = {
+		secret: "s3cret",
+		ip: "1.2.3.4",
+		userAgent: "Mozilla/5.0",
+		targetKind: "stack",
+		targetId: "abc",
+		dayStartMs: 1_700_000_000_000,
+	};
+
+	it("gives the same hash for the same visitor, target and day", () => {
+		expect(visitorHashFor(base)).toBe(visitorHashFor({ ...base }));
+	});
+
+	it("rotates the hash on the next day", () => {
+		expect(
+			visitorHashFor({ ...base, dayStartMs: base.dayStartMs + 86_400_000 }),
+		).not.toBe(visitorHashFor(base));
+	});
+
+	it("gives a different hash per target, so one pseudonym cannot be traced across pages", () => {
+		expect(visitorHashFor({ ...base, targetId: "def" })).not.toBe(
+			visitorHashFor(base),
+		);
+	});
+
+	it("changes with the IP and with the User-Agent", () => {
+		expect(visitorHashFor({ ...base, ip: "5.6.7.8" })).not.toBe(
+			visitorHashFor(base),
+		);
+		expect(visitorHashFor({ ...base, userAgent: "curl/8" })).not.toBe(
+			visitorHashFor(base),
+		);
+	});
+
+	it("changes with the secret, so one deployment's hashes mean nothing in another", () => {
+		expect(visitorHashFor({ ...base, secret: "other" })).not.toBe(
+			visitorHashFor(base),
+		);
+	});
+
+	it("never contains the raw IP", () => {
+		expect(visitorHashFor(base)).not.toContain("1.2.3.4");
+	});
+});
+
+describe("rateKeyFor", () => {
+	it("is one bucket per address, whatever page is being read", () => {
+		expect(rateKeyFor("s", "1.2.3.4")).toBe(rateKeyFor("s", "1.2.3.4"));
+		expect(rateKeyFor("s", "1.2.3.4")).not.toBe(rateKeyFor("s", "5.6.7.8"));
+	});
+
+	it("differs from the visitor hash for the same address", () => {
+		expect(rateKeyFor("s", "1.2.3.4")).not.toBe(
+			visitorHashFor({
+				secret: "s",
+				ip: "1.2.3.4",
+				userAgent: "u",
+				targetKind: "stack",
+				targetId: "t",
+				dayStartMs: 0,
+			}),
+		);
+	});
+});
+
+describe("isCountableRequest", () => {
+	const browser =
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36";
+
+	it("counts a real browser", () => {
+		expect(isCountableRequest({ userAgent: browser, secPurpose: null })).toBe(
+			true,
+		);
+	});
+
+	it("refuses a known bot", () => {
+		expect(
+			isCountableRequest({
+				userAgent:
+					"Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+				secPurpose: null,
+			}),
+		).toBe(false);
+	});
+
+	it("refuses a request with no User-Agent at all", () => {
+		expect(isCountableRequest({ userAgent: null, secPurpose: null })).toBe(
+			false,
+		);
+	});
+
+	it("refuses a browser prefetch", () => {
+		expect(
+			isCountableRequest({ userAgent: browser, secPurpose: "prefetch" }),
+		).toBe(false);
+		expect(
+			isCountableRequest({
+				userAgent: browser,
+				secPurpose: "Prefetch;Prerender",
+			}),
+		).toBe(false);
+	});
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,81 @@
+// Client-side product events (#77, map #76).
+//
+// Three of the seven events fire here; the other four fire server-side, because
+// the browser cannot honestly observe a signup completing, a CLI storing a
+// token, a first sync landing, or a machine turning auto-sync on.
+//
+// Nothing in the app ever READS these back. PostHog is the funnel, not a data
+// source — every number the product displays comes from Convex.
+
+import posthog from "posthog-js";
+
+/**
+ * PostHog mounts on browser idle, up to 2s late
+ * (`src/integrations/posthog/provider.tsx`). An event fired before that is
+ * dropped.
+ *
+ * The three events below all fire on user-initiated actions well after mount,
+ * so this is not a live risk today. Any FUTURE client event on a callback or
+ * redirect path must be checked against it — that is what this note is for.
+ */
+function capture(
+	event: string,
+	properties: Record<string, string | number | boolean | null>,
+): void {
+	try {
+		posthog.capture(event, properties);
+	} catch (error) {
+		// Analytics must never break a user action.
+		console.error(`[analytics] capture failed for ${event}`, error);
+	}
+}
+
+/**
+ * Bind the browser to a user id.
+ *
+ * This is what keeps the client and server halves of the funnel ONE person:
+ * every server capture uses the same user id as its `distinct_id`, and
+ * posthog-js aliases the pre-signup anonymous id automatically. Without it a
+ * signup and its first stack look like two strangers.
+ */
+export function identifyUser(userId: string | null | undefined): void {
+	if (!userId) return;
+	try {
+		posthog.identify(userId);
+	} catch (error) {
+		console.error("[analytics] identify failed", error);
+	}
+}
+
+export function captureStackCreated(input: {
+	toolCount: number;
+	published: boolean;
+}): void {
+	capture("stack_created", input);
+}
+
+export function captureStackPublished(input: {
+	toolCount: number;
+	/**
+	 * The stack's cost-publication preference. Absent reads as opted IN — the
+	 * field only ever records a refusal — so the funnel sees `true` by default.
+	 */
+	publishCost: boolean;
+}): void {
+	capture("stack_published", input);
+}
+
+/**
+ * A click through from the leaderboard.
+ *
+ * This is also how internal traffic from the leaderboard gets measured at all:
+ * a same-origin SPA navigation sends no `Referer` header, so the view counter
+ * files it as `internal` with no source page. Splitting the internal bucket by
+ * source would undercount badly and read as "the leaderboard sends no traffic".
+ */
+export function captureLeaderboardStackClicked(input: {
+	rank: number;
+	stackSlug: string;
+}): void {
+	capture("leaderboard_stack_clicked", input);
+}

--- a/src/lib/client-ip.ts
+++ b/src/lib/client-ip.ts
@@ -1,0 +1,75 @@
+// Resolving the real client address behind the edge proxy.
+//
+// Lifted out of `src/routes/api.stacks.$slug.tsx` by #78 (map #76): the view
+// counter needs the same address the public API rate-limits on, and two copies
+// of this rule would eventually disagree.
+
+/**
+ * Behind Coolify's Traefik edge proxy, which APPENDS the real client
+ * connection IP as the last X-Forwarded-For entry. Read the rightmost
+ * (trusted) hop, never the client-controlled leftmost one.
+ *
+ * Precondition: this is trustworthy only as long as Traefik is the sole
+ * terminating proxy and is NOT configured to trust or preserve a
+ * client-supplied X-Forwarded-For header (i.e. forwardedHeaders.trustedIPs /
+ * insecure mode must remain off). If a CDN or additional proxy is ever placed
+ * in front of Traefik, the rightmost hop is no longer guaranteed to be the
+ * real client IP and this selection must be revisited.
+ */
+export function ipFromForwardedFor(
+	request: Request | string | undefined,
+): string | null {
+	const xff =
+		typeof request === "string" || request === undefined
+			? request
+			: request.headers.get("x-forwarded-for");
+	if (!xff) return null;
+	const hops = xff.split(",");
+	for (let i = hops.length - 1; i >= 0; i--) {
+		const hop = hops[i]?.trim();
+		if (hop) return hop;
+	}
+	return null;
+}
+
+/**
+ * Narrow interface covering the srvx ServerRequest extensions present at
+ * runtime (srvx v0.11.x). Casting to this instead of `any` keeps strict-mode
+ * happy while still letting us reach the peer address fields.
+ */
+interface SrvxRequest {
+	ip?: string;
+	runtime?: {
+		node?: {
+			req?: {
+				socket?: {
+					remoteAddress?: string;
+				};
+			};
+		};
+	};
+}
+
+/**
+ * Resolve the best available client IP:
+ *
+ * 1. Prefer the rightmost X-Forwarded-For hop — Coolify's Traefik APPENDS the
+ *    real client IP in prod, so this is the trusted value when running behind
+ *    the proxy.
+ * 2. Fall back to the real TCP connection IP exposed by srvx (`request.ip` or
+ *    `request.runtime.node.req.socket.remoteAddress`). This is per-client and
+ *    meaningful for local dev / direct non-proxied access.
+ * 3. Return null only when neither source is resolvable.
+ *
+ * Degraded case: if deployed behind Traefik but XFF is somehow absent, the
+ * peer address would be Traefik's own IP, collapsing all traffic into one
+ * bucket. The documented precondition is that Traefik always sets XFF, so
+ * this path is acceptable and not expected in production.
+ */
+export function clientIp(request: Request): string | null {
+	const fromXff = ipFromForwardedFor(request);
+	if (fromXff !== null) return fromXff;
+
+	const sr = request as unknown as SrvxRequest;
+	return sr.ip ?? sr.runtime?.node?.req?.socket?.remoteAddress ?? null;
+}

--- a/src/lib/referrer.ts
+++ b/src/lib/referrer.ts
@@ -1,0 +1,137 @@
+// First-touch session attribution (#77, map #76).
+//
+// The session's FIRST page classifies `document.referrer`. Every later page in
+// the session is `internal`. This is deliberately not a per-page referrer: a
+// same-origin SPA navigation sends no `Referer` header at all, so per-page
+// classification would report almost everything as `direct`.
+//
+// The value is client-supplied and therefore spoofable. That is accepted: it
+// selects one of six buckets on the spoofer's own view, and the raw referrer is
+// never stored — only the bucket travels.
+
+export type ReferrerBucket =
+	| "direct"
+	| "search"
+	| "ai"
+	| "social"
+	| "internal"
+	| "other";
+
+const STORAGE_KEY = "aistack:referrer-bucket";
+
+/**
+ * Assistants get their own bucket, split out of `search`.
+ *
+ * "Did an assistant send someone here" is the question the aggregate page
+ * exists to answer, and the split cannot be applied retroactively — a view
+ * filed under `search` today can never be recovered as `ai`.
+ */
+const AI_HOSTS = [
+	"chatgpt.com",
+	"chat.openai.com",
+	"claude.ai",
+	"perplexity.ai",
+	"gemini.google.com",
+	"copilot.microsoft.com",
+	"you.com",
+	"phind.com",
+	"poe.com",
+];
+
+const SEARCH_HOSTS = [
+	"google.",
+	"bing.com",
+	"duckduckgo.com",
+	"search.brave.com",
+	"ecosia.org",
+	"yandex.",
+	"baidu.com",
+	"startpage.com",
+	"kagi.com",
+	"qwant.com",
+];
+
+const SOCIAL_HOSTS = [
+	"x.com",
+	"twitter.com",
+	"t.co",
+	"reddit.com",
+	"news.ycombinator.com",
+	"linkedin.com",
+	"lnkd.in",
+	"facebook.com",
+	"instagram.com",
+	"bsky.app",
+	"mastodon.",
+	"youtube.com",
+	"discord.com",
+	"github.com",
+	"lobste.rs",
+	"dev.to",
+	"medium.com",
+	"substack.com",
+];
+
+function matches(host: string, needles: readonly string[]): boolean {
+	return needles.some((n) => host === n || host.includes(n));
+}
+
+/**
+ * Classify one raw referrer against one current origin.
+ *
+ * Exported separately from the stateful reader below so the rule is testable
+ * without a DOM or a storage stub.
+ */
+export function classifyReferrer(
+	rawReferrer: string,
+	currentOrigin: string,
+): ReferrerBucket {
+	if (!rawReferrer) return "direct";
+
+	let host: string;
+	let origin: string;
+	try {
+		const url = new URL(rawReferrer);
+		host = url.hostname.toLowerCase().replace(/^www\./, "");
+		origin = url.origin;
+	} catch {
+		return "other";
+	}
+
+	if (origin === currentOrigin) return "internal";
+	if (matches(host, AI_HOSTS)) return "ai";
+	if (matches(host, SEARCH_HOSTS)) return "search";
+	if (matches(host, SOCIAL_HOSTS)) return "social";
+	return "other";
+}
+
+/**
+ * The bucket for this session, deciding it on the first call and remembering it
+ * for every later page.
+ *
+ * `sessionStorage` and not `localStorage`: the attribution belongs to one visit,
+ * and a returning visitor next week arrived from somewhere new.
+ *
+ * A session whose first page was same-origin resolves to `internal`, which is
+ * correct — the visitor was already here.
+ */
+export function sessionReferrerBucket(): ReferrerBucket {
+	if (typeof window === "undefined") return "direct";
+
+	try {
+		const held = window.sessionStorage.getItem(STORAGE_KEY);
+		if (held) return held as ReferrerBucket;
+	} catch {
+		// Storage denied (private mode, blocked cookies). Classify every page,
+		// which reads as `internal` after the first — undercounting the source
+		// rather than inventing one.
+	}
+
+	const bucket = classifyReferrer(document.referrer, window.location.origin);
+	try {
+		window.sessionStorage.setItem(STORAGE_KEY, bucket);
+	} catch {
+		// Same as above. The bucket for THIS page is still correct.
+	}
+	return bucket;
+}

--- a/src/lib/useRecordView.ts
+++ b/src/lib/useRecordView.ts
@@ -1,0 +1,41 @@
+// The client half of view counting (#78, map #76).
+
+import { useEffect, useRef } from "react";
+import { recordView, type ViewTargetKind } from "../server/record-view";
+import { sessionReferrerBucket } from "./referrer";
+
+/**
+ * Count one view of `targetId` when this component mounts.
+ *
+ * A MOUNT EFFECT, deliberately, and not a route loader: `defaultPreload:
+ * "viewport"` runs loaders for cards merely scrolled into view, and a preloaded
+ * route that is then clicked does not re-run its loader. Mount is the only
+ * event that means a person is looking at the page.
+ *
+ * Pass `null` while the target id is still loading — the effect waits for it.
+ * Fires ONCE per target: React remounts the tree on refocus-driven auth
+ * transitions, and a remount is not a second visit.
+ */
+export function useRecordView(
+	targetKind: ViewTargetKind,
+	targetId: string | null | undefined,
+): void {
+	const sent = useRef<string | null>(null);
+
+	useEffect(() => {
+		if (!targetId) return;
+		const key = `${targetKind}:${targetId}`;
+		if (sent.current === key) return;
+		sent.current = key;
+
+		// Fire and forget. The server function never rejects, and a view that
+		// fails to count must not reach the reader.
+		void recordView({
+			data: {
+				targetKind,
+				targetId,
+				referrerBucket: sessionReferrerBucket(),
+			},
+		});
+	}, [targetKind, targetId]);
+}

--- a/src/lib/view-hash.ts
+++ b/src/lib/view-hash.ts
@@ -1,0 +1,85 @@
+// The pure half of view counting (#78, map #76).
+//
+// Split out of the server function so the rules can be tested without a request
+// context. Everything here runs on the SERVER only — the raw IP and the raw
+// User-Agent must never reach the browser bundle or Convex.
+
+import { createHmac } from "node:crypto";
+import { isbot } from "isbot";
+
+export const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Length-delimited join.
+ *
+ * Raw concatenation lets two different input tuples collide — `("ab", "c")` and
+ * `("a", "bc")` hash the same. Prefixing each part with its length removes the
+ * ambiguity.
+ */
+export function delimitedJoin(parts: readonly string[]): string {
+	return parts.map((p) => `${p.length}:${p}`).join("|");
+}
+
+export function hashSecret(): string | null {
+	const secret = process.env.VIEW_HASH_SECRET;
+	if (secret) return secret;
+	// Dev has no secret to keep — there is no shared database and no visitor to
+	// re-identify. Production without the variable counts nothing rather than
+	// storing a guessable pseudonym.
+	if (process.env.NODE_ENV !== "production") return "dev-view-hash-secret";
+	return null;
+}
+
+/**
+ * The daily visitor pseudonym.
+ *
+ * `IP + User-Agent` merges people behind one NAT and splits one person across
+ * networks, which is why every surface calls the result **deduped daily
+ * visitors** and never people. The target and the day are inside the hash, so a
+ * pseudonym is useless outside the one target-day it was minted for.
+ */
+export function visitorHashFor(input: {
+	secret: string;
+	ip: string;
+	userAgent: string;
+	targetKind: string;
+	targetId: string;
+	dayStartMs: number;
+}): string {
+	return createHmac("sha256", input.secret)
+		.update(
+			delimitedJoin([
+				input.ip,
+				input.userAgent,
+				input.targetKind,
+				input.targetId,
+				String(input.dayStartMs),
+			]),
+		)
+		.digest("hex");
+}
+
+/** The per-address bucket the write path rate-limits on. No target, no day. */
+export function rateKeyFor(secret: string, ip: string): string {
+	return createHmac("sha256", secret)
+		.update(delimitedJoin(["ratelimit", ip]))
+		.digest("hex");
+}
+
+/**
+ * Should this request count as a view?
+ *
+ * Three refusals, all of them about requests no person made:
+ * - a known bot User-Agent,
+ * - no User-Agent at all (every real browser sends one),
+ * - `Sec-Purpose: prefetch`, which is the browser speculating, not a visitor.
+ */
+export function isCountableRequest(headers: {
+	userAgent: string | null;
+	secPurpose: string | null;
+}): boolean {
+	if (!headers.userAgent) return false;
+	if (isbot(headers.userAgent)) return false;
+	if (headers.secPurpose?.toLowerCase().includes("prefetch")) return false;
+	return true;
+}

--- a/src/routes/$creator.tsx
+++ b/src/routes/$creator.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 import { ProfilePage } from "@/features/profile/ProfilePage";
 import { seoMeta } from "@/lib/seo";
+import { useRecordView } from "@/lib/useRecordView";
 import { api } from "../../convex/_generated/api";
 
 /**
@@ -55,6 +56,9 @@ function CreatorProfileRoute() {
 	// Client-only owner query — never part of the SSR payload, so the shared
 	// cache can't seed with an owner view.
 	const ownProfile = useQuery(api.creators.getOwnProfileView, { handle });
+	// Deduped daily visitors (#78). Before the early returns below, because a
+	// hook cannot be called conditionally.
+	useRecordView("creator", data?.profile._id);
 
 	if (data === undefined) {
 		return (

--- a/src/routes/api.stacks.$slug.tsx
+++ b/src/routes/api.stacks.$slug.tsx
@@ -1,6 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { ConvexHttpClient } from "convex/browser";
 import { api } from "../../convex/_generated/api";
+import { clientIp, ipFromForwardedFor } from "../lib/client-ip";
+
+// Re-exported so existing importers and tests keep one import site while the
+// rule itself lives in one place (#78).
+export { clientIp, ipFromForwardedFor };
 
 const convexUrl = process.env.VITE_CONVEX_URL;
 
@@ -9,77 +14,6 @@ if (!convexUrl) {
 }
 
 const convex = new ConvexHttpClient(convexUrl);
-
-/**
- * Behind Coolify's Traefik edge proxy, which APPENDS the real client
- * connection IP as the last X-Forwarded-For entry. Read the rightmost
- * (trusted) hop, never the client-controlled leftmost one.
- *
- * Precondition: this is trustworthy only as long as Traefik is the sole
- * terminating proxy and is NOT configured to trust or preserve a
- * client-supplied X-Forwarded-For header (i.e. forwardedHeaders.trustedIPs /
- * insecure mode must remain off). If a CDN or additional proxy is ever placed
- * in front of Traefik, the rightmost hop is no longer guaranteed to be the
- * real client IP and this selection must be revisited.
- */
-export function ipFromForwardedFor(
-	request: Request | string | undefined,
-): string | null {
-	const xff =
-		typeof request === "string" || request === undefined
-			? request
-			: request.headers.get("x-forwarded-for");
-	if (!xff) return null;
-	const hops = xff.split(",");
-	for (let i = hops.length - 1; i >= 0; i--) {
-		const hop = hops[i]?.trim();
-		if (hop) return hop;
-	}
-	return null;
-}
-
-/**
- * Narrow interface covering the srvx ServerRequest extensions present at
- * runtime (srvx v0.11.x). Casting to this instead of `any` keeps strict-mode
- * happy while still letting us reach the peer address fields.
- */
-interface SrvxRequest {
-	ip?: string;
-	runtime?: {
-		node?: {
-			req?: {
-				socket?: {
-					remoteAddress?: string;
-				};
-			};
-		};
-	};
-}
-
-/**
- * Resolve the best available client IP for rate-limiting:
- *
- * 1. Prefer the rightmost X-Forwarded-For hop — Coolify's Traefik APPENDS the
- *    real client IP in prod, so this is the trusted value when running behind
- *    the proxy.
- * 2. Fall back to the real TCP connection IP exposed by srvx (`request.ip` or
- *    `request.runtime.node.req.socket.remoteAddress`). This is per-client and
- *    meaningful for local dev / direct non-proxied access.
- * 3. Return null only when neither source is resolvable — the caller SHOULD
- *    then respond 400.
- *
- * Degraded case: if deployed behind Traefik but XFF is somehow absent, the
- * peer address would be Traefik's own IP, collapsing all traffic into one
- * bucket. The documented precondition is that Traefik always sets XFF, so
- * this path is acceptable and not expected in production.
- */
-export function clientIp(request: Request): string | null {
-	const fromXff = ipFromForwardedFor(request);
-	if (fromXff !== null) return fromXff;
-
-	const sr = request as unknown as SrvxRequest;
-	return sr.ip ?? sr.runtime?.node?.req?.socket?.remoteAddress ?? null;
-}
 
 export function rateLimitHeaders(rl: {
 	limit: number;

--- a/src/routes/stacks.$slug.tsx
+++ b/src/routes/stacks.$slug.tsx
@@ -19,6 +19,7 @@ import { StackHeader } from "@/features/stack-view/StackHeader";
 import { GuideSection, ToolsSection } from "@/features/stack-view/sections";
 import { formatPricingSummary } from "@/lib/pricing";
 import { SITE_URL, seoMeta } from "@/lib/seo";
+import { useRecordView } from "@/lib/useRecordView";
 import { api } from "../../convex/_generated/api";
 
 type ViewTool = {
@@ -156,6 +157,9 @@ function StackDetailsPage() {
 	const navigate = useNavigate();
 	const { isAuthenticated } = useConvexAuth();
 	const stack = useQuery(api.stacks.getBySlug, { slug });
+	// Deduped daily visitors (#78). Counted on MOUNT and keyed by document id, so
+	// a slug rename keeps the page's history.
+	useRecordView("stack", stack?._id);
 	const me = useQuery(api.creators.getMe);
 	const upvoteStatus = useQuery(
 		api.stacks.getUpvoteStatus,

--- a/src/server/record-view.ts
+++ b/src/server/record-view.ts
@@ -1,0 +1,88 @@
+// The view-counting server function (#78, map #76).
+//
+// Everything that needs the raw client address happens HERE and stops here.
+// Convex receives a hash and a bucket, never an IP and never a referrer.
+
+import { createServerFn } from "@tanstack/react-start";
+import { getRequest } from "@tanstack/react-start/server";
+import { api } from "../../convex/_generated/api";
+import { fetchAuthMutation } from "../lib/auth-server";
+import { clientIp } from "../lib/client-ip";
+import type { ReferrerBucket } from "../lib/referrer";
+import {
+	DAY_MS,
+	hashSecret,
+	isCountableRequest,
+	rateKeyFor,
+	visitorHashFor,
+} from "../lib/view-hash";
+
+export type ViewTargetKind = "stack" | "creator" | "aggregate";
+
+export interface RecordViewInput {
+	targetKind: ViewTargetKind;
+	/** The Convex document id — never the slug, so a rename keeps its history. */
+	targetId: string;
+	referrerBucket: ReferrerBucket;
+}
+
+/**
+ * Count one view.
+ *
+ * Called from a MOUNT EFFECT, never a route loader. `defaultPreload: "viewport"`
+ * runs the loader for every card scrolled into view, and
+ * `defaultPreloadStaleTime: 30_000` means a preloaded route that is then clicked
+ * does not re-run its loader — so a loader write both invents views and misses
+ * real ones. Mount is the only event that means a person is looking at the page.
+ *
+ * Always resolves. A failed count must never surface to the reader.
+ */
+export const recordView = createServerFn({ method: "POST" })
+	.inputValidator((data: RecordViewInput) => data)
+	.handler(async ({ data }) => {
+		try {
+			const request = getRequest();
+			const userAgent = request.headers.get("user-agent");
+			if (
+				!isCountableRequest({
+					userAgent,
+					secPurpose: request.headers.get("sec-purpose"),
+				})
+			) {
+				return { counted: false };
+			}
+
+			const secret = hashSecret();
+			if (!secret) {
+				console.error("[views] VIEW_HASH_SECRET unset — not counting views");
+				return { counted: false };
+			}
+
+			const ip = clientIp(request);
+			if (!ip) return { counted: false };
+
+			const dayStartMs = Math.floor(Date.now() / DAY_MS) * DAY_MS;
+
+			// The viewer identity is NOT passed. `fetchAuthMutation` forwards this
+			// request's session, so Convex derives the viewer itself — a
+			// caller-supplied `viewerUserId` would let anyone suppress a
+			// competitor's views or attribute their own.
+			return await fetchAuthMutation(api.views.record, {
+				targetKind: data.targetKind,
+				targetId: data.targetId,
+				referrerBucket: data.referrerBucket,
+				visitorHash: visitorHashFor({
+					secret,
+					ip,
+					userAgent: userAgent as string,
+					targetKind: data.targetKind,
+					targetId: data.targetId,
+					dayStartMs,
+				}),
+				rateKey: rateKeyFor(secret, ip),
+			});
+		} catch (error) {
+			console.error("[views] record failed", error);
+			return { counted: false };
+		}
+	});


### PR DESCRIPTION
Closes #78. Part of map #76, built to the data model settled in #77.

The **write side** only. Nothing user-facing ships here — the feed (#85), the aggregate page (#83) and the private dashboard (#86) read these tables.

## Tables

| Table | Life | Bound by |
|---|---|---|
| `viewCounters` | permanent | targets x days x buckets |
| `viewDedupe` | today + yesterday, hourly GC | traffic, briefly |
| `activityEvents` | permanent | real activity |

All three are new, so the widen/migrate/narrow rule does not apply. The two additive fields on existing tables (`cliSessions.cliVersion`, `cliTokens.autoSync`) are optional.

## Views

Counted from a **mount effect**, not a route loader. `defaultPreload: "viewport"` runs loaders for cards merely scrolled into view, and a preloaded route that is then clicked does not re-run its loader — a loader write both invents views and misses real ones.

The server function drops bots, User-Agent-less requests and prefetches, reads the client IP through the rightmost `X-Forwarded-For` hop, and sends Convex an HMAC and one of six referrer buckets. **The raw IP and the raw referrer stop at the web server.**

**The viewer identity is never an argument.** It is derived from the forwarded session inside the mutation, so no caller can suppress a competitor's views or attribute their own.

The number is labelled **deduped daily visitors** everywhere: `IP + User-Agent` merges people behind one NAT and splits one person across networks.

## Activity events

Emitted inside the mutation that causes them, so a failed write cannot leave a phantom event.

- `stack.published` — from create with `published: true` **and** from the draft-to-public flip.
- `stack.composition_changed` — a tool, model or bundle added or removed, diffed on slug, names frozen at write time. Prose edits are excluded.
- `sync.landed` — **once** per approved sync, summarizing all up to 8 harness payloads.

The draft gate reads **resulting** state (`args.published ?? stack.published`). Reading the old value would let an update that unpublishes write an event the reader hides, which a republish months later would surface as current activity.

## Product events

Four fire server-side through a scheduled `internalAction`, because the browser cannot honestly observe a signup, a token exchange, a first sync or an auto-sync opt-in. Three fire client-side. All share one `distinct_id` via `posthog.identify`.

The CLI reports its version at login and its auto-sync opt-in on sync. Both are additive and optional. The opt-in is named in the gate preview, because the preview describes what goes.

## Deploy

New env vars. **Set them before or with the deploy** — unset means the four server events log and drop, and production counts no views.

- Convex: `POSTHOG_PROJECT_API_KEY`, `POSTHOG_HOST`
- Web app: `VIEW_HASH_SECRET` (any long random string)

Backend deploys before the CLI release, as usual. Installed CLIs keep working — they simply report neither field.

## Not in this PR

- `cliVersion` on the **sync** call. #77 lists it, but no event on this map consumes it — `cli_login_completed` fires at the token exchange, which the login path already carries. Sending a field nothing reads was not worth the wire.
- Call sites for `leaderboard_stack_clicked` and the `aggregate` view target. Both are supported; the leaderboard and the aggregate page are #83.

## Tests

35 new tests. Full suite 1313 passed, 6 skipped. Typecheck baseline unchanged. A production build confirms `isbot`, `createHmac` and `VIEW_HASH_SECRET` are absent from the client bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPaGJivZLF7XeqckSkFDa1