### PR TITLE
docs(research): charting library decision — TanStack Charts

### DIFF
--- a/docs/research/charting-library-2026-08.md
+++ b/docs/research/charting-library-2026-08.md
@@ -1,0 +1,206 @@
+# Charting library for the house style
+
+**Ticket:** [Research: charting library for the house style](https://github.com/alp82/aistack/issues/79) (map [#76](https://github.com/alp82/aistack/issues/76))
+**Date:** 2026-08-04
+**Status:** decided
+
+## Verdict
+
+**Build the charts by hand as SVG components, on `d3-shape` and `d3-time` only.**
+Collect them in one internal module so the four surfaces share one chart layer.
+Measured added weight: **5.2 KB gzip**.
+
+**Fallback: [visx](https://airbnb.io/visx/) (29 KB gzip).** Use it if the axis and
+scale code we write starts to cost more than it saves. visx renders the same
+plain SVG and server-renders correctly, so moving to it replaces internals and
+keeps the component API. It is an escalation, not a rewrite.
+
+**Recharts and the shadcn/ui chart family are ruled out.** They render **nothing**
+on the server, and they cost 146 KB gzip.
+
+## The measurement
+
+Every number below was measured in this repo's toolchain, not read from a
+listicle. Method and reproduction are at the end.
+
+### Added bundle weight
+
+Each candidate was built alone with Vite 7 and esbuild minification. React and
+React DOM are external, so the number is the weight the chart layer **adds**.
+
+| Candidate | raw | **gzip** | brotli |
+|---|---:|---:|---:|
+| Recharts 3.10.1 (area + stacked bar + tooltip + legend) | 605 KB | **146 KB** | 118 KB |
+| Observable Plot 0.6.17 (area + line) | 374 KB | **105 KB** | 88 KB |
+| visx 4.0.0 (shape + scale + axis + group) | 103 KB | **29 KB** | 26 KB |
+| `d3-scale` + `d3-shape` | 60 KB | **17 KB** | 15 KB |
+| **`d3-time` + `d3-shape` (the recommendation)** | 18 KB | **5.2 KB** | — |
+| Zero dependencies (arithmetic + `<polyline>`) | 0.9 KB | **0.5 KB** | 0.4 KB |
+
+Split of the d3 packages: `d3-scale` alone is 13.3 KB gzip, `d3-shape` alone is
+3.0 KB, `d3-time` alone is 2.3 KB. Most of `d3-scale` is date formatting and
+color interpolation that `Intl.DateTimeFormat` and our own tokens already cover.
+
+For scale: this app's main client chunk is **223 KB gzip** today
+(`main-xkMTyyUu.js`, 703 KB raw). Recharts adds 65% to that figure.
+
+### Server rendering
+
+Each component was passed to `renderToString`. The table counts the SVG marks
+that reached the server HTML.
+
+| Candidate | bytes of HTML | marks rendered |
+|---|---:|---|
+| Recharts, `ResponsiveContainer` | 139 | **none** |
+| Recharts, fixed 600x240 pixels | 127 | **none** — an empty `<div class="recharts-wrapper">` |
+| visx | 12,876 | 2 paths, 27 lines, 25 text nodes |
+| `d3-shape` hand-rolled | 635 | 2 paths, 4 text nodes |
+| Zero-dependency hand-rolled | 232 | 1 polyline |
+
+Recharts 3 renders an empty wrapper **even when the size is fixed**, so the usual
+`ResponsiveContainer` workaround does not help. The cause is the v3 rewrite: chart
+state moved into a Redux store that only fills after an effect runs, and React
+does not run effects on the server.
+
+This is confirmed by the maintainers, not inferred:
+
+- [recharts#5997](https://github.com/recharts/recharts/issues/5997) — "Unable to
+  render chart on the server using 3.0.0", opened 2025-06-24, **still open**.
+  Maintainer: "recharts is a client side library and uses APIs that require a
+  browser. This was the case in 2.x as well, server side rendering has never been
+  explicitly supported."
+- [recharts#6139](https://github.com/recharts/recharts/issues/6139) — closed as a
+  duplicate of the above.
+
+## Why this matters more here than on a normal dashboard
+
+Three of the four surfaces are public and server-rendered. Only the private view
+analytics dashboard is not, because `/settings/*` routes already set `ssr: false`
+(`src/routes/settings.machines.tsx:19`).
+
+A client-only chart on the public pages costs three things:
+
+1. **A flash.** The stack page paints, the chart box stays empty, then it pops in.
+   The ticket names this as a thing to avoid.
+2. **Machine readability.** `docs/direction.md` treats citable, crawlable numbers
+   as the point of the aggregate page. Server-rendered SVG carries real `<text>`
+   nodes. An empty div carries nothing.
+3. **The leaderboard.** A sparkline per row means many charts on one page. Each
+   Recharts chart mounts its own Redux store and `ResizeObserver`. Recharts also
+   has an open bug for two charts sharing a page
+   ([recharts#5996](https://github.com/recharts/recharts/issues/5996)). A
+   hand-rolled sparkline is one `<polyline>` in the server HTML.
+
+## The house style argument
+
+The repo's style is unusual for chart libraries: no border-radius anywhere,
+monospace labels, lime accent, sharp corners, flat panels. Every library ships
+its own opinion about rounded bars, drop shadows, default gray axes and a
+tooltip card, and the work becomes overriding those opinions.
+
+The repo already hand-rolls its only chart. The model share bar in
+`src/features/measured/MeasuredSection.tsx:226` is a `<span>` with a width
+percentage. It looks correct because nothing had to be undone first.
+
+**One conflict to record so it is not re-argued.** The `dataviz` skill specifies
+4px rounded data-ends on bars. `AGENTS.md` specifies no border-radius. **The
+house rule wins: square ends everywhere.** Every other rule in that skill
+applies unchanged.
+
+## What we give up, and what it costs
+
+Hand-rolling means we write the hover layer ourselves. The `dataviz` skill makes
+a crosshair and tooltip mandatory on line and area charts, and a per-mark tooltip
+on bars. That is the one real cost of this decision.
+
+It is smaller than it looks. A tooltip that matches this site is a mono-label
+panel with a sharp border, which is a component the design system already has.
+Restyling a library tooltip to reach the same result costs about the same, and
+leaves the library's markup underneath.
+
+What we do **not** give up: `d3-shape` supplies the path generators (`area`,
+`line`, `stack`, curves) and `d3-time` supplies honest date ticks. Those are the
+two parts that are genuinely fiddly to write. Position is a linear interpolation.
+Labels are `Intl.DateTimeFormat`.
+
+If the arithmetic gets awkward, adding `d3-scale` costs 13 KB gzip and is a
+normal step, not a change of plan.
+
+## Chart types the four surfaces need
+
+| Surface | Form | Fits the recommendation |
+|---|---|---|
+| Stack page | Time series over sparse, irregular days | Yes. A time scale places points by real date, so a two-week gap looks like a gap. |
+| Stack page | Stacked composition per harness and model | Yes. `d3-shape`'s `stack`. |
+| Aggregate page | Horizontal bars, totals | Yes. Already the pattern in `MeasuredSection`. |
+| Leaderboard | Sparkline per row | Yes, and this is where a library hurts most. |
+| Private analytics | Views per day, bars | Yes. This route is client-only anyway. |
+
+**Sparse data degrades well.** With two to five points, a library draws its full
+axis furniture and grid around almost nothing, which reads as broken. Our own
+component decides what to draw: below a point threshold, show the points and drop
+the grid. That decision is not available inside a library's render.
+
+## Candidates ruled out
+
+| Candidate | Reason |
+|---|---|
+| **Recharts 3.10.1** | Renders nothing on the server. 146 KB gzip. Pulls Redux Toolkit, react-redux, immer, reselect and a bundled d3 copy as runtime dependencies. |
+| **shadcn/ui charts** | A thin wrapper over Recharts v3. It inherits every point above. Its CSS-variable theming is the one good part, and we can copy that idea without the library. |
+| **Tremor 3.18.7** | Last published 2025-01. Peer dependency is React 18, and this app is on React 19. Wraps Recharts v2. Rounded corners are baked into its look. Dead end. |
+| **Nivo 0.99.0** | Last published 2025-05, 15 months stale. Adds react-spring. Its strength is looking good by default, which is the opposite of what this repo needs. |
+| **Observable Plot 0.6.17** | 105 KB gzip and it depends on all of `d3`. It builds DOM imperatively rather than returning React elements, so it needs a client effect or a jsdom shim on the server. |
+| **Apache ECharts 6.1.0** | Canvas-first. It does support `renderToSVGString` on the server, but that path is documented as non-interactive and needs a separate client runtime to restore hover. Large, imperative, and themed by JS objects rather than CSS variables, so light and dark mode stop being a CSS concern. |
+| **Chart.js 4.5.1** | Canvas. No server rendering. Nothing in a canvas is selectable, crawlable or CSS-themeable. |
+| **uPlot 1.6.32** | Canvas, last published 2025-03. Built for 100,000 points at speed. Our charts have 2 to 90 points. Wrong tool. |
+| **MUI X Charts 9.10.1** | Healthy and server-renderable, but it requires `@mui/material`, `@mui/system` and Emotion. Pulling a second design system into a Tailwind app is not worth it. |
+| **LayerChart** | Svelte only. Not applicable. |
+
+## Finding for the prototype ticket: the existing chart tokens fail
+
+`src/styles.css` carries `--chart-1` through `--chart-5`, scaffolded by shadcn and
+never used. Run through the `dataviz` validator against the dark canvas
+(`#0b0d11`), they fail:
+
+```
+[FAIL] Lightness band       #83b755 (0.721), #8dcd50 (0.779) outside the dark band
+[FAIL] Chroma floor         #499fb8 at 0.09 reads as gray
+[FAIL] Normal-vision floor  #8dcd50 vs #83b755 — ΔE 6.5, below the floor of 15
+[WARN] CVD separation       #8dcd50 vs #83b755 — ΔE 6.2 deutan
+```
+
+The cause is plain: `--chart-2` and `--chart-4` are both lime at hue 132 and
+differ only in lightness. Nobody can tell them apart, with or without color
+vision deficiency.
+
+**A validated categorical palette has to be built before any multi-series chart
+ships.** That is work for
+[Prototype: the living stack page](https://github.com/alp82/aistack/issues/80),
+not for this ticket. The lime accent stays the single-series color, which needs
+no palette at all.
+
+Two further notes for that ticket:
+
+- The site has 12 per-stack accent presets (`.accent-*` in `src/styles.css`). A
+  single-series chart on a stack page should use the stack's own accent. A
+  multi-series chart must not, because the palette has to stay fixed per entity.
+- Light and dark need separately chosen steps, not an automatic flip. The
+  validator has to be run for both surfaces.
+
+## Method
+
+Everything is reproducible.
+
+1. Bundle weight: a scratch Vite 7 project, one entry per candidate, built in
+   library mode with `esbuild` minification, React marked external. Sizes are
+   `gzip -9` over the emitted chunk.
+2. Server rendering: `renderToString` from `react-dom/server` on each candidate
+   component, counting `<path>`, `<rect>`, `<line>` and `<text>` in the output.
+3. Library metadata: `npm view <pkg> version time.modified peerDependencies
+   dependencies` against the live registry on 2026-08-04.
+4. Maintainer statements: the GitHub issues linked above, read with `gh`.
+5. Palette: repo OKLCH tokens converted to sRGB hex, then
+   `dataviz/scripts/validate_palette.js --mode dark --surface "#0b0d11"`.
+
+Baseline for comparison: `.output/public/assets/main-xkMTyyUu.js`, 703 KB raw and
+223 KB gzip, from the build of 2026-08-03.

--- a/docs/research/charting-library-2026-08.md
+++ b/docs/research/charting-library-2026-08.md
@@ -6,61 +6,58 @@
 
 ## Verdict
 
-**Build the charts by hand as SVG components, on `d3-shape` and `d3-time` only.**
-Collect them in one internal module so the four surfaces share one chart layer.
-Measured added weight: **5.2 KB gzip**.
+**Use [TanStack Charts](https://tanstack.com/charts) (`@tanstack/charts` +
+`@tanstack/react-charts`), pinned to an exact version and wrapped in one
+internal chart module.** Measured added weight: **44 KB gzip** for everything
+the four surfaces need.
 
-**Fallback: [visx](https://airbnb.io/visx/) (29 KB gzip).** Use it if the axis and
-scale code we write starts to cost more than it saves. visx renders the same
-plain SVG and server-renders correctly, so moving to it replaces internals and
-keeps the component API. It is an escalation, not a rewrite.
+**Fallback: hand-rolled SVG components on `d3-shape` and `d3-time`, 5.2 KB
+gzip.** Take it if the pre-1.0 API churns faster than the map can absorb. The
+fallback is fully costed in this report, so it is a known path and not a
+guess.
 
-**Recharts and the shadcn/ui chart family are ruled out.** They render **nothing**
-on the server, and they cost 146 KB gzip.
+**Recharts and the shadcn/ui chart family are ruled out.** They render
+**nothing** on the server, and they cost 146 KB gzip.
+
+The single risk in this choice is maturity: TanStack Charts is **0.6.2,
+published 2026-08-03**. See [Maturity risk](#maturity-risk) for why it is worth
+taking and how it is contained.
 
 ## The measurement
 
 Every number below was measured in this repo's toolchain, not read from a
-listicle. Method and reproduction are at the end.
-
-### Added bundle weight
-
-Each candidate was built alone with Vite 7 and esbuild minification. React and
-React DOM are external, so the number is the weight the chart layer **adds**.
-
-| Candidate | raw | **gzip** | brotli |
-|---|---:|---:|---:|
-| Recharts 3.10.1 (area + stacked bar + tooltip + legend) | 605 KB | **146 KB** | 118 KB |
-| Observable Plot 0.6.17 (area + line) | 374 KB | **105 KB** | 88 KB |
-| visx 4.0.0 (shape + scale + axis + group) | 103 KB | **29 KB** | 26 KB |
-| `d3-scale` + `d3-shape` | 60 KB | **17 KB** | 15 KB |
-| **`d3-time` + `d3-shape` (the recommendation)** | 18 KB | **5.2 KB** | — |
-| Zero dependencies (arithmetic + `<polyline>`) | 0.9 KB | **0.5 KB** | 0.4 KB |
-
-Split of the d3 packages: `d3-scale` alone is 13.3 KB gzip, `d3-shape` alone is
-3.0 KB, `d3-time` alone is 2.3 KB. Most of `d3-scale` is date formatting and
-color interpolation that `Intl.DateTimeFormat` and our own tokens already cover.
-
-For scale: this app's main client chunk is **223 KB gzip** today
-(`main-xkMTyyUu.js`, 703 KB raw). Recharts adds 65% to that figure.
+comparison article. Method and reproduction are at the end.
 
 ### Server rendering
 
-Each component was passed to `renderToString`. The table counts the SVG marks
-that reached the server HTML.
+This is the criterion that decided it. Each component was passed to
+`renderToString`, counting the SVG marks that reached the server HTML.
 
 | Candidate | bytes of HTML | marks rendered |
 |---|---:|---|
+| **TanStack Charts** — series | **7,242** | **2 paths, 18 lines, 10 text** |
+| **TanStack Charts** — composition | **4,300** | **2 rects, 11 lines, 9 text** |
+| visx | 12,876 | 2 paths, 27 lines, 25 text |
+| `d3-shape` hand-rolled | 635 | 2 paths, 4 text |
 | Recharts, `ResponsiveContainer` | 139 | **none** |
 | Recharts, fixed 600x240 pixels | 127 | **none** — an empty `<div class="recharts-wrapper">` |
-| visx | 12,876 | 2 paths, 27 lines, 25 text nodes |
-| `d3-shape` hand-rolled | 635 | 2 paths, 4 text nodes |
-| Zero-dependency hand-rolled | 232 | 1 polyline |
+
+TanStack Charts emits a complete, responsive SVG on the server:
+
+```html
+<svg class="ts-chart" width="100%" height="100%" viewBox="0 0 720 240"
+     role="img" aria-roledescription="chart" aria-label="tokens per day" tabindex="0">
+```
+
+That is a `viewBox` that scales with CSS, so there is no client measurement, no
+`ResizeObserver` before first paint, and no flash. The documented adapter
+contract states it plainly: React gets "Complete SVG" on the server and
+"Hydrates and adopts the existing surface" in the browser.
 
 Recharts 3 renders an empty wrapper **even when the size is fixed**, so the usual
-`ResponsiveContainer` workaround does not help. The cause is the v3 rewrite: chart
-state moved into a Redux store that only fills after an effect runs, and React
-does not run effects on the server.
+`ResponsiveContainer` workaround does not help. The cause is the v3 rewrite:
+chart state moved into a Redux store that only fills after an effect runs, and
+React does not run effects on the server.
 
 This is confirmed by the maintainers, not inferred:
 
@@ -72,91 +69,136 @@ This is confirmed by the maintainers, not inferred:
 - [recharts#6139](https://github.com/recharts/recharts/issues/6139) — closed as a
   duplicate of the above.
 
-## Why this matters more here than on a normal dashboard
+### Added bundle weight
+
+Each candidate was built alone with Vite 7 and esbuild minification. React and
+React DOM are external, so the number is the weight the chart layer **adds**.
+
+| Candidate | raw | **gzip** | brotli |
+|---|---:|---:|---:|
+| Recharts 3.10.1 (area + stacked bar + tooltip + legend) | 605 KB | **146 KB** | 118 KB |
+| Observable Plot 0.6.17 (area + line) | 374 KB | **105 KB** | 88 KB |
+| **TanStack Charts 0.6.2** (area + line + bar + tooltip + `d3-scale`) | 149 KB | **44 KB** | 38 KB |
+| TanStack Charts — one line mark, no tooltip, no axes | 118 KB | **34 KB** | — |
+| visx 4.0.0 (shape + scale + axis + group) | 103 KB | **29 KB** | 26 KB |
+| `d3-scale` + `d3-shape` | 60 KB | **17 KB** | 15 KB |
+| **`d3-time` + `d3-shape` (the fallback)** | 18 KB | **5.2 KB** | — |
+| Zero dependencies (arithmetic + `<polyline>`) | 0.9 KB | **0.5 KB** | 0.4 KB |
+
+The two TanStack rows show where its weight sits: about **34 KB is the grammar
+engine floor**, and the full set of marks and the tooltip add roughly 10 KB on
+top. Marks tree-shake; the runtime does not.
+
+For scale: this app's main client chunk is **223 KB gzip**
+(`main-xkMTyyUu.js`, 703 KB raw, build of 2026-08-03). TanStack Charts adds 20%
+to that figure and only on the routes that import it. Recharts adds 65%.
+
+## Why TanStack Charts wins
+
+**1. It solves the hard problem by design.** Server-rendered responsive SVG is
+the thing that killed Recharts, and it is the thing this library documents as a
+contract with a per-adapter support table and a determinism checklist.
 
 Three of the four surfaces are public and server-rendered. Only the private view
-analytics dashboard is not, because `/settings/*` routes already set `ssr: false`
-(`src/routes/settings.machines.tsx:19`).
+analytics dashboard is not, because `/settings/*` routes already set
+`ssr: false` (`src/routes/settings.machines.tsx:19`). Server-rendered SVG carries
+real `<text>` nodes, which matters because `docs/direction.md` treats citable,
+crawlable numbers as the point of the aggregate page.
 
-A client-only chart on the public pages costs three things:
+**2. It ships no visual theme to fight.** The house style is unusual for chart
+libraries: no border-radius anywhere, monospace labels, lime accent, sharp
+corners, flat panels. Most libraries ship rounded bars, gray axes and a tooltip
+card, and the work becomes undoing them.
 
-1. **A flash.** The stack page paints, the chart box stays empty, then it pops in.
-   The ticket names this as a thing to avoid.
-2. **Machine readability.** `docs/direction.md` treats citable, crawlable numbers
-   as the point of the aggregate page. Server-rendered SVG carries real `<text>`
-   nodes. An empty div carries nothing.
-3. **The leaderboard.** A sparkline per row means many charts on one page. Each
-   Recharts chart mounts its own Redux store and `ResizeObserver`. Recharts also
-   has an open bug for two charts sharing a page
-   ([recharts#5996](https://github.com/recharts/recharts/issues/5996)). A
-   hand-rolled sparkline is one `<polyline>` in the server HTML.
+TanStack Charts defaults to `currentColor` for foreground, text and grid,
+`transparent` for the background, and six CSS-variable categorical colors. It
+inherits the surrounding application rather than installing a look. Light and
+dark stay a pure CSS concern, so there is no theme flash and no JS theme object.
 
-## The house style argument
+**3. It includes the layer that hand-rolling makes us write.** The `dataviz`
+skill makes a crosshair and tooltip mandatory on line and area, and a per-mark
+tooltip on bars. It also wants legends, keyboard access and exact-value
+alternatives. TanStack Charts ships tooltips, grouped focus, keyboard
+navigation, legends, reduced-motion support and `role="img"` with an aria label.
+That was the one real cost of the hand-rolled option, and it is the difference
+between 5.2 KB and 44 KB.
 
-The repo's style is unusual for chart libraries: no border-radius anywhere,
-monospace labels, lime accent, sharp corners, flat panels. Every library ships
-its own opinion about rounded bars, drop shadows, default gray axes and a
-tooltip card, and the work becomes overriding those opinions.
+**4. It fits this codebase.** The app is TanStack throughout — Router, Start,
+Query, Form, Virtual. The library also ships `llms.txt`, an API reference and an
+AI-authoring guide inside the package, which is worth real money in a codebase
+driven by coding agents.
 
-The repo already hand-rolls its only chart. The model share bar in
-`src/features/measured/MeasuredSection.tsx:226` is a `<span>` with a width
-percentage. It looks correct because nothing had to be undone first.
+**5. Every form the four surfaces need is a built-in mark.** `areaY` and `lineY`
+for the time series, implicit stacking by repeated x for composition, `barX` for
+horizontal bars, and a marks-only chart with `axis: false` for a leaderboard
+sparkline.
 
-**One conflict to record so it is not re-argued.** The `dataviz` skill specifies
-4px rounded data-ends on bars. `AGENTS.md` specifies no border-radius. **The
-house rule wins: square ends everywhere.** Every other rule in that skill
-applies unchanged.
+## Maturity risk
 
-## What we give up, and what it costs
+`@tanstack/charts` is **0.6.2**, first published days before this decision. That
+is the whole case against it, and it is not a small one. A pre-1.0 library can
+break its API inside the window this map runs.
 
-Hand-rolling means we write the hover layer ourselves. The `dataviz` skill makes
-a crosshair and tooltip mandatory on line and area charts, and a per-mark tooltip
-on bars. That is the one real cost of this decision.
+Three things contain it:
 
-It is smaller than it looks. A tooltip that matches this site is a mono-label
-panel with a sharp border, which is a component the design system already has.
-Restyling a library tooltip to reach the same result costs about the same, and
-leaves the library's markup underneath.
+1. **Pin the exact version.** No caret. Upgrade deliberately.
+2. **Wrap it.** The shared chart module
+   ([#91](https://github.com/alp82/aistack/issues/91)) is the only place that
+   imports it. The four surfaces import our components, never the library.
+3. **The fallback is designed, not hypothetical.** Hand-rolled SVG on
+   `d3-shape` + `d3-time` is measured at 5.2 KB gzip in this report, with a
+   working server-render test. If the library becomes a problem, the exit is a
+   module rewrite behind a stable component API, not a surface rewrite.
 
-What we do **not** give up: `d3-shape` supplies the path generators (`area`,
-`line`, `stack`, curves) and `d3-time` supplies honest date ticks. Those are the
-two parts that are genuinely fiddly to write. Position is a linear interpolation.
-Labels are `Intl.DateTimeFormat`.
-
-If the arithmetic gets awkward, adding `d3-scale` costs 13 KB gzip and is a
-normal step, not a change of plan.
-
-## Chart types the four surfaces need
-
-| Surface | Form | Fits the recommendation |
-|---|---|---|
-| Stack page | Time series over sparse, irregular days | Yes. A time scale places points by real date, so a two-week gap looks like a gap. |
-| Stack page | Stacked composition per harness and model | Yes. `d3-shape`'s `stack`. |
-| Aggregate page | Horizontal bars, totals | Yes. Already the pattern in `MeasuredSection`. |
-| Leaderboard | Sparkline per row | Yes, and this is where a library hurts most. |
-| Private analytics | Views per day, bars | Yes. This route is client-only anyway. |
-
-**Sparse data degrades well.** With two to five points, a library draws its full
-axis furniture and grid around almost nothing, which reads as broken. Our own
-component decides what to draw: below a point threshold, show the points and drop
-the grid. That decision is not available inside a library's render.
+The trade being made: accept churn risk on a wrapped dependency, in exchange for
+a correct SSR story and an accessible interaction layer we would otherwise write
+and test ourselves.
 
 ## Candidates ruled out
 
 | Candidate | Reason |
 |---|---|
-| **Recharts 3.10.1** | Renders nothing on the server. 146 KB gzip. Pulls Redux Toolkit, react-redux, immer, reselect and a bundled d3 copy as runtime dependencies. |
-| **shadcn/ui charts** | A thin wrapper over Recharts v3. It inherits every point above. Its CSS-variable theming is the one good part, and we can copy that idea without the library. |
+| **Recharts 3.10.1** | Renders nothing on the server, even at a fixed size. 146 KB gzip. Pulls Redux Toolkit, react-redux, immer, reselect and a bundled d3 copy as runtime dependencies. Also has an open two-charts-per-page bug ([recharts#5996](https://github.com/recharts/recharts/issues/5996)), which the leaderboard would hit on every row. |
+| **shadcn/ui charts** | A thin wrapper over Recharts v3. It inherits every point above. Its CSS-variable theming is the good part, and TanStack Charts does the same thing without the Recharts underneath. |
+| **Bklit UI** | Suggested on the ticket, and genuinely nice work — MIT, 1.4k stars, a shadcn registry of 17+ charts you copy into the repo rather than install. But it is **client-only by construction**: every component starts with `"use client"` and sizes itself with `ParentSize` from `@visx/responsive`, so the server sends an empty box. It also builds on visx, so it is not a separate engine choice — it is starting source for the visx option. Its Vercel/Geist look is the opposite of this repo's. Worth keeping as a **reference for chart anatomy and tooltip behavior**, not as the chart layer. |
+| **visx 4.0.0** | Healthy, server-renders correctly, 29 KB. It is the middle option: more machinery than hand-rolling, no grammar, no tooltip or focus layer, and axes we would restyle anyway. TanStack Charts gives more for 15 KB more; hand-rolling gives enough for 24 KB less. visx is squeezed from both sides. |
 | **Tremor 3.18.7** | Last published 2025-01. Peer dependency is React 18, and this app is on React 19. Wraps Recharts v2. Rounded corners are baked into its look. Dead end. |
 | **Nivo 0.99.0** | Last published 2025-05, 15 months stale. Adds react-spring. Its strength is looking good by default, which is the opposite of what this repo needs. |
-| **Observable Plot 0.6.17** | 105 KB gzip and it depends on all of `d3`. It builds DOM imperatively rather than returning React elements, so it needs a client effect or a jsdom shim on the server. |
-| **Apache ECharts 6.1.0** | Canvas-first. It does support `renderToSVGString` on the server, but that path is documented as non-interactive and needs a separate client runtime to restore hover. Large, imperative, and themed by JS objects rather than CSS variables, so light and dark mode stop being a CSS concern. |
+| **Observable Plot 0.6.17** | 105 KB gzip and it depends on all of `d3`. It builds DOM imperatively rather than returning React elements, so it needs a client effect or a jsdom shim on the server. TanStack Charts uses the same marks-and-channels grammar with a React adapter and half the weight. |
+| **Apache ECharts 6.1.0** | Canvas-first. It does support `renderToSVGString` on the server, but that path is documented as non-interactive and needs a separate client runtime to restore hover. Large, imperative, and themed by JS objects rather than CSS variables, so light and dark mode stops being a CSS concern. |
 | **Chart.js 4.5.1** | Canvas. No server rendering. Nothing in a canvas is selectable, crawlable or CSS-themeable. |
 | **uPlot 1.6.32** | Canvas, last published 2025-03. Built for 100,000 points at speed. Our charts have 2 to 90 points. Wrong tool. |
 | **MUI X Charts 9.10.1** | Healthy and server-renderable, but it requires `@mui/material`, `@mui/system` and Emotion. Pulling a second design system into a Tailwind app is not worth it. |
+| **`react-charts` 2.0.0-beta.7** | The old TanStack chart package. Last published 2023-11, React 16 peer. Superseded by `@tanstack/charts`. Do not confuse the two. |
 | **LayerChart** | Svelte only. Not applicable. |
 
-## Finding for the prototype ticket: the existing chart tokens fail
+## Chart types the four surfaces need
+
+| Surface | Form | Mark |
+|---|---|---|
+| Stack page | Time series over sparse, irregular days | `areaY` + `lineY` on `scaleUtc`, so a two-week gap looks like a gap |
+| Stack page | Stacked composition per harness and model | `areaY`/`barX` with implicit stacking by repeated position |
+| Aggregate page | Horizontal bars, totals | `barX` |
+| Leaderboard | Sparkline per row | `lineY` with `axis: false` |
+| Private analytics | Views per day, bars | `barY`. This route is client-only anyway |
+
+**Sparse data is the common case.** Most stacks will have two to five points for
+a long while. Any library draws its full axis furniture around almost nothing,
+which reads as broken. This is not solved by the library choice — it is solved by
+our wrapper deciding what to draw below a point threshold. That decision belongs
+in the chart module either way.
+
+## Style rules to carry forward
+
+**One conflict, resolved so it is not re-argued.** The `dataviz` skill specifies
+4px rounded data-ends on bars. `AGENTS.md` specifies no border-radius. **The
+house rule wins: square ends everywhere.** Every other rule in that skill
+applies unchanged.
+
+**Palette tokens.** TanStack Charts reads `--ts-chart-1` through `--ts-chart-6`
+at any container boundary. Map them from our own validated tokens in one place.
+
+## Finding for the shared chart module: the existing chart tokens fail
 
 `src/styles.css` carries `--chart-1` through `--chart-5`, scaffolded by shadcn and
 never used. Run through the `dataviz` validator against the dark canvas
@@ -175,17 +217,17 @@ vision deficiency.
 
 **A validated categorical palette has to be built before any multi-series chart
 ships.** That is work for
-[Prototype: the living stack page](https://github.com/alp82/aistack/issues/80),
-not for this ticket. The lime accent stays the single-series color, which needs
-no palette at all.
+[Task: the shared chart module](https://github.com/alp82/aistack/issues/91).
+The lime accent stays the single-series color, which needs no palette at all.
 
 Two further notes for that ticket:
 
 - The site has 12 per-stack accent presets (`.accent-*` in `src/styles.css`). A
   single-series chart on a stack page should use the stack's own accent. A
-  multi-series chart must not, because the palette has to stay fixed per entity.
+  multi-series chart must not, because categorical color has to stay fixed per
+  entity.
 - Light and dark need separately chosen steps, not an automatic flip. The
-  validator has to be run for both surfaces.
+  validator has to be run against both surfaces.
 
 ## Method
 
@@ -198,9 +240,10 @@ Everything is reproducible.
    component, counting `<path>`, `<rect>`, `<line>` and `<text>` in the output.
 3. Library metadata: `npm view <pkg> version time.modified peerDependencies
    dependencies` against the live registry on 2026-08-04.
-4. Maintainer statements: the GitHub issues linked above, read with `gh`.
-5. Palette: repo OKLCH tokens converted to sRGB hex, then
+4. TanStack Charts behavior: read from the docs shipped inside the package
+   (`node_modules/@tanstack/charts/docs`), not from the website.
+5. Bklit behavior: read from `bklit/bklit-ui` source on GitHub
+   (`packages/ui/src/line-chart.tsx`).
+6. Maintainer statements: the GitHub issues linked above, read with `gh`.
+7. Palette: repo OKLCH tokens converted to sRGB hex, then
    `dataviz/scripts/validate_palette.js --mode dark --surface "#0b0d11"`.
-
-Baseline for comparison: `.output/public/assets/main-xkMTyyUu.js`, 703 KB raw and
-223 KB gzip, from the build of 2026-08-03.


### PR DESCRIPTION
Resolves [Research: charting library for the house style](https://github.com/alp82/aistack/issues/79) on map #76.

The report is `docs/research/charting-library-2026-08.md`. Every number in it was measured in this repo's toolchain, not read from a comparison article.

> **Revised.** The first pass missed two candidates suggested on the ticket — bklit and TanStack Charts. Both are now measured and the answer changed.

## What it decides

**TanStack Charts** (`@tanstack/charts` + `@tanstack/react-charts`), pinned to an exact version and wrapped in one internal chart module. Measured added weight: **44 KB gzip**.

**Fallback:** hand-rolled SVG on `d3-shape` + `d3-time`, **5.2 KB gzip**, fully costed in the report so the exit from a pre-1.0 dependency is a designed path.

## Why

It server-renders complete responsive SVG — the criterion that killed Recharts:

```html
<svg class="ts-chart" width="100%" height="100%" viewBox="0 0 720 240"
     role="img" aria-roledescription="chart" aria-label="tokens per day" tabindex="0">
```

A `viewBox` that scales with CSS. No client measure, no `ResizeObserver` before first paint, no flash.

It also ships no visual theme to fight (`currentColor` + CSS variables + transparent background), includes the tooltip/focus/keyboard/aria layer that hand-rolling would make us write, and fits a codebase that is already TanStack Router, Start, Query, Form and Virtual.

The one risk is maturity — 0.6.2, published 2026-08-03. Contained by pinning the version, letting only the shared chart module import it, and keeping the fallback costed.

## Why not Recharts / shadcn charts

They render **nothing** on the server. An empty `<div class="recharts-wrapper">` comes back even with a fixed pixel size, so the usual `ResponsiveContainer` workaround does not help. Recharts 3 moved chart state into a Redux store that only fills after an effect runs. Maintainers confirm it in recharts#5997, open since 2025-06. 146 KB gzip against a 223 KB main chunk, plus an open two-charts-per-page bug the leaderboard would hit on every row.

## Why not bklit

Genuinely nice work, MIT, a shadcn registry you copy in. But every component opens with `"use client"` and sizes itself with `ParentSize` from `@visx/responsive`, so the server sends an empty box. It also builds on visx, so it is starting source for the visx option rather than a separate engine. Worth keeping as a reference for chart anatomy and tooltip behavior.

## Side finding

The scaffolded `--chart-1..5` tokens fail the dataviz validator. `--chart-2` and `--chart-4` are both lime at hue 132 and differ only in lightness — ΔE 6.5 in normal vision, against a floor of 15. A validated palette has to be built before any multi-series chart ships. Handed to #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPaGJivZLF7XeqckSkFDa1