### PR TITLE
feat(views): the owner-private view analytics dashboard (#86)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -59,6 +59,7 @@ import type * as seeds_stacks from "../seeds/stacks.js";
 import type * as seeds_tools from "../seeds/tools.js";
 import type * as stacks from "../stacks.js";
 import type * as tools from "../tools.js";
+import type * as viewAnalytics from "../viewAnalytics.js";
 import type * as views from "../views.js";
 import type * as waitlist from "../waitlist.js";
 
@@ -120,6 +121,7 @@ declare const fullApi: ApiFromModules<{
   "seeds/tools": typeof seeds_tools;
   stacks: typeof stacks;
   tools: typeof tools;
+  viewAnalytics: typeof viewAnalytics;
   views: typeof views;
   waitlist: typeof waitlist;
 }>;

--- a/convex/viewAnalytics.test.ts
+++ b/convex/viewAnalytics.test.ts
@@ -1,0 +1,362 @@
+/// <reference types="vite/client" />
+/**
+ * The read side of view counting (#86, map #76).
+ *
+ * The tests that matter here are the ownership ones. This query is the only
+ * reader of a table the map locked as strictly private, and the repo already
+ * shipped one public function that trusted a client-side route guard. So the
+ * guard is asserted from three sides: a stranger, a signed-out caller, and an
+ * owner who must see their own rows and nobody else's.
+ */
+import { convexTest } from 'convex-test'
+import { expect, test } from 'vitest'
+import schema from './schema'
+import { api } from './_generated/api'
+import type { MutationCtx } from './_generated/server'
+import type { Id } from './_generated/dataModel'
+
+const modules = import.meta.glob('./**/*.{js,ts}')
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+function today(): number {
+  return Math.floor(Date.now() / DAY_MS) * DAY_MS
+}
+
+type Seeded = { creatorId: Id<'creators'>; stackId: Id<'stacks'> }
+
+async function seedCreator(
+  t: ReturnType<typeof convexTest>,
+  opts: { userId: string; slug: string; stackName?: string; published?: boolean },
+): Promise<Seeded> {
+  return await t.run(async (ctx: MutationCtx) => {
+    const creatorId = await ctx.db.insert('creators', {
+      name: `Creator ${opts.userId}`,
+      slug: opts.slug,
+      userId: opts.userId,
+      verified: false,
+      personalPages: [],
+      projectPages: [],
+      createdAt: Date.now(),
+    })
+    const stackId = await ctx.db.insert('stacks', {
+      name: opts.stackName ?? 'Main Stack',
+      slug: `${opts.slug}-stack`,
+      shortId: opts.slug.slice(0, 6),
+      creatorId,
+      oneLiner: 'one',
+      toolSubscriptions: [],
+      hasUsageComponent: false,
+      published: opts.published ?? true,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    })
+    return { creatorId, stackId }
+  })
+}
+
+async function seedCounter(
+  t: ReturnType<typeof convexTest>,
+  row: {
+    targetKind: 'stack' | 'creator' | 'aggregate'
+    targetId: string
+    dayStartMs: number
+    referrerBucket: 'direct' | 'search' | 'ai' | 'social' | 'internal' | 'other'
+    count: number
+  },
+): Promise<void> {
+  await t.run(async (ctx: MutationCtx) => {
+    await ctx.db.insert('viewCounters', row)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// The guard
+// ---------------------------------------------------------------------------
+
+test('a signed-out caller gets nothing', async () => {
+  const t = convexTest(schema, modules)
+  await seedCreator(t, { userId: 'owner-1', slug: 'owner-one' })
+  expect(await t.query(api.viewAnalytics.mine, {})).toBeNull()
+})
+
+test('a signed-in user with no creator profile gets nothing', async () => {
+  const t = convexTest(schema, modules)
+  const asStranger = t.withIdentity({ tokenIdentifier: 'convex|stranger' })
+  expect(await asStranger.query(api.viewAnalytics.mine, {})).toBeNull()
+})
+
+test('the query takes no target argument, so it cannot be pointed at anyone', async () => {
+  // The guard is structural, not a check that could be forgotten: there is no
+  // argument naming a target, so a caller has nothing to substitute.
+  const t = convexTest(schema, modules)
+  const { stackId } = await seedCreator(t, { userId: 'victim', slug: 'victim' })
+  const asStranger = t.withIdentity({ tokenIdentifier: 'convex|stranger' })
+  await expect(
+    // @ts-expect-error — proving the argument does not exist
+    asStranger.query(api.viewAnalytics.mine, { targetId: stackId }),
+  ).rejects.toThrow()
+})
+
+test("one owner never sees another owner's views", async () => {
+  const t = convexTest(schema, modules)
+  const mine = await seedCreator(t, { userId: 'owner-a', slug: 'owner-a' })
+  const theirs = await seedCreator(t, { userId: 'owner-b', slug: 'owner-b' })
+  const day = today()
+
+  await seedCounter(t, {
+    targetKind: 'stack',
+    targetId: mine.stackId,
+    dayStartMs: day,
+    referrerBucket: 'search',
+    count: 3,
+  })
+  await seedCounter(t, {
+    targetKind: 'stack',
+    targetId: theirs.stackId,
+    dayStartMs: day,
+    referrerBucket: 'search',
+    count: 900,
+  })
+
+  const asA = t.withIdentity({ tokenIdentifier: 'convex|owner-a' })
+  const result = await asA.query(api.viewAnalytics.mine, {})
+  expect(result?.total).toBe(3)
+  expect(result?.targets.map((x) => x.targetId)).not.toContain(theirs.stackId)
+})
+
+test('the aggregate counter is nobody’s, so it never lands in an owner’s numbers', async () => {
+  // `views.record` counts an `aggregate` target with the sentinel id `global`.
+  // It has no owner document, and this page is per-owner.
+  const t = convexTest(schema, modules)
+  await seedCreator(t, { userId: 'owner-c', slug: 'owner-c' })
+  await seedCounter(t, {
+    targetKind: 'aggregate',
+    targetId: 'global',
+    dayStartMs: today(),
+    referrerBucket: 'direct',
+    count: 500,
+  })
+
+  const asC = t.withIdentity({ tokenIdentifier: 'convex|owner-c' })
+  const result = await asC.query(api.viewAnalytics.mine, {})
+  expect(result?.total).toBe(0)
+})
+
+// ---------------------------------------------------------------------------
+// What it returns
+// ---------------------------------------------------------------------------
+
+test('the profile and every owned stack are listed, in that order', async () => {
+  const t = convexTest(schema, modules)
+  const { creatorId } = await seedCreator(t, {
+    userId: 'owner-d',
+    slug: 'owner-d',
+    stackName: 'First Stack',
+  })
+  const asD = t.withIdentity({ tokenIdentifier: 'convex|owner-d' })
+  const result = await asD.query(api.viewAnalytics.mine, {})
+
+  expect(result?.targets).toHaveLength(2)
+  expect(result?.targets[0]).toMatchObject({
+    kind: 'profile',
+    targetId: creatorId,
+    label: 'Your profile',
+  })
+  expect(result?.targets[1]).toMatchObject({
+    kind: 'stack',
+    label: 'First Stack',
+  })
+})
+
+test('a target nobody visited is still listed, with a zero total', async () => {
+  // A stack published yesterday has no rows at all. Dropping it would read as
+  // "this page does not know about your stack" rather than "nobody came yet".
+  const t = convexTest(schema, modules)
+  await seedCreator(t, { userId: 'owner-e', slug: 'owner-e' })
+  const asE = t.withIdentity({ tokenIdentifier: 'convex|owner-e' })
+  const result = await asE.query(api.viewAnalytics.mine, {})
+
+  expect(result?.targets.every((x) => x.total === 0)).toBe(true)
+  expect(result?.targets.every((x) => x.days.length === 0)).toBe(true)
+  expect(result?.total).toBe(0)
+})
+
+test('a draft stack is marked as not openable, because nobody can reach its page', async () => {
+  // `stacks.getBySlug` returns null for an unpublished stack, so a draft's
+  // counter can only ever be zero. The row says why.
+  const t = convexTest(schema, modules)
+  await seedCreator(t, { userId: 'owner-f', slug: 'owner-f', published: false })
+  const asF = t.withIdentity({ tokenIdentifier: 'convex|owner-f' })
+  const result = await asF.query(api.viewAnalytics.mine, {})
+
+  const stack = result?.targets.find((x) => x.kind === 'stack')
+  expect(stack?.openable).toBe(false)
+})
+
+test('a day sums every referrer bucket that counted on it', async () => {
+  const t = convexTest(schema, modules)
+  const { stackId } = await seedCreator(t, { userId: 'owner-g', slug: 'owner-g' })
+  const day = today()
+  await seedCounter(t, {
+    targetKind: 'stack',
+    targetId: stackId,
+    dayStartMs: day,
+    referrerBucket: 'search',
+    count: 2,
+  })
+  await seedCounter(t, {
+    targetKind: 'stack',
+    targetId: stackId,
+    dayStartMs: day,
+    referrerBucket: 'ai',
+    count: 5,
+  })
+
+  const asG = t.withIdentity({ tokenIdentifier: 'convex|owner-g' })
+  const result = await asG.query(api.viewAnalytics.mine, {})
+  const stack = result?.targets.find((x) => x.kind === 'stack')
+  expect(stack?.days).toEqual([{ at: day, value: 7 }])
+  expect(stack?.total).toBe(7)
+})
+
+test('quiet days inside a target’s history read as zero, not as a gap', async () => {
+  // A line drawn straight from Monday to Friday claims visits on Wednesday. The
+  // series is filled from the first counted day so the quiet days are visible.
+  const t = convexTest(schema, modules)
+  const { stackId } = await seedCreator(t, { userId: 'owner-h', slug: 'owner-h' })
+  const day = today()
+  await seedCounter(t, {
+    targetKind: 'stack',
+    targetId: stackId,
+    dayStartMs: day - 3 * DAY_MS,
+    referrerBucket: 'direct',
+    count: 4,
+  })
+  await seedCounter(t, {
+    targetKind: 'stack',
+    targetId: stackId,
+    dayStartMs: day,
+    referrerBucket: 'direct',
+    count: 1,
+  })
+
+  const asH = t.withIdentity({ tokenIdentifier: 'convex|owner-h' })
+  const result = await asH.query(api.viewAnalytics.mine, {})
+  const stack = result?.targets.find((x) => x.kind === 'stack')
+  expect(stack?.days).toEqual([
+    { at: day - 3 * DAY_MS, value: 4 },
+    { at: day - 2 * DAY_MS, value: 0 },
+    { at: day - 1 * DAY_MS, value: 0 },
+    { at: day, value: 1 },
+  ])
+})
+
+test('the series starts at the first counted day, never before it', async () => {
+  // Counting started on a date. Padding the window back to 30 days would print
+  // "0 views" for days that were never counted, which is a claim, not a gap.
+  const t = convexTest(schema, modules)
+  const { stackId } = await seedCreator(t, { userId: 'owner-i', slug: 'owner-i' })
+  const day = today()
+  await seedCounter(t, {
+    targetKind: 'stack',
+    targetId: stackId,
+    dayStartMs: day - DAY_MS,
+    referrerBucket: 'direct',
+    count: 2,
+  })
+
+  const asI = t.withIdentity({ tokenIdentifier: 'convex|owner-i' })
+  const result = await asI.query(api.viewAnalytics.mine, {})
+  const stack = result?.targets.find((x) => x.kind === 'stack')
+  expect(stack?.days).toHaveLength(2)
+  expect(stack?.days[0]?.at).toBe(day - DAY_MS)
+})
+
+test('days older than the window are left out of every number', async () => {
+  const t = convexTest(schema, modules)
+  const { stackId } = await seedCreator(t, { userId: 'owner-j', slug: 'owner-j' })
+  const day = today()
+  await seedCounter(t, {
+    targetKind: 'stack',
+    targetId: stackId,
+    dayStartMs: day - 40 * DAY_MS,
+    referrerBucket: 'direct',
+    count: 99,
+  })
+  await seedCounter(t, {
+    targetKind: 'stack',
+    targetId: stackId,
+    dayStartMs: day,
+    referrerBucket: 'direct',
+    count: 1,
+  })
+
+  const asJ = t.withIdentity({ tokenIdentifier: 'convex|owner-j' })
+  const result = await asJ.query(api.viewAnalytics.mine, {})
+  expect(result?.total).toBe(1)
+  expect(result?.windowDays).toBe(30)
+})
+
+test('referrer buckets sum across every target, and empty buckets are dropped', async () => {
+  const t = convexTest(schema, modules)
+  const { creatorId, stackId } = await seedCreator(t, {
+    userId: 'owner-k',
+    slug: 'owner-k',
+  })
+  const day = today()
+  await seedCounter(t, {
+    targetKind: 'creator',
+    targetId: creatorId,
+    dayStartMs: day,
+    referrerBucket: 'ai',
+    count: 2,
+  })
+  await seedCounter(t, {
+    targetKind: 'stack',
+    targetId: stackId,
+    dayStartMs: day,
+    referrerBucket: 'ai',
+    count: 3,
+  })
+  await seedCounter(t, {
+    targetKind: 'stack',
+    targetId: stackId,
+    dayStartMs: day,
+    referrerBucket: 'direct',
+    count: 1,
+  })
+
+  const asK = t.withIdentity({ tokenIdentifier: 'convex|owner-k' })
+  const result = await asK.query(api.viewAnalytics.mine, {})
+  expect(result?.referrers).toEqual([
+    { bucket: 'ai', count: 5 },
+    { bucket: 'direct', count: 1 },
+  ])
+  expect(result?.total).toBe(6)
+})
+
+test('the first counted day is reported, so the page can label the real range', async () => {
+  const t = convexTest(schema, modules)
+  const { stackId } = await seedCreator(t, { userId: 'owner-l', slug: 'owner-l' })
+  const day = today()
+  await seedCounter(t, {
+    targetKind: 'stack',
+    targetId: stackId,
+    dayStartMs: day - 2 * DAY_MS,
+    referrerBucket: 'direct',
+    count: 1,
+  })
+
+  const asL = t.withIdentity({ tokenIdentifier: 'convex|owner-l' })
+  const result = await asL.query(api.viewAnalytics.mine, {})
+  expect(result?.firstCountedDayMs).toBe(day - 2 * DAY_MS)
+})
+
+test('an owner with nothing counted reports no first day at all', async () => {
+  const t = convexTest(schema, modules)
+  await seedCreator(t, { userId: 'owner-m', slug: 'owner-m' })
+  const asM = t.withIdentity({ tokenIdentifier: 'convex|owner-m' })
+  const result = await asM.query(api.viewAnalytics.mine, {})
+  expect(result?.firstCountedDayMs).toBeNull()
+})

--- a/convex/viewAnalytics.ts
+++ b/convex/viewAnalytics.ts
@@ -1,0 +1,196 @@
+// The read side of view counting (#86, map #76).
+//
+// STRICTLY PRIVATE, and the guard is structural. This query takes NO target
+// argument: it derives the caller's creator row from the authenticated session
+// and reads only the counters of that creator's own profile and stacks. There is
+// nothing for a caller to substitute, which is the difference between this and
+// the repo's earlier public functions that leaned on a client-side route guard.
+//
+// What the number means, in one sentence the page repeats: deduped daily
+// visitors — approximate browser and network combinations per UTC day, per page,
+// with authenticated owner views excluded. Never people, never impressions.
+
+import { v } from 'convex/values'
+import type { Infer } from 'convex/values'
+import { query } from './_generated/server'
+import type { QueryCtx } from './_generated/server'
+import type { Doc } from './_generated/dataModel'
+import { ReferrerBucket } from './schema'
+import { utcDayStart } from './views'
+
+type ReferrerBucketValue = Infer<typeof ReferrerBucket>
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/**
+ * The window every number on the page covers.
+ *
+ * Thirty days matches the rolling window the rest of the site already speaks in,
+ * and it bounds the read at `targets x 30 x buckets` rows.
+ */
+const WINDOW_DAYS = 30
+
+/** One day of one target, shaped as the chart module's point input. */
+const DayPoint = v.object({ at: v.number(), value: v.number() })
+
+const ViewTarget = v.object({
+  kind: v.union(v.literal('profile'), v.literal('stack')),
+  /** The document id the counter rows are filed under. */
+  targetId: v.string(),
+  label: v.string(),
+  /** The path a visitor would open. */
+  href: v.string(),
+  /**
+   * Whether anyone but the owner can reach the page. False for a draft stack,
+   * whose counter is therefore always zero.
+   */
+  openable: v.boolean(),
+  total: v.number(),
+  /** Empty when nothing was ever counted. Otherwise one entry per day. */
+  days: v.array(DayPoint),
+})
+
+async function callerCreator(ctx: QueryCtx): Promise<Doc<'creators'> | null> {
+  const identity = await ctx.auth.getUserIdentity()
+  if (!identity) return null
+  const userId = identity.tokenIdentifier.split('|')[1]
+  return await ctx.db
+    .query('creators')
+    .withIndex('by_userId', (q) => q.eq('userId', userId))
+    .first()
+}
+
+/**
+ * Fill every day from the first counted one through today.
+ *
+ * A quiet day is a real zero and has to be drawn as one — a line jumped straight
+ * from Monday to Friday claims visits on Wednesday. The fill starts at the first
+ * counted day and NOT at the window start, because counting began on a date and
+ * "0 views" for a day nobody was counting is a claim rather than a gap.
+ */
+function fillDays(
+  byDay: Map<number, number>,
+  endDayMs: number
+): { at: number; value: number }[] {
+  if (byDay.size === 0) return []
+  const first = Math.min(...byDay.keys())
+  const days: { at: number; value: number }[] = []
+  for (let at = first; at <= endDayMs; at += DAY_MS) {
+    days.push({ at, value: byDay.get(at) ?? 0 })
+  }
+  return days
+}
+
+export const mine = query({
+  args: {},
+  returns: v.union(
+    v.object({
+      windowDays: v.number(),
+      /** UTC midnight of the oldest day the window can hold. */
+      windowStartMs: v.number(),
+      /** UTC midnight of today, the last day in every series. */
+      endDayMs: v.number(),
+      /** The oldest day with a counted visit, or null when there are none. */
+      firstCountedDayMs: v.union(v.number(), v.null()),
+      total: v.number(),
+      targets: v.array(ViewTarget),
+      /** Non-empty buckets only, largest first. */
+      referrers: v.array(v.object({ bucket: ReferrerBucket, count: v.number() })),
+    }),
+    v.null()
+  ),
+  handler: async (ctx) => {
+    const creator = await callerCreator(ctx)
+    if (!creator) return null
+
+    const endDayMs = utcDayStart(Date.now())
+    const windowStartMs = endDayMs - (WINDOW_DAYS - 1) * DAY_MS
+
+    const stacks = await ctx.db
+      .query('stacks')
+      .withIndex('by_creatorId', (q) => q.eq('creatorId', creator._id))
+      .collect()
+
+    // The profile leads, then each stack. The aggregate counter is deliberately
+    // absent: it has no owner document, so it belongs to nobody.
+    const wanted: {
+      kind: 'profile' | 'stack'
+      targetKind: 'creator' | 'stack'
+      targetId: string
+      label: string
+      href: string
+      openable: boolean
+    }[] = [
+      {
+        kind: 'profile',
+        targetKind: 'creator',
+        targetId: creator._id,
+        label: 'Your profile',
+        href: `/${creator.slug}`,
+        openable: true,
+      },
+      ...stacks.map((s) => ({
+        kind: 'stack' as const,
+        targetKind: 'stack' as const,
+        targetId: s._id as string,
+        label: s.name,
+        href: `/stacks/${s.slug}`,
+        openable: s.published,
+      })),
+    ]
+
+    const referrers = new Map<ReferrerBucketValue, number>()
+    const targets = []
+    let total = 0
+    let firstCountedDayMs: number | null = null
+
+    for (const t of wanted) {
+      const rows = await ctx.db
+        .query('viewCounters')
+        .withIndex('by_target_day', (q) =>
+          q
+            .eq('targetKind', t.targetKind)
+            .eq('targetId', t.targetId)
+            .gte('dayStartMs', windowStartMs)
+        )
+        .collect()
+
+      const byDay = new Map<number, number>()
+      let targetTotal = 0
+      for (const row of rows) {
+        byDay.set(row.dayStartMs, (byDay.get(row.dayStartMs) ?? 0) + row.count)
+        referrers.set(
+          row.referrerBucket,
+          (referrers.get(row.referrerBucket) ?? 0) + row.count
+        )
+        targetTotal += row.count
+        if (firstCountedDayMs === null || row.dayStartMs < firstCountedDayMs) {
+          firstCountedDayMs = row.dayStartMs
+        }
+      }
+
+      total += targetTotal
+      targets.push({
+        kind: t.kind,
+        targetId: t.targetId,
+        label: t.label,
+        href: t.href,
+        openable: t.openable,
+        total: targetTotal,
+        days: fillDays(byDay, endDayMs),
+      })
+    }
+
+    return {
+      windowDays: WINDOW_DAYS,
+      windowStartMs,
+      endDayMs,
+      firstCountedDayMs,
+      total,
+      targets,
+      referrers: [...referrers.entries()]
+        .map(([bucket, count]) => ({ bucket, count }))
+        .sort((a, b) => b.count - a.count || a.bucket.localeCompare(b.bucket)),
+    }
+  },
+})

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useRouterState } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 import {
+	ChartLine,
 	Home,
 	Laptop,
 	Layers,
@@ -299,6 +300,15 @@ export default function Header() {
 														</p>
 													)}
 											</div>
+											{/* The only way into the private view numbers (#86). */}
+											<Link
+												to="/settings/analytics"
+												onClick={() => setMenuOpen(false)}
+												className="flex w-full items-center gap-2 px-4 py-2 font-mono text-xs uppercase tracking-wide text-fg-secondary transition-colors hover:bg-bg-panel-muted hover:text-fg-primary"
+											>
+												<ChartLine className="size-3.5" />
+												Views
+											</Link>
 											{/* The only way into the revoke surface (#49). */}
 											<Link
 												to="/settings/machines"

--- a/src/features/settings/AnalyticsPage.tsx
+++ b/src/features/settings/AnalyticsPage.tsx
@@ -1,0 +1,231 @@
+import { Link } from "@tanstack/react-router";
+import { useQuery } from "convex/react";
+import {
+	BarsChart,
+	type ChartBar,
+	type ChartSeries,
+	formatDayFull,
+	formatExact,
+	TimeSeriesChart,
+} from "@/features/charts";
+import { api } from "../../../convex/_generated/api";
+
+/**
+ * Views — the owner-private read surface over the view counters (#86, map #76).
+ *
+ * PRIVATE BY DECISION, not by obscurity. `viewAnalytics.mine` takes no target
+ * argument and answers for the signed-in creator alone, so this page cannot be
+ * pointed at anyone else even by a caller who skips it entirely. The route guard
+ * below is a convenience for the reader, never the protection.
+ *
+ * The other decision this file carries is HONEST LABELING. The counter dedupes
+ * on `IP + User-Agent` per UTC day, which merges an office behind one number and
+ * splits one person across two devices. So the page says "deduped daily
+ * visitors", says what the number is not, and never prints it beside the word
+ * views alone.
+ */
+
+/** Where a session came from, in words a reader does not have to decode. */
+export const REFERRER_LABELS = {
+	direct: "Typed or bookmarked",
+	search: "Search engine",
+	ai: "AI assistant",
+	social: "Social post",
+	internal: "A link on this site",
+	other: "Somewhere else",
+} as const;
+
+/**
+ * The range the numbers really cover.
+ *
+ * Counting started on a date, so a three-day-old account has three days of data
+ * and not a 30-day window with 27 zeros. Saying "last 30 days" there would be a
+ * claim about days nobody was counting.
+ */
+export function rangeLabel(
+	firstCountedDayMs: number | null,
+	windowStartMs: number,
+	windowDays: number,
+): string {
+	if (firstCountedDayMs === null || firstCountedDayMs <= windowStartMs) {
+		return `last ${windowDays} days`;
+	}
+	return `since ${formatDayFull(new Date(firstCountedDayMs))}`;
+}
+
+export function AnalyticsPage() {
+	const data = useQuery(api.viewAnalytics.mine, {});
+
+	if (data === undefined) {
+		return (
+			<Shell>
+				<p className="mt-8 font-mono text-sm text-fg-muted">Loading...</p>
+			</Shell>
+		);
+	}
+
+	// No creator row means nothing of this user is reachable yet, so there is
+	// nothing to count rather than nothing counted.
+	if (data === null) {
+		return (
+			<Shell>
+				<div className="mt-8 border-2 border-stroke-strong bg-bg-panel p-6">
+					<p className="font-mono text-sm text-fg-primary">
+						Nothing to count yet.
+					</p>
+					<p className="mt-2 text-sm text-fg-secondary">
+						Publish a stack and these numbers start on the day someone opens it.
+					</p>
+				</div>
+			</Shell>
+		);
+	}
+
+	const range = rangeLabel(
+		data.firstCountedDayMs,
+		data.windowStartMs,
+		data.windowDays,
+	);
+	const series: ChartSeries[] = data.targets
+		.filter((t) => t.days.length > 0)
+		.map((t) => ({ key: t.targetId, label: t.label, points: t.days }));
+	const bars: ChartBar[] = data.referrers.map((r) => ({
+		key: r.bucket,
+		label: REFERRER_LABELS[r.bucket],
+		value: r.count,
+	}));
+
+	return (
+		<Shell>
+			{/* No total when nothing was counted: "0 · last 30 days" would claim a
+			    window that was never observed. The empty state says it instead. */}
+			{data.total > 0 && (
+				<div className="mt-8 border-2 border-stroke-strong bg-bg-panel p-6">
+					<p className="font-mono text-4xl font-black text-accent">
+						{formatExact(data.total)}
+					</p>
+					<p className="mt-1 font-mono text-xs uppercase tracking-[0.2em] text-fg-muted">
+						deduped daily visitors · {range}
+					</p>
+				</div>
+			)}
+
+			{data.total === 0 ? (
+				<div className="mt-8 border-2 border-stroke-strong bg-bg-panel p-6">
+					<p className="font-mono text-sm text-fg-primary">
+						No visits counted yet.
+					</p>
+					<p className="mt-2 text-sm text-fg-secondary">
+						Counting starts the first time somebody who is not you opens one of
+						your pages. Your own visits never count while you are signed in, so
+						reloading your stack will not move this number.
+					</p>
+				</div>
+			) : (
+				<>
+					{series.length > 0 && (
+						<section className="mt-8">
+							<h2 className="font-mono text-xs font-bold uppercase tracking-[0.2em] text-fg-muted">
+								Visitors per day
+							</h2>
+							<TimeSeriesChart
+								className="mt-3"
+								series={series}
+								ariaLabel="Deduped daily visitors per page"
+								ariaDescription={`One line per page, ${range}.`}
+								valueLabel="Visitors"
+								caption={`deduped daily visitors · ${range}`}
+							/>
+						</section>
+					)}
+
+					{bars.length > 0 && (
+						<section className="mt-8">
+							<h2 className="font-mono text-xs font-bold uppercase tracking-[0.2em] text-fg-muted">
+								Where they came from
+							</h2>
+							<p className="mt-2 max-w-prose text-sm leading-relaxed text-fg-secondary">
+								Decided once per visit, from the page the visitor came off. A
+								visitor who then clicks around your pages counts as a link on
+								this site.
+							</p>
+							<BarsChart
+								className="mt-3"
+								bars={bars}
+								ariaLabel="Deduped daily visitors by where the visit came from"
+								valueLabel="Visitors"
+							/>
+						</section>
+					)}
+				</>
+			)}
+
+			<section className="mt-8">
+				<h2 className="font-mono text-xs font-bold uppercase tracking-[0.2em] text-fg-muted">
+					Each page
+				</h2>
+				<ul aria-label="Views per page" className="mt-3 space-y-3">
+					{data.targets.map((t) => (
+						<li
+							key={t.targetId}
+							className="flex items-baseline justify-between gap-4 border-2 border-stroke-strong bg-bg-panel p-4"
+						>
+							<div className="min-w-0">
+								<p className="truncate font-mono text-sm font-bold text-fg-primary">
+									{t.openable ? (
+										<Link to={t.href} className="hover:text-accent">
+											{t.label}
+										</Link>
+									) : (
+										t.label
+									)}
+								</p>
+								<p className="mt-1 font-mono text-xs text-fg-muted">
+									{targetNote(t.openable, t.total)}
+								</p>
+							</div>
+							<p className="shrink-0 font-mono text-lg font-black text-fg-primary">
+								{formatExact(t.total)}
+							</p>
+						</li>
+					))}
+				</ul>
+			</section>
+		</Shell>
+	);
+}
+
+/**
+ * The line under a page's name.
+ *
+ * A draft says why its number can only be zero. Without that, an owner reads a
+ * zero as "nobody is interested" when the truth is that the page cannot be
+ * reached at all.
+ */
+function targetNote(openable: boolean, total: number): string {
+	if (!openable) return "Draft — nobody can open it yet";
+	if (total === 0) return "Nobody has opened it yet";
+	return "deduped daily visitors";
+}
+
+/** The heading and the labeling that every state of this page shows. */
+function Shell({ children }: { readonly children: React.ReactNode }) {
+	return (
+		<div className="mx-auto max-w-3xl px-6 py-12">
+			<h1 className="font-mono text-xs font-bold uppercase tracking-[0.2em] text-fg-muted">
+				Views
+			</h1>
+			<p className="mt-3 max-w-prose text-sm leading-relaxed text-fg-secondary">
+				How often your profile and your stacks were opened. Only you can see
+				these numbers, and no view count appears anywhere else on the site.
+			</p>
+			<p className="mt-3 max-w-prose text-sm leading-relaxed text-fg-muted">
+				One page counts one visitor once per day. A visitor is a browser on a
+				network, not a person — an office shares one number and one person on a
+				phone and a laptop counts twice. Visits you make while signed in are
+				left out. These are not page loads.
+			</p>
+			{children}
+		</div>
+	);
+}

--- a/src/features/settings/__tests__/analytics-page.test.tsx
+++ b/src/features/settings/__tests__/analytics-page.test.tsx
@@ -1,0 +1,237 @@
+// @vitest-environment jsdom
+/**
+ * Views — wayfinder #86 (map #76).
+ *
+ * The map locked this surface as strictly private and as honestly labeled, so
+ * the tests guard those two decisions rather than the layout:
+ *
+ *   1. THE PAGE SAYS WHAT THE NUMBER IS NOT. A visitor is a browser and network
+ *      combination, owner views are missing, and it is not a page-load count. A
+ *      number read as impressions is a wrong number.
+ *   2. NOTHING THAT COULD IDENTIFY A VISITOR REACHES THE PAGE. The query returns
+ *      counts, and this is where a leak would become visible.
+ *   3. A QUIET TARGET STILL APPEARS. A stack published yesterday must read as
+ *      "nobody came yet", never as a missing stack.
+ */
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { getFunctionName } from "convex/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	AnalyticsPage,
+	REFERRER_LABELS,
+	rangeLabel,
+} from "@/features/settings/AnalyticsPage";
+
+const queryMock = vi.fn();
+
+vi.mock("convex/react", () => ({
+	useQuery: (ref: unknown, args: unknown) => queryMock(ref, args),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+	Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+		<a href={to}>{children}</a>
+	),
+}));
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+const DAY = 24 * 60 * 60 * 1000;
+const TODAY = Date.UTC(2026, 7, 5);
+
+/** The accessible name of the per-page list, so row assertions can scope to it. */
+const PER_PAGE_LIST = "Views per page";
+
+function days(n: number, values: number[]) {
+	return values.slice(0, n).map((value, i) => ({
+		at: TODAY - (n - 1 - i) * DAY,
+		value,
+	}));
+}
+
+function payload(over: Record<string, unknown> = {}) {
+	return {
+		windowDays: 30,
+		windowStartMs: TODAY - 29 * DAY,
+		endDayMs: TODAY,
+		firstCountedDayMs: TODAY - 4 * DAY,
+		total: 24,
+		targets: [
+			{
+				kind: "profile",
+				targetId: "creator_1",
+				label: "Your profile",
+				href: "/alp",
+				openable: true,
+				total: 9,
+				days: days(5, [1, 2, 0, 3, 3]),
+			},
+			{
+				kind: "stack",
+				targetId: "stack_1",
+				label: "Main Stack",
+				href: "/stacks/main-stack",
+				openable: true,
+				total: 15,
+				days: days(5, [4, 2, 4, 1, 4]),
+			},
+		],
+		referrers: [
+			{ bucket: "ai", count: 14 },
+			{ bucket: "search", count: 7 },
+			{ bucket: "direct", count: 3 },
+		],
+		...over,
+	};
+}
+
+function setup(data: unknown) {
+	queryMock.mockImplementation((ref: never) =>
+		getFunctionName(ref).endsWith("mine") ? data : undefined,
+	);
+	render(<AnalyticsPage />);
+}
+
+describe("AnalyticsPage", () => {
+	it("shows a loading state rather than an empty one while the query answers", () => {
+		setup(undefined);
+		expect(screen.getByText("Loading...")).toBeTruthy();
+		expect(screen.queryByText(/No visits counted yet/)).toBeNull();
+	});
+
+	it("says the numbers are only visible to the owner", () => {
+		setup(payload());
+		expect(screen.getByText(/Only you can see/i)).toBeTruthy();
+	});
+
+	it("says what the number is not: not people, not page loads", () => {
+		setup(payload());
+		const text = document.body.textContent ?? "";
+		expect(text).toMatch(/not a person|not people/i);
+		expect(text).toMatch(/page loads/i);
+		// The exclusion is a property of the number, so it is printed with it.
+		expect(text).toMatch(/signed in/i);
+	});
+
+	it("leads with the total for the window it actually covers", () => {
+		setup(payload());
+		expect(screen.getAllByText("24").length).toBeGreaterThan(0);
+		expect(screen.getAllByText(/since Aug 1, 2026/).length).toBeGreaterThan(0);
+	});
+
+	it("names the profile and every stack with its own total", () => {
+		setup(payload());
+		// Scoped to the list: chart axis ticks are numbers too, and a bare
+		// getByText would sometimes match a tick label instead of a row.
+		const rows = within(screen.getByRole("list", { name: PER_PAGE_LIST }));
+		expect(rows.getByText("Your profile")).toBeTruthy();
+		expect(rows.getByText("Main Stack")).toBeTruthy();
+		expect(rows.getByText("9")).toBeTruthy();
+		expect(rows.getByText("15")).toBeTruthy();
+	});
+
+	it("puts where visitors came from in plain words, never a bucket key", () => {
+		setup(payload());
+		const text = document.body.textContent ?? "";
+		expect(text).toMatch(/AI assistant/);
+		expect(text).not.toMatch(/\bbucket\b/i);
+	});
+
+	it("still lists a stack nobody has opened, and says so", () => {
+		setup(
+			payload({
+				total: 0,
+				firstCountedDayMs: null,
+				referrers: [],
+				targets: [
+					{
+						kind: "profile",
+						targetId: "creator_1",
+						label: "Your profile",
+						href: "/alp",
+						openable: true,
+						total: 0,
+						days: [],
+					},
+					{
+						kind: "stack",
+						targetId: "stack_1",
+						label: "Fresh Stack",
+						href: "/stacks/fresh",
+						openable: true,
+						total: 0,
+						days: [],
+					},
+				],
+			}),
+		);
+		expect(screen.getAllByText("Fresh Stack").length).toBeGreaterThan(0);
+		expect(screen.getByText(/No visits counted yet/)).toBeTruthy();
+		// Nothing was counted, so no window was observed. "0 over the last 30
+		// days" would be a claim about 30 days nobody watched.
+		expect(document.body.textContent).not.toMatch(/last 30 days/);
+	});
+
+	it("says a draft stack cannot be opened, instead of showing it a zero", () => {
+		setup(
+			payload({
+				targets: [
+					{
+						kind: "stack",
+						targetId: "stack_2",
+						label: "Draft Stack",
+						href: "/stacks/draft",
+						openable: false,
+						total: 0,
+						days: [],
+					},
+				],
+			}),
+		);
+		const rows = within(screen.getByRole("list", { name: PER_PAGE_LIST }));
+		expect(rows.getByText("Draft Stack")).toBeTruthy();
+		expect(rows.getByText(/nobody can open it/i)).toBeTruthy();
+		// A draft's name is not a link: there is no page to send anyone to.
+		expect(rows.queryByRole("link")).toBeNull();
+	});
+
+	it("never renders anything that could identify a visitor", () => {
+		setup(payload());
+		const text = document.body.textContent ?? "";
+		expect(text).not.toMatch(/\d+\.\d+\.\d+\.\d+/); // an IP
+		expect(text).not.toMatch(/hash|user-agent|Mozilla/i);
+	});
+
+	it("tells a user with no creator profile how to get numbers", () => {
+		setup(null);
+		expect(screen.getByText(/Publish a stack/i)).toBeTruthy();
+	});
+});
+
+describe("copy helpers", () => {
+	it("says the real range, so a fresh account is not told it has 30 days of data", () => {
+		// Counting started on a date. "Last 30 days" on day three would imply 27
+		// days of zeros that were never counted.
+		const windowStart = TODAY - 29 * DAY;
+		expect(rangeLabel(TODAY - 2 * DAY, windowStart, 30)).toBe(
+			"since Aug 3, 2026",
+		);
+		expect(rangeLabel(windowStart, windowStart, 30)).toBe("last 30 days");
+		expect(rangeLabel(windowStart - DAY, windowStart, 30)).toBe("last 30 days");
+		expect(rangeLabel(null, windowStart, 30)).toBe("last 30 days");
+	});
+
+	it("names every referrer bucket in plain words", () => {
+		// The union is closed in the schema. A bucket with no label would render
+		// its key to a user.
+		const buckets = ["direct", "search", "ai", "social", "internal", "other"];
+		for (const b of buckets) {
+			expect(REFERRER_LABELS[b as keyof typeof REFERRER_LABELS]).toBeTruthy();
+		}
+		expect(REFERRER_LABELS.ai).toBe("AI assistant");
+		expect(REFERRER_LABELS.internal).toBe("A link on this site");
+	});
+});

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -27,6 +27,7 @@ import { Route as ToolsNewRouteImport } from './routes/tools_.new'
 import { Route as StacksNewRouteImport } from './routes/stacks.new'
 import { Route as StacksSlugRouteImport } from './routes/stacks.$slug'
 import { Route as SettingsMachinesRouteImport } from './routes/settings.machines'
+import { Route as SettingsAnalyticsRouteImport } from './routes/settings.analytics'
 import { Route as CliAuthRouteImport } from './routes/cli.auth'
 import { Route as ApiSyncConfigRouteImport } from './routes/api.sync-config'
 import { Route as AdminIconsRouteImport } from './routes/admin_.icons'
@@ -132,6 +133,11 @@ const SettingsMachinesRoute = SettingsMachinesRouteImport.update({
   path: '/settings/machines',
   getParentRoute: () => rootRouteImport,
 } as any)
+const SettingsAnalyticsRoute = SettingsAnalyticsRouteImport.update({
+  id: '/settings/analytics',
+  path: '/settings/analytics',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CliAuthRoute = CliAuthRouteImport.update({
   id: '/cli/auth',
   path: '/cli/auth',
@@ -219,6 +225,7 @@ export interface FileRoutesByFullPath {
   '/admin/icons': typeof AdminIconsRoute
   '/api/sync-config': typeof ApiSyncConfigRoute
   '/cli/auth': typeof CliAuthRoute
+  '/settings/analytics': typeof SettingsAnalyticsRoute
   '/settings/machines': typeof SettingsMachinesRoute
   '/stacks/$slug': typeof StacksSlugRoute
   '/stacks/new': typeof StacksNewRoute
@@ -253,6 +260,7 @@ export interface FileRoutesByTo {
   '/admin/icons': typeof AdminIconsRoute
   '/api/sync-config': typeof ApiSyncConfigRoute
   '/cli/auth': typeof CliAuthRoute
+  '/settings/analytics': typeof SettingsAnalyticsRoute
   '/settings/machines': typeof SettingsMachinesRoute
   '/stacks/$slug': typeof StacksSlugRoute
   '/stacks/new': typeof StacksNewRoute
@@ -288,6 +296,7 @@ export interface FileRoutesById {
   '/admin_/icons': typeof AdminIconsRoute
   '/api/sync-config': typeof ApiSyncConfigRoute
   '/cli/auth': typeof CliAuthRoute
+  '/settings/analytics': typeof SettingsAnalyticsRoute
   '/settings/machines': typeof SettingsMachinesRoute
   '/stacks/$slug': typeof StacksSlugRoute
   '/stacks/new': typeof StacksNewRoute
@@ -324,6 +333,7 @@ export interface FileRouteTypes {
     | '/admin/icons'
     | '/api/sync-config'
     | '/cli/auth'
+    | '/settings/analytics'
     | '/settings/machines'
     | '/stacks/$slug'
     | '/stacks/new'
@@ -358,6 +368,7 @@ export interface FileRouteTypes {
     | '/admin/icons'
     | '/api/sync-config'
     | '/cli/auth'
+    | '/settings/analytics'
     | '/settings/machines'
     | '/stacks/$slug'
     | '/stacks/new'
@@ -392,6 +403,7 @@ export interface FileRouteTypes {
     | '/admin_/icons'
     | '/api/sync-config'
     | '/cli/auth'
+    | '/settings/analytics'
     | '/settings/machines'
     | '/stacks/$slug'
     | '/stacks/new'
@@ -427,6 +439,7 @@ export interface RootRouteChildren {
   AdminIconsRoute: typeof AdminIconsRoute
   ApiSyncConfigRoute: typeof ApiSyncConfigRoute
   CliAuthRoute: typeof CliAuthRoute
+  SettingsAnalyticsRoute: typeof SettingsAnalyticsRoute
   SettingsMachinesRoute: typeof SettingsMachinesRoute
   StacksSlugRoute: typeof StacksSlugRoute
   StacksNewRoute: typeof StacksNewRoute
@@ -573,6 +586,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsMachinesRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/settings/analytics': {
+      id: '/settings/analytics'
+      path: '/settings/analytics'
+      fullPath: '/settings/analytics'
+      preLoaderRoute: typeof SettingsAnalyticsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/cli/auth': {
       id: '/cli/auth'
       path: '/cli/auth'
@@ -702,6 +722,7 @@ const rootRouteChildren: RootRouteChildren = {
   AdminIconsRoute: AdminIconsRoute,
   ApiSyncConfigRoute: ApiSyncConfigRoute,
   CliAuthRoute: CliAuthRoute,
+  SettingsAnalyticsRoute: SettingsAnalyticsRoute,
   SettingsMachinesRoute: SettingsMachinesRoute,
   StacksSlugRoute: StacksSlugRoute,
   StacksNewRoute: StacksNewRoute,

--- a/src/routes/settings.analytics.tsx
+++ b/src/routes/settings.analytics.tsx
@@ -1,0 +1,55 @@
+import { useConvexAuth } from "@convex-dev/react-query";
+import {
+	createFileRoute,
+	useLocation,
+	useNavigate,
+} from "@tanstack/react-router";
+import { useEffect } from "react";
+import { AnalyticsPage } from "@/features/settings/AnalyticsPage";
+import { seoMeta } from "@/lib/seo";
+
+/**
+ * `/settings/analytics` — the owner-private view numbers (#86, map #76).
+ *
+ * `/settings` is where account-scoped surfaces already live, so this is a
+ * sibling of `/settings/machines` rather than a new `/dashboard`. A dashboard
+ * would promise a home for numbers the map keeps private and numbers it
+ * publishes, and those two must not share a page.
+ *
+ * The gate here is plain authentication and nothing more. `viewAnalytics.mine`
+ * takes no target argument and answers for the signed-in creator alone, so the
+ * privacy lives in the query — this redirect only saves a signed-out visitor a
+ * blank page.
+ */
+export const Route = createFileRoute("/settings/analytics")({
+	ssr: false,
+	component: SettingsAnalyticsPage,
+	head: () => ({
+		meta: seoMeta({
+			title: "Views - AI Stack",
+			description: "How often your profile and your stacks were opened.",
+			noindex: true,
+		}),
+	}),
+});
+
+function SettingsAnalyticsPage() {
+	const navigate = useNavigate();
+	const location = useLocation();
+	const { isAuthenticated, isLoading } = useConvexAuth();
+
+	useEffect(() => {
+		if (isLoading || isAuthenticated) return;
+		navigate({ to: "/signin", search: { redirect: location.pathname } });
+	}, [isLoading, isAuthenticated, navigate, location.pathname]);
+
+	if (isLoading || !isAuthenticated) {
+		return (
+			<div className="flex min-h-screen items-center justify-center bg-bg-canvas">
+				<div className="font-mono text-sm text-fg-muted">Loading...</div>
+			</div>
+		);
+	}
+
+	return <AnalyticsPage />;
+}


### PR DESCRIPTION
Closes the read side of view counting: `/settings/analytics` shows the owner their own numbers, and nobody else theirs.

## What it adds

- `convex/viewAnalytics.ts` — `mine`, the only reader of `viewCounters`. **No target argument**: it derives the caller's creator row from the session and reads that creator's profile and stacks alone. There is nothing for a caller to substitute, so the privacy does not depend on the route guard.
- `src/features/settings/AnalyticsPage.tsx` — the total, visitors per day per page, where the visits came from, and one row per page.
- `src/routes/settings.analytics.tsx` — a sibling of `/settings/machines`, `ssr: false`, noindex.
- A `Views` entry in the account menu.

No schema change. The charts come from `src/features/charts`.

## The decisions worth reviewing

- **A series is filled from its first counted day, never from the window start.** A line jumped from Monday to Friday claims visits on Wednesday. A zero for a day nobody was counting is a claim, not a gap. So a three-day-old account reads "since Aug 1", not "last 30 days".
- **A draft stack is listed and says "nobody can open it yet".** `stacks.getBySlug` returns null for an unpublished stack, so a draft's counter can only ever be zero. A bare zero would read as lost interest.
- **No total when nothing was counted.** "0 · last 30 days" claims a window that was never observed.
- **The page prints what the number is not.** A visitor is a browser on a network, not a person. Owner views are missing while the owner is signed in. These are not page loads.

## Tests

15 query tests (three sides of the guard: signed out, a stranger, one owner against another) and 12 page tests. Full suite: 1385 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPaGJivZLF7XeqckSkFDa1