### PR TITLE
feat(pricing): share the price table and reprice cost at read time (#93)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,23 @@ cd packages/cli && pnpm publish
 * Better Auth
 * Resend
 
+## Pricing
+
+There is ONE price table, in `packages/pricing` (`@aistack/pricing`). The CLI
+and the Convex backend both import it. It is a private workspace package and is
+never published — `tsup` bundles it into the CLI's `dist`.
+
+* The CLI prices each response at its own timestamp, at ingest. That figure is
+  exact and always wins.
+* The backend re-prices at READ time in `convex/lib/reprice.ts`, filling gaps
+  only. Its figures are LOWER BOUNDS: the wire carries one merged `cacheWrite`
+  (so it charges the cheap 5-minute tier, about 8% low for Claude Code), and it
+  has no per-response timestamps (so a window straddling a repricing pays the
+  cheaper rate).
+* Every surface that prints dollars prints the price-table id and the share of
+  tokens the figure covers. `publishCost` on the stack is the consent gate —
+  check the flag, never the presence of dollars.
+
 ## Charts
 
 All charts come from `src/features/charts`. It is the only place that imports

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -32,6 +32,7 @@ import type * as lib_cliScopes from "../lib/cliScopes.js";
 import type * as lib_iconUrl from "../lib/iconUrl.js";
 import type * as lib_ids from "../lib/ids.js";
 import type * as lib_names from "../lib/names.js";
+import type * as lib_reprice from "../lib/reprice.js";
 import type * as lib_resourceLinks from "../lib/resourceLinks.js";
 import type * as lib_tiers from "../lib/tiers.js";
 import type * as measured from "../measured.js";
@@ -94,6 +95,7 @@ declare const fullApi: ApiFromModules<{
   "lib/iconUrl": typeof lib_iconUrl;
   "lib/ids": typeof lib_ids;
   "lib/names": typeof lib_names;
+  "lib/reprice": typeof lib_reprice;
   "lib/resourceLinks": typeof lib_resourceLinks;
   "lib/tiers": typeof lib_tiers;
   measured: typeof measured;

--- a/convex/lib/reprice.test.ts
+++ b/convex/lib/reprice.test.ts
@@ -1,0 +1,239 @@
+import { OPENAI_PRICING_TABLE_VERSION, PRICING_TABLE_VERSION } from '@aistack/pricing'
+import { describe, expect, it } from 'vitest'
+import { repriceSnapshot, type WireModel } from './reprice'
+
+const MTOK = 1_000_000
+
+const tokens = (t: Partial<WireModel['tokens']> = {}) => ({
+  input: 0,
+  output: 0,
+  cacheWrite: 0,
+  cacheRead: 0,
+  ...t,
+})
+
+/** A window entirely inside one price period for every model used here. */
+const JULY = { from: '2026-07-01', to: '2026-07-31' }
+
+describe('repriceSnapshot — the gap filler (#93)', () => {
+  it('returns a fully-priced snapshot unchanged', () => {
+    // The regression that matters most: repricing must be invisible where the
+    // CLI already did the job. Its dollars are per-response and cache-TTL
+    // aware, so they are exact and ours are not.
+    const models: WireModel[] = [
+      {
+        id: 'claude-opus-5',
+        tokens: tokens({ input: MTOK, output: MTOK }),
+        apiEquivalentUSD: 30,
+      },
+      {
+        id: 'claude-haiku-4-5',
+        tokens: tokens({ input: MTOK }),
+        apiEquivalentUSD: 1,
+      },
+    ]
+    const out = repriceSnapshot({
+      models,
+      window: JULY,
+      publishedTable: PRICING_TABLE_VERSION,
+      publishCost: true,
+    })
+
+    expect(out.models.map((m) => m.apiEquivalentUSD)).toEqual([30, 1])
+    expect(out.models.every((m) => m.costEstimated === false)).toBe(true)
+    expect(out.repricedTokens).toBe(0)
+    expect(out.cost).toEqual({
+      lowerBoundUSD: 31,
+      publishedUSD: 31,
+      estimatedUSD: 0,
+      coverage: 1,
+      pricedTokens: 3 * MTOK,
+      measuredTokens: 3 * MTOK,
+      pricingTables: [PRICING_TABLE_VERSION],
+    })
+  })
+
+  it('prices a model the syncing CLI had no rate for', () => {
+    // The prod defect: `openai-list-2026-08-01` does not price the gpt-5.6
+    // family, so three of four stacks published a fraction of their real cost.
+    const out = repriceSnapshot({
+      models: [
+        { id: 'gpt-5.6-sol', tokens: tokens({ input: MTOK, output: MTOK }) },
+      ],
+      window: JULY,
+      publishedTable: 'openai-list-2026-08-01',
+      publishCost: true,
+    })
+
+    expect(out.models[0].apiEquivalentUSD).toBeCloseTo(35, 9) // $5 in + $30 out
+    expect(out.models[0].costEstimated).toBe(true)
+    expect(out.repricedTokens).toBe(2 * MTOK)
+    expect(out.cost).toMatchObject({
+      lowerBoundUSD: 35,
+      publishedUSD: 0,
+      estimatedUSD: 35,
+      coverage: 1,
+    })
+    // The estimate is cited by OUR table. The payload's table priced nothing
+    // here, so naming it would date a figure it did not produce.
+    expect(out.cost?.pricingTables).toEqual([OPENAI_PRICING_TABLE_VERSION])
+  })
+
+  it('mixes an exact row and an estimated row in one reading', () => {
+    const out = repriceSnapshot({
+      models: [
+        {
+          id: 'claude-opus-5',
+          tokens: tokens({ output: MTOK }),
+          apiEquivalentUSD: 25,
+        },
+        { id: 'gpt-5.6-luna', tokens: tokens({ output: MTOK }) },
+      ],
+      window: JULY,
+      publishedTable: PRICING_TABLE_VERSION,
+      publishCost: true,
+    })
+
+    expect(out.cost).toMatchObject({
+      publishedUSD: 25,
+      estimatedUSD: 1.2,
+      lowerBoundUSD: 26.2,
+      coverage: 1,
+    })
+    expect(out.cost?.pricingTables).toEqual([
+      PRICING_TABLE_VERSION,
+      OPENAI_PRICING_TABLE_VERSION,
+    ])
+  })
+
+  it('leaves `unknown` unpriced forever, and says so in the coverage', () => {
+    // `unknown` is not a model, so no rate can ever apply. OrcDev's coverage
+    // caps at 85.2% for exactly this reason, and the number has to show it.
+    const out = repriceSnapshot({
+      models: [
+        { id: 'gpt-5.6-sol', tokens: tokens({ input: 8 * MTOK }) },
+        { id: 'unknown', tokens: tokens({ input: 2 * MTOK }) },
+      ],
+      window: JULY,
+      publishedTable: 'openai-list-2026-08-01',
+      publishCost: true,
+    })
+
+    expect(out.models[1].apiEquivalentUSD).toBeUndefined()
+    expect(out.models[1].costEstimated).toBe(false)
+    expect(out.cost?.coverage).toBeCloseTo(0.8, 9)
+  })
+
+  it('publishes no cost at all when the owner turned cost off', () => {
+    // The flag is the gate, not the presence of dollars. A stack that switched
+    // `publishCost` off still has dollars in its stored payloads.
+    const out = repriceSnapshot({
+      models: [
+        {
+          id: 'claude-opus-5',
+          tokens: tokens({ output: MTOK }),
+          apiEquivalentUSD: 25,
+        },
+        { id: 'gpt-5.6-sol', tokens: tokens({ output: MTOK }) },
+      ],
+      window: JULY,
+      publishedTable: PRICING_TABLE_VERSION,
+      publishCost: false,
+    })
+
+    expect(out.cost).toBeNull()
+    expect(out.models.every((m) => m.apiEquivalentUSD === undefined)).toBe(true)
+    expect(out.repricedTokens).toBe(0)
+  })
+
+  it('reports no cost when nothing in the window can be priced', () => {
+    const out = repriceSnapshot({
+      models: [{ id: 'unknown', tokens: tokens({ input: MTOK }) }],
+      window: JULY,
+      publishedTable: null,
+      publishCost: true,
+    })
+    expect(out.cost).toBeNull()
+  })
+
+  it('charges a merged cache write at the CHEAP tier', () => {
+    // The wire carries one `cacheWrite`, so the 5m/1h split the CLI priced from
+    // is gone. Assuming the 1.25x tier under-reports Claude Code by ~8%, which
+    // is what keeps every server-side figure a lower bound.
+    const out = repriceSnapshot({
+      models: [{ id: 'claude-opus-5', tokens: tokens({ cacheWrite: MTOK }) }],
+      window: JULY,
+      publishedTable: 'anthropic-list-2026-01-01',
+      publishCost: true,
+    })
+    expect(out.models[0].apiEquivalentUSD).toBeCloseTo(6.25, 9) // $5 x 1.25
+  })
+
+  it('charges a cache read at a tenth of the input rate', () => {
+    const out = repriceSnapshot({
+      models: [{ id: 'claude-opus-5', tokens: tokens({ cacheRead: MTOK }) }],
+      window: JULY,
+      publishedTable: 'anthropic-list-2026-01-01',
+      publishCost: true,
+    })
+    expect(out.models[0].apiEquivalentUSD).toBeCloseTo(0.5, 9)
+  })
+
+  it('takes the CHEAPER rate when the window straddles a repricing', () => {
+    // A published snapshot has no per-response timestamps, so the split across
+    // the boundary is unknowable. Picking the cheap side keeps the figure a
+    // lower bound instead of a guess that can overstate.
+    const straddling = { from: '2026-08-20', to: '2026-09-05' }
+    const out = repriceSnapshot({
+      models: [
+        { id: 'claude-sonnet-5', tokens: tokens({ input: MTOK, output: MTOK }) },
+      ],
+      window: straddling,
+      publishedTable: null,
+      publishCost: true,
+    })
+    expect(out.models[0].apiEquivalentUSD).toBeCloseTo(12, 9) // $2 + $10, not $3 + $15
+  })
+
+  it('uses the only rate the window can pay when it straddles nothing', () => {
+    const after = { from: '2026-09-05', to: '2026-10-05' }
+    const out = repriceSnapshot({
+      models: [
+        { id: 'claude-sonnet-5', tokens: tokens({ input: MTOK, output: MTOK }) },
+      ],
+      window: after,
+      publishedTable: null,
+      publishCost: true,
+    })
+    expect(out.models[0].apiEquivalentUSD).toBeCloseTo(18, 9)
+  })
+
+  it('estimates nothing from a window it cannot read', () => {
+    const out = repriceSnapshot({
+      models: [
+        { id: 'gpt-5.6-sol', tokens: tokens({ input: MTOK }) },
+        {
+          id: 'claude-opus-5',
+          tokens: tokens({ input: MTOK }),
+          apiEquivalentUSD: 5,
+        },
+      ],
+      window: { from: 'not-a-date', to: '2026-07-31' },
+      publishedTable: PRICING_TABLE_VERSION,
+      publishCost: true,
+    })
+    expect(out.models[0].apiEquivalentUSD).toBeUndefined()
+    expect(out.cost).toMatchObject({ estimatedUSD: 0, publishedUSD: 5 })
+    expect(out.cost?.coverage).toBeCloseTo(0.5, 9)
+  })
+
+  it('reports full coverage for a snapshot with no tokens at all', () => {
+    const out = repriceSnapshot({
+      models: [],
+      window: JULY,
+      publishedTable: null,
+      publishCost: true,
+    })
+    expect(out.cost).toBeNull()
+  })
+})

--- a/convex/lib/reprice.ts
+++ b/convex/lib/reprice.ts
@@ -1,0 +1,223 @@
+/**
+ * Read-time repricing of a published measured snapshot. Wayfinder ticket #93
+ * (map #76).
+ *
+ * WHY THIS EXISTS
+ * A snapshot's cost is frozen at whatever price table the syncing CLI happened
+ * to ship. One day of drift produced this on prod (2026-08-04): a stack with
+ * 279B Codex tokens published $14,764 when the same tokens are worth at least
+ * $167,331, and a second stack published nothing at all — because
+ * `openai-list-2026-08-01` has no rate for the gpt-5.6 family. Snapshots are
+ * immutable, so the repair happens where catalog resolution already happens: at
+ * read time, against the shared table in `@aistack/pricing`.
+ *
+ * GAPS ONLY (#82). A model that carries `apiEquivalentUSD` keeps it. The CLI
+ * priced each response at its own timestamp and split cache writes into 5-minute
+ * and 1-hour tiers, so its figure is exact. Only a model with no dollars at all
+ * gets an estimate. One reading can therefore be part exact and part estimated.
+ *
+ * EVERY ESTIMATE IS BIASED LOW, ON PURPOSE
+ * Two facts are lost by the time a payload lands, and both are resolved
+ * downward so the result stays a lower bound:
+ *
+ *   1. The wire carries ONE merged `cacheWrite`. The 5m tier costs 1.25x input
+ *      and the 1h tier 2.0x, and the split is gone — so everything charges the
+ *      5m rate. Measured against a stack the CLI priced exactly, this
+ *      under-reports Claude Code by roughly 8%. Codex is exact, because every
+ *      Codex row carries `cacheWrite: 0`.
+ *   2. There are no per-response timestamps. When the window straddles a
+ *      repricing (`claude-sonnet-5` on 2026-09-01), the share of tokens on each
+ *      side is unknowable, so the CHEAPER rate prices the whole window.
+ *
+ * A one-directional bias is what makes the "at least" framing on the stack page
+ * and the leaderboard sound. Do not add a heuristic that can overstate.
+ *
+ * CONSENT IS A FLAG, NOT AN ABSENCE. Cost publishes only when the owner has
+ * `publishCost` on. This module takes that flag and strips every dollar when it
+ * is off, including dollars already stored in the payload — an owner who turns
+ * cost off after a sync has turned it off for the rows already sent.
+ */
+
+import {
+  CACHE_READ_MULTIPLIER,
+  CACHE_WRITE_5M_MULTIPLIER,
+  pricePeriodsInWindow,
+  pricingTableFor,
+} from '@aistack/pricing'
+
+/** The token block on the wire — one merged `cacheWrite`, no TTL split. */
+export type WireTokens = {
+  input: number
+  output: number
+  cacheWrite: number
+  cacheRead: number
+}
+
+export type WireModel = {
+  id: string
+  tokens: WireTokens
+  apiEquivalentUSD?: number
+}
+
+/** The reported window, as the two UTC date strings the payload carries. */
+export type SnapshotWindow = { from: string; to: string }
+
+export type RepricedModel<T> = T & {
+  apiEquivalentUSD?: number
+  /** True when the dollars above came from this module, not from the CLI. */
+  costEstimated: boolean
+}
+
+/**
+ * What a surface needs to print money honestly. Every figure is USD over the
+ * snapshot's own window.
+ */
+export type CostReading = {
+  /** `published + estimated`. Never an equality — always "at least this much". */
+  lowerBoundUSD: number
+  /** The part the CLI priced exactly. */
+  publishedUSD: number
+  /** The part priced here, from the shared table. */
+  estimatedUSD: number
+  /**
+   * Share of measured tokens carrying a citable price, 0..1. Below 1 the
+   * missing tokens are real spend that no table can name — `unknown` rows and
+   * models no vendor list page covers. A surface that prints dollars must print
+   * this too.
+   */
+  coverage: number
+  /** The numerator of `coverage`. Carried so several readings can merge exactly. */
+  pricedTokens: number
+  /** The denominator of `coverage` — every token the snapshot's models report. */
+  measuredTokens: number
+  /** Every table cited by the dollars above, in payload-then-estimate order. */
+  pricingTables: string[]
+}
+
+const M = 1_000_000
+/** Cents. The CLI rounds its published dollars the same way. */
+export const round2 = (n: number) => Math.round(n * 100) / 100
+
+const tokensOf = (t: WireTokens) =>
+  t.input + t.output + t.cacheWrite + t.cacheRead
+
+/**
+ * The window as an epoch-ms range. `null` when either end is unreadable — an
+ * undated window cannot pick a rate, and substituting "now" would attribute
+ * today's price to a record that may predate it.
+ */
+function windowRange(w: SnapshotWindow): { from: number; to: number } | null {
+  const from = Date.parse(`${w.from}T00:00:00.000Z`)
+  const to = Date.parse(`${w.to}T23:59:59.999Z`)
+  if (Number.isNaN(from) || Number.isNaN(to) || to < from) return null
+  return { from, to }
+}
+
+/**
+ * The cheapest dollars this model's tokens can have cost over the window, or
+ * `null` when no citable rate covers it.
+ *
+ * "Cheapest" is the whole policy: when more than one rate applies, each is
+ * costed and the smallest wins.
+ */
+export function estimateModelUSD(
+  id: string,
+  t: WireTokens,
+  window: SnapshotWindow
+): number | null {
+  const range = windowRange(window)
+  if (!range) return null
+  const periods = pricePeriodsInWindow(id, range.from, range.to)
+  if (periods.length === 0) return null
+  const costs = periods.map(
+    (p) =>
+      (t.input * p.input +
+        t.output * p.output +
+        t.cacheWrite * p.input * CACHE_WRITE_5M_MULTIPLIER +
+        t.cacheRead * p.input * CACHE_READ_MULTIPLIER) /
+      M
+  )
+  return round2(Math.min(...costs))
+}
+
+export function repriceSnapshot<T extends WireModel>(input: {
+  models: readonly T[]
+  window: SnapshotWindow
+  /** `payload.pricingTable` — the citation for the dollars already on the wire. */
+  publishedTable: string | null
+  /** `stacks.publishCost`, absent reading as ON. */
+  publishCost: boolean
+}): {
+  models: RepricedModel<T>[]
+  /** `null` when cost is off, and when nothing in the snapshot can be priced. */
+  cost: CostReading | null
+  /** Tokens that moved from unpriced to priced, so the caller can shrink
+   *  `excludedTokens.unpriced` by the same amount. */
+  repricedTokens: number
+} {
+  const { models, window, publishedTable, publishCost } = input
+
+  if (!publishCost) {
+    return {
+      models: models.map((m) => {
+        const { apiEquivalentUSD: _dropped, ...rest } = m
+        return { ...(rest as T), costEstimated: false }
+      }),
+      cost: null,
+      repricedTokens: 0,
+    }
+  }
+
+  let publishedUSD = 0
+  let estimatedUSD = 0
+  let pricedTokens = 0
+  let repricedTokens = 0
+  let totalTokens = 0
+  const estimateTables = new Set<string>()
+
+  const out = models.map((m): RepricedModel<T> => {
+    const size = tokensOf(m.tokens)
+    totalTokens += size
+
+    if (m.apiEquivalentUSD !== undefined) {
+      publishedUSD += m.apiEquivalentUSD
+      pricedTokens += size
+      return { ...m, costEstimated: false }
+    }
+
+    const usd = estimateModelUSD(m.id, m.tokens, window)
+    if (usd === null) return { ...m, costEstimated: false }
+
+    estimatedUSD += usd
+    pricedTokens += size
+    repricedTokens += size
+    const table = pricingTableFor(m.id)
+    if (table) estimateTables.add(table)
+    return { ...m, apiEquivalentUSD: usd, costEstimated: true }
+  })
+
+  if (pricedTokens === 0) return { models: out, cost: null, repricedTokens: 0 }
+
+  // The payload's own table leads: it cites the exact dollars, and the estimate
+  // is the addition. A table already named by the payload is not repeated.
+  const pricingTables = [
+    ...(publishedUSD > 0 && publishedTable ? [publishedTable] : []),
+    ...[...estimateTables].filter(
+      (t) => !(publishedUSD > 0 && t === publishedTable)
+    ),
+  ]
+
+  return {
+    models: out,
+    cost: {
+      lowerBoundUSD: round2(publishedUSD + estimatedUSD),
+      publishedUSD: round2(publishedUSD),
+      estimatedUSD: round2(estimatedUSD),
+      coverage: totalTokens > 0 ? pricedTokens / totalTokens : 0,
+      pricedTokens,
+      measuredTokens: totalTokens,
+      pricingTables,
+    },
+    repricedTokens,
+  }
+}

--- a/convex/measured.test.ts
+++ b/convex/measured.test.ts
@@ -79,7 +79,12 @@ type Ctx = Awaited<ReturnType<typeof convexTest>>
 
 async function seedStack(
   t: Ctx,
-  opts: { userId?: string; published?: boolean; name?: string } = {},
+  opts: {
+    userId?: string
+    published?: boolean
+    name?: string
+    publishCost?: boolean
+  } = {},
 ) {
   return await t.run(async (ctx) => {
     const creatorId = await ctx.db.insert('creators', {
@@ -100,6 +105,9 @@ async function seedStack(
       toolSubscriptions: [],
       hasUsageComponent: false,
       published: opts.published ?? true,
+      ...(opts.publishCost === undefined
+        ? {}
+        : { publishCost: opts.publishCost }),
       createdAt: Date.now(),
       updatedAt: Date.now(),
     })
@@ -2102,16 +2110,29 @@ describe('batch publish + per-harness aggregation (#67)', () => {
     const t = convexTest(schema, modules)
     const { stackId, shortId } = await seedStack(t)
 
+    // A model NO table can price, so the read-time gap filler cannot rescue the
+    // silent half — which is the only way the halves still disagree after #93.
+    // It happens when the syncing CLI ships a newer table than the server holds.
+    const unpriceable = 'gpt-5.7-unreleased'
     await t.mutation(internal.measured.publishSnapshot, {
       stackId,
-      payload: payload(), // claude-opus-5 with apiEquivalentUSD 12.34
+      payload: payload({
+        models: [
+          {
+            id: unpriceable,
+            tokenShare: 1,
+            apiEquivalentUSD: 12.34,
+            tokens: { input: 1, output: 1, cacheWrite: 0, cacheRead: 0 },
+          },
+        ],
+      }),
     })
     await t.mutation(internal.measured.publishSnapshot, {
       stackId,
       payload: codexPayload({
         models: [
           {
-            id: 'claude-opus-5', // same id, cost withheld on this side
+            id: unpriceable, // same id, cost withheld on this side
             tokenShare: 1,
             tokens: { input: 1, output: 1, cacheWrite: 0, cacheRead: 0 },
           },
@@ -2167,34 +2188,56 @@ describe('read-time repricing of unpriced OpenAI rows (#72)', () => {
     })
     // 1M in × $5 + 100k out × $30 + 400k cached × $0.50, per 1M.
     expect(current?.models[0].apiEquivalentUSD).toBeCloseTo(5 + 3 + 0.2, 6)
+    expect(current?.models[0].costEstimated).toBe(true)
     const harness = current?.harnesses[0]
     expect(harness?.models[0].apiEquivalentUSD).toBeCloseTo(8.2, 6)
     expect(harness?.excludedTokens.unpriced).toBe(0)
-    // The footer must cite the table the read-time dollars came from.
-    expect(harness?.pricingTable).toBe(
-      'openai-list-2026-08-01 + openai-list-2026-08-02',
-    )
+    // The footer cites the table the dollars came from, and ONLY that one: the
+    // payload's own table priced nothing here, so naming it would date a figure
+    // it did not produce.
+    expect(harness?.pricingTable).toBe('openai-list-2026-08-02')
+    expect(current?.cost).toMatchObject({
+      publishedUSD: 0,
+      estimatedUSD: 8.2,
+      lowerBoundUSD: 8.2,
+      coverage: 1,
+    })
   })
 
-  test('never reprices when the payload published no cost at all', async () => {
+  test('publishes no cost at all when the owner turned cost off', async () => {
     const t = convexTest(schema, modules)
-    const { stackId, shortId } = await seedStack(t)
+    // The FLAG is the gate, not the payload's silence (#93). This snapshot even
+    // carries dollars, and they must not reach the page.
+    const { stackId, shortId } = await seedStack(t, { publishCost: false })
     await t.mutation(internal.measured.publishSnapshot, {
       stackId,
-      // publishCost off: pricingTable null is the owner's choice, and
-      // read-time dollars would override it.
-      payload: codexPayload({ pricingTable: null }),
+      payload: codexPayload({
+        models: [
+          {
+            id: 'gpt-5.6-sol',
+            tokenShare: 1,
+            apiEquivalentUSD: 8.2,
+            tokens: {
+              input: 1_000_000,
+              output: 100_000,
+              cacheWrite: 0,
+              cacheRead: 400_000,
+            },
+          },
+        ],
+      }),
     })
 
     const current = await t.query(api.measured.getCurrentByStackSlug, {
       slug: `my-stack-${shortId}`,
     })
     expect(current?.models[0].apiEquivalentUSD).toBeUndefined()
+    expect(current?.cost).toBeNull()
     expect(current?.harnesses[0].pricingTable).toBeNull()
     expect(current?.harnesses[0].excludedTokens.unpriced).toBe(1_500_000)
   })
 
-  test('leaves ids outside the read-time table unpriced', async () => {
+  test('leaves an id no table can price unpriced', async () => {
     const t = convexTest(schema, modules)
     const { stackId, shortId } = await seedStack(t)
     await t.mutation(internal.measured.publishSnapshot, {
@@ -2216,6 +2259,50 @@ describe('read-time repricing of unpriced OpenAI rows (#72)', () => {
     })
     expect(current?.models[0].apiEquivalentUSD).toBeUndefined()
     expect(current?.harnesses[0].excludedTokens.unpriced).toBe(110)
-    expect(current?.harnesses[0].pricingTable).toBe('openai-list-2026-08-01')
+    // Nothing was priced, so no table is cited and no cost block exists.
+    expect(current?.harnesses[0].pricingTable).toBeNull()
+    expect(current?.cost).toBeNull()
+  })
+
+  test('reports the share of tokens it could price', async () => {
+    // The prod shape: a named model our table covers, beside `unknown`, which
+    // no table can ever cover. The figure is a lower bound and says by how much.
+    const t = convexTest(schema, modules)
+    const { stackId, shortId } = await seedStack(t)
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: codexPayload({
+        models: [
+          {
+            id: 'gpt-5.6-sol',
+            tokenShare: 0.8,
+            tokens: {
+              input: 8_000_000,
+              output: 0,
+              cacheWrite: 0,
+              cacheRead: 0,
+            },
+          },
+          {
+            id: 'unknown',
+            tokenShare: 0.2,
+            tokens: {
+              input: 2_000_000,
+              output: 0,
+              cacheWrite: 0,
+              cacheRead: 0,
+            },
+          },
+        ],
+      }),
+    })
+
+    const current = await t.query(api.measured.getCurrentByStackSlug, {
+      slug: `my-stack-${shortId}`,
+    })
+    expect(current?.cost?.coverage).toBeCloseTo(0.8, 6)
+    expect(current?.cost?.pricedTokens).toBe(8_000_000)
+    expect(current?.cost?.measuredTokens).toBe(10_000_000)
+    expect(current?.cost?.lowerBoundUSD).toBeCloseTo(40, 6)
   })
 })

--- a/convex/measured.ts
+++ b/convex/measured.ts
@@ -16,6 +16,7 @@ import {
 import { captureServerEvent } from './analytics'
 import { emitActivityEvent } from './activity'
 import { extractShortId } from './lib/ids'
+import { type RepricedModel, repriceSnapshot, round2 } from './lib/reprice'
 import {
   MODEL_ID_MAX,
   NAME_MAX,
@@ -210,6 +211,28 @@ const ResolvedModel = v.object({
     cacheRead: v.number(),
   }),
   apiEquivalentUSD: v.optional(v.number()),
+  /**
+   * True when the dollars above were priced server-side from the shared table
+   * rather than by the syncing CLI (#93). An estimate is a lower bound: the
+   * wire carries one merged `cacheWrite`, so it charges the cheap tier.
+   */
+  costEstimated: v.boolean(),
+})
+
+/**
+ * What a surface needs to print money honestly (#93). `null` when the owner
+ * has `publishCost` off, and when nothing in the snapshot carries a citable
+ * price. Every dollar figure here is a LOWER BOUND — see `convex/lib/reprice.ts`
+ * for the two facts the wire loses and why both resolve downward.
+ */
+const Cost = v.object({
+  lowerBoundUSD: v.number(),
+  publishedUSD: v.number(),
+  estimatedUSD: v.number(),
+  coverage: v.number(),
+  pricedTokens: v.number(),
+  measuredTokens: v.number(),
+  pricingTables: v.array(v.string()),
 })
 
 /**
@@ -246,73 +269,6 @@ async function resolveModels(
       }
     })
   )
-}
-
-/**
- * Read-time repricing for rows that landed before the CLI knew their price
- * (#72). The Codex live test published `gpt-5.6-*` and `codex-auto-review`
- * rows with tokens but no `apiEquivalentUSD` — the CLI's pinned table had no
- * rate for them — and snapshots are immutable, so the fix has to happen where
- * catalog resolution already does: at read time.
- *
- * Rates mirror the CLI's `openai-list-2026-08-02` table (source:
- * https://developers.openai.com/api/docs/pricing; cached input is 10% of
- * input; `codex-auto-review` is the aggregator-consensus rate, see the CLI
- * table comment). Only ids with a single open-ended price period are safe
- * here — per-response timestamps are gone by publish time, so a repriced
- * model must cost the same at every moment the window can cover.
- *
- * Two guards keep this honest:
- *   - it never fires when the payload published no cost at all
- *     (`pricingTable === null` — the owner turned cost publishing off, and
- *     read-time dollars would override that choice), and
- *   - it skips rows with cache-write tokens: OpenAI publishes no cache-write
- *     rate, and Codex never reports writes, so a row that has them is not a
- *     row this table can price.
- */
-const READTIME_OPENAI_PRICES: Record<string, { input: number; output: number }> =
-  {
-    'gpt-5.6-sol': { input: 5, output: 30 },
-    'gpt-5.6-terra': { input: 2, output: 12 },
-    'gpt-5.6-luna': { input: 0.2, output: 1.2 },
-    'gpt-5.3-codex': { input: 1.75, output: 14 },
-    'codex-auto-review': { input: 2.5, output: 15 },
-  }
-const READTIME_PRICING_TABLE = 'openai-list-2026-08-02'
-const READTIME_CACHE_READ_MULTIPLIER = 0.1
-
-/**
- * Price unpriced rows from `READTIME_OPENAI_PRICES`, in place on a copy.
- * Returns the repriced list plus the token total that moved from unpriced to
- * priced, so the caller can shrink `excludedTokens.unpriced` to match.
- */
-function applyReadTimePrices<
-  T extends {
-    id: string
-    tokens: {
-      input: number
-      output: number
-      cacheWrite: number
-      cacheRead: number
-    }
-    apiEquivalentUSD?: number
-  },
->(models: T[]): { models: T[]; repricedTokens: number } {
-  let repricedTokens = 0
-  const out = models.map((m) => {
-    if (m.apiEquivalentUSD !== undefined) return m
-    const rate = READTIME_OPENAI_PRICES[m.id]
-    if (!rate || m.tokens.cacheWrite > 0) return m
-    const usd =
-      (m.tokens.input * rate.input +
-        m.tokens.output * rate.output +
-        m.tokens.cacheRead * rate.input * READTIME_CACHE_READ_MULTIPLIER) /
-      1_000_000
-    repricedTokens +=
-      m.tokens.input + m.tokens.output + m.tokens.cacheRead
-    return { ...m, apiEquivalentUSD: usd }
-  })
-  return { models: out, repricedTokens }
 }
 
 const harnessOf = (row: Doc<'measuredSnapshots'>): string => row.harness
@@ -366,6 +322,7 @@ const HarnessSnapshot = v.object({
     version: v.union(v.string(), v.null()),
   }),
   pricingTable: v.union(v.string(), v.null()),
+  cost: v.union(Cost, v.null()),
   activity: v.object({
     sessions: v.number(),
     activeDays: v.number(),
@@ -420,6 +377,8 @@ const CurrentMeasured = v.object({
   window: v.object({ days: v.number(), from: v.string(), to: v.string() }),
   /** Every cited price table, joined for display; null when none published cost. */
   pricingTable: v.union(v.string(), v.null()),
+  /** The whole stack's money, summed across harnesses. Null when cost is off. */
+  cost: v.union(Cost, v.null()),
   activity: v.object({
     sessions: v.number(),
     /** MAX across harnesses, not a sum — the same day can appear in both. */
@@ -437,14 +396,17 @@ const CurrentMeasured = v.object({
 
 async function toHarnessSnapshot(
   ctx: QueryCtx,
-  snapshot: Doc<'measuredSnapshots'>
+  snapshot: Doc<'measuredSnapshots'>,
+  publishCost: boolean
 ) {
   const p = snapshot.payload
   const resolved = await resolveModels(ctx, p.models)
-  const { models, repricedTokens } =
-    p.pricingTable !== null
-      ? applyReadTimePrices(resolved)
-      : { models: resolved, repricedTokens: 0 }
+  const { models, cost, repricedTokens } = repriceSnapshot({
+    models: resolved,
+    window: p.window,
+    publishedTable: p.pricingTable,
+    publishCost,
+  })
   return {
     capturedAt: snapshot.capturedAt,
     receivedAt: snapshot.receivedAt,
@@ -452,12 +414,11 @@ async function toHarnessSnapshot(
     isFresh: Date.now() - snapshot.receivedAt <= SEVEN_DAYS_MS,
     window: p.window,
     harness: p.harness,
-    // A repriced row's dollars are cited by OUR table, not the payload's —
-    // the footer must name both.
-    pricingTable:
-      repricedTokens > 0 && p.pricingTable !== READTIME_PRICING_TABLE
-        ? `${p.pricingTable} + ${READTIME_PRICING_TABLE}`
-        : p.pricingTable,
+    // The tables that dated the dollars, which is not always the payload's own:
+    // an estimated row is cited by OUR table. A table that priced nothing is
+    // not named at all.
+    pricingTable: cost ? cost.pricingTables.join(' + ') : null,
+    cost,
     activity: p.activity,
     models,
     inventory: p.inventory,
@@ -470,15 +431,19 @@ async function toHarnessSnapshot(
 }
 
 type Resolved = Awaited<ReturnType<typeof resolveModels>>[number]
+type Priced = RepricedModel<Resolved>
 
 /**
  * Merge per-harness model lists by id, summing the absolute token objects and
  * recomputing `tokenShare` over the combined total. Dollars sum only while
  * every contributor priced — a merged row that mixed a priced and an unpriced
  * half would understate without saying so, so it drops the field instead.
+ *
+ * A merged row is "estimated" as soon as ANY half is: the sum is only as exact
+ * as its weakest term.
  */
-function mergeModels(lists: Resolved[][]): Resolved[] {
-  const merged = new Map<string, Resolved>()
+function mergeModels(lists: Priced[][]): Priced[] {
+  const merged = new Map<string, Priced>()
   for (const list of lists) {
     for (const m of list) {
       const held = merged.get(m.id)
@@ -492,8 +457,10 @@ function mergeModels(lists: Resolved[][]): Resolved[] {
       held.tokens.cacheRead += m.tokens.cacheRead
       if (held.apiEquivalentUSD !== undefined && m.apiEquivalentUSD !== undefined) {
         held.apiEquivalentUSD += m.apiEquivalentUSD
+        held.costEstimated = held.costEstimated || m.costEstimated
       } else {
         held.apiEquivalentUSD = undefined
+        held.costEstimated = false
       }
       if (held.catalogSlug === null) {
         held.catalogSlug = m.catalogSlug
@@ -531,9 +498,12 @@ export const getCurrentByStackSlug = query({
     const snapshots = await newestSnapshotsPerHarness(ctx, stack._id)
     if (snapshots.length === 0) return null
 
+    // The flag is the gate, not the presence of dollars (#93): an owner who
+    // turned cost off after a sync has turned it off for the rows already sent.
+    const publishCost = stack.publishCost !== false
     const harnesses = []
     for (const snapshot of snapshots) {
-      harnesses.push(await toHarnessSnapshot(ctx, snapshot))
+      harnesses.push(await toHarnessSnapshot(ctx, snapshot, publishCost))
     }
 
     const totalTokens = harnesses.reduce(
@@ -549,11 +519,30 @@ export const getCurrentByStackSlug = query({
       cacheRead += m.tokens.cacheRead
       inputClass += m.tokens.input + m.tokens.cacheRead + m.tokens.cacheWrite
     }
+    // Money sums across harnesses without double-counting: a session belongs to
+    // exactly one harness. Coverage re-divides over the combined token mass
+    // rather than averaging the per-harness shares, which would weight a tiny
+    // harness the same as a huge one.
+    const costs = harnesses.map((h) => h.cost).filter((c) => c !== null)
+    const sum = (pick: (c: (typeof costs)[number]) => number) =>
+      costs.reduce((a, c) => a + pick(c), 0)
+    const pricedTokens = sum((c) => c.pricedTokens)
+    const measuredTokens = sum((c) => c.measuredTokens)
     const pricingTables = [
-      ...new Set(
-        harnesses.map((h) => h.pricingTable).filter((t): t is string => t !== null)
-      ),
+      ...new Set(costs.flatMap((c) => c.pricingTables)),
     ]
+    const cost =
+      costs.length === 0
+        ? null
+        : {
+            lowerBoundUSD: round2(sum((c) => c.lowerBoundUSD)),
+            publishedUSD: round2(sum((c) => c.publishedUSD)),
+            estimatedUSD: round2(sum((c) => c.estimatedUSD)),
+            coverage: measuredTokens > 0 ? pricedTokens / measuredTokens : 0,
+            pricedTokens,
+            measuredTokens,
+            pricingTables,
+          }
 
     return {
       receivedAt: Math.max(...harnesses.map((h) => h.receivedAt)),
@@ -565,6 +554,7 @@ export const getCurrentByStackSlug = query({
         to: harnesses.map((h) => h.window.to).sort()[harnesses.length - 1],
       },
       pricingTable: pricingTables.length > 0 ? pricingTables.join(' + ') : null,
+      cost,
       activity: {
         sessions: harnesses.reduce((a, h) => a + h.activity.sessions, 0),
         activeDays: Math.max(...harnesses.map((h) => h.activity.activeDays)),
@@ -725,10 +715,12 @@ export const getReconcileSuggestions = query({
     const suggestedSlugs = new Set<string>()
     for (const snapshot of snapshots) {
       const resolved = await resolveModels(ctx, snapshot.payload.models)
-      const repriced =
-        snapshot.payload.pricingTable !== null
-          ? applyReadTimePrices(resolved).models
-          : resolved
+      const { models: repriced } = repriceSnapshot({
+        models: resolved,
+        window: snapshot.payload.window,
+        publishedTable: snapshot.payload.pricingTable,
+        publishCost: stack.publishCost !== false,
+      })
       for (const m of repriced) {
         if (m.catalogSlug === null) continue
         if (authoredModels.has(m.catalogSlug)) continue

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "check": "biome check"
   },
   "dependencies": {
+    "@aistack/pricing": "workspace:*",
     "@convex-dev/better-auth": "^0.10.9",
     "@convex-dev/react-query": "0.1.0",
     "@radix-ui/react-label": "^2.1.8",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
     "yaml": "^2.9.0"
   },
   "devDependencies": {
+    "@aistack/pricing": "workspace:*",
     "@types/node": "^24",
     "tsup": "^8.4.0",
     "typescript": "^5.7.2"

--- a/packages/cli/src/harness/claude/adapter.ts
+++ b/packages/cli/src/harness/claude/adapter.ts
@@ -4,7 +4,7 @@
 
 import { stat } from "node:fs/promises";
 import { BUILTIN_TOOLS } from "../shared/allowlist.js";
-import { PRICING_TABLE_VERSION } from "../shared/pricing.js";
+import { PRICING_TABLE_VERSION } from "@aistack/pricing";
 import type {
 	HarnessAdapter,
 	HarnessScan,

--- a/packages/cli/src/harness/claude/analyzer.test.ts
+++ b/packages/cli/src/harness/claude/analyzer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { SONNET_5_INTRO_ENDS_MS } from "../shared/pricing.js";
+import { SONNET_5_INTRO_ENDS_MS } from "@aistack/pricing";
 import {
 	type Aggregate,
 	cleanName,

--- a/packages/cli/src/harness/claude/analyzer.ts
+++ b/packages/cli/src/harness/claude/analyzer.ts
@@ -48,7 +48,7 @@ import {
 	apiEquivalentCost,
 	normalizeModel,
 	type TokenCounts,
-} from "../shared/pricing.js";
+} from "@aistack/pricing";
 
 // Re-exported for the existing import sites (tests, stage, summary); the
 // definitions moved to ../shared/aggregate.ts in #67.

--- a/packages/cli/src/harness/codex/adapter.ts
+++ b/packages/cli/src/harness/codex/adapter.ts
@@ -2,7 +2,7 @@
 
 import { stat } from "node:fs/promises";
 
-import { OPENAI_PRICING_TABLE_VERSION } from "../shared/pricing.js";
+import { OPENAI_PRICING_TABLE_VERSION } from "@aistack/pricing";
 import type {
 	HarnessAdapter,
 	HarnessScan,

--- a/packages/cli/src/harness/codex/analyzer.ts
+++ b/packages/cli/src/harness/codex/analyzer.ts
@@ -39,7 +39,7 @@ import {
 	apiEquivalentCost,
 	normalizeModel,
 	type TokenCounts,
-} from "../shared/pricing.js";
+} from "@aistack/pricing";
 
 /** Codex needs no response dedup bookkeeping — deltas count once by construction. */
 export type Aggregate = SharedAggregate<never>;

--- a/packages/cli/src/harness/index.ts
+++ b/packages/cli/src/harness/index.ts
@@ -93,7 +93,7 @@ export {
 	priceAt,
 	SONNET_5_INTRO_ENDS_MS,
 	type TokenCounts,
-} from "./shared/pricing.js";
+} from "@aistack/pricing";
 export {
 	DEFAULT_WINDOW_DAYS,
 	type ScanStats,

--- a/packages/cli/src/harness/shared/aggregate.ts
+++ b/packages/cli/src/harness/shared/aggregate.ts
@@ -6,7 +6,7 @@
 // inheriting Claude's record-dedup logic. Everything here is pure — no I/O,
 // no console.
 
-import { isPricedModel, type TokenCounts } from "./pricing.js";
+import { isPricedModel, type TokenCounts } from "@aistack/pricing";
 
 // ---------------------------------------------------------------------------
 // Narrowing helpers — records are untrusted external JSON

--- a/packages/cli/src/harness/shared/payload.test.ts
+++ b/packages/cli/src/harness/shared/payload.test.ts
@@ -19,7 +19,7 @@ import {
 	type MeasuredPayload,
 	sanitizeModelId,
 } from "./payload.js";
-import { PRICING_TABLE_VERSION } from "./pricing.js";
+import { PRICING_TABLE_VERSION } from "@aistack/pricing";
 import type { ScanStats } from "./window.js";
 
 const NOW = Date.UTC(2026, 6, 25, 12, 0, 0); // 2026-07-25

--- a/packages/cli/src/harness/shared/payload.ts
+++ b/packages/cli/src/harness/shared/payload.ts
@@ -28,7 +28,7 @@ import {
 	type NameCategory,
 	type SyncConfig,
 } from "./allowlist.js";
-import { baseModelId } from "./pricing.js";
+import { baseModelId } from "@aistack/pricing";
 import { type ScanStats, windowStartMs } from "./window.js";
 
 export const SCHEMA_VERSION = 1;

--- a/packages/cli/src/sync/stage.test.ts
+++ b/packages/cli/src/sync/stage.test.ts
@@ -14,7 +14,7 @@ import {
 	BUNDLED_SYNC_CONFIG,
 	EMPTY_OPT_INS,
 } from "../harness/shared/allowlist.js";
-import { PRICING_TABLE_VERSION } from "../harness/shared/pricing.js";
+import { PRICING_TABLE_VERSION } from "@aistack/pricing";
 import type { ScanStats } from "../harness/shared/window.js";
 import type { HarnessAdapter } from "../harness/types.js";
 import { type StageDeps, stageId, stageSync } from "./stage.js";

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
   format: ['esm'],
   target: 'node18',
   clean: true,
+  // The price table is a workspace package that is never published (#93), so it
+  // has to be bundled INTO dist. It is a devDependency, which tsup already
+  // bundles — this is the belt to that braces, because externalizing it would
+  // ship a package.json pointing at a package npm does not have.
+  noExternal: ['@aistack/pricing'],
   banner: { js: '#!/usr/bin/env node' },
   splitting: false,
   sourcemap: true,

--- a/packages/pricing/package.json
+++ b/packages/pricing/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@aistack/pricing",
+  "version": "0.0.0",
+  "private": true,
+  "description": "The pinned API price table, shared by the CLI and the Convex backend",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "src"
+  ]
+}

--- a/packages/pricing/src/index.test.ts
+++ b/packages/pricing/src/index.test.ts
@@ -7,10 +7,14 @@ import {
 	CACHE_WRITE_5M_MULTIPLIER,
 	isPricedModel,
 	normalizeModel,
+	OPENAI_PRICING_TABLE_VERSION,
+	PRICING_TABLE_VERSION,
 	priceAt,
+	pricePeriodsInWindow,
+	pricingTableFor,
 	SONNET_5_INTRO_ENDS_MS,
 	type TokenCounts,
-} from "./pricing.js";
+} from "./index.js";
 
 const noTokens: TokenCounts = {
 	input: 0,
@@ -126,5 +130,61 @@ describe("apiEquivalentCost", () => {
 		expect(
 			apiEquivalentCost("claude-unreleased-9", t, Date.UTC(2026, 6, 20)),
 		).toBeNull();
+	});
+});
+
+describe("pricingTableFor — the citation rides on the rate (#93)", () => {
+	it("cites each vendor's own table", () => {
+		expect(pricingTableFor("claude-opus-5")).toBe(PRICING_TABLE_VERSION);
+		expect(pricingTableFor("gpt-5.6-sol")).toBe(OPENAI_PRICING_TABLE_VERSION);
+	});
+
+	it("cites nothing for a model it cannot price", () => {
+		expect(pricingTableFor("unknown")).toBeNull();
+	});
+});
+
+describe("pricePeriodsInWindow — read-time rate lookup (#93)", () => {
+	const DAY = 86_400_000;
+
+	it("returns the one rate a window inside a single period can pay", () => {
+		const periods = pricePeriodsInWindow(
+			"claude-sonnet-5",
+			SONNET_5_INTRO_ENDS_MS - 30 * DAY,
+			SONNET_5_INTRO_ENDS_MS - DAY,
+		);
+		expect(periods).toHaveLength(1);
+		expect(periods[0]).toMatchObject({ input: 2, output: 10 });
+	});
+
+	it("returns BOTH rates when the window straddles a repricing", () => {
+		// The reprice has no per-response timestamps, so it cannot know the split.
+		// Handing it both is what lets it choose the cheaper one and stay a lower
+		// bound.
+		const periods = pricePeriodsInWindow(
+			"claude-sonnet-5",
+			SONNET_5_INTRO_ENDS_MS - 25 * DAY,
+			SONNET_5_INTRO_ENDS_MS + 5 * DAY,
+		);
+		expect(periods.map((p) => p.input)).toEqual([2, 3]);
+	});
+
+	it("excludes a period the window closes before", () => {
+		const periods = pricePeriodsInWindow(
+			"claude-sonnet-5",
+			SONNET_5_INTRO_ENDS_MS - 40 * DAY,
+			SONNET_5_INTRO_ENDS_MS - 10 * DAY,
+		);
+		expect(periods.map((p) => p.input)).toEqual([2]);
+	});
+
+	it("returns nothing for a model with no citable rate", () => {
+		expect(
+			pricePeriodsInWindow(
+				"unknown",
+				Date.UTC(2026, 6, 1),
+				Date.UTC(2026, 7, 1),
+			),
+		).toEqual([]);
 	});
 });

--- a/packages/pricing/src/index.ts
+++ b/packages/pricing/src/index.ts
@@ -1,6 +1,15 @@
 // Time-aware pinned price table for API-equivalent cost.
 //
 // Wayfinder ticket #37 (map #29), decision 8 of the wire-format grilling #33.
+// Moved out of the CLI by ticket #93 (map #76).
+//
+// WHY THIS IS A PACKAGE AND NOT A CLI FILE
+// Two programs price the same tokens. The CLI prices each response at ingest,
+// where the per-response timestamp still exists. The backend re-prices a
+// published snapshot at READ time, to fill the gaps a stale CLI table left
+// behind — one day of table drift published a stack at $14,764 when the same
+// tokens are worth at least $167,331 (#93). Two copies of a price table drift
+// against each other by construction, so there is one copy and both import it.
 //
 // WHY THIS IS A LIST OF PERIODS AND NOT A FLAT MAP
 // A published "API-equivalent cost" covers a rolling 30-day window, and a
@@ -25,7 +34,8 @@
 //
 // Each harness's payload is stamped with ITS vendor's table id — the id is a
 // citation for the dollars in that payload, and one payload never mixes
-// vendors.
+// vendors. A read-time estimate cites the table of the model it priced, which
+// is why the table id sits on the rate rather than beside it.
 
 export const PRICING_TABLE_VERSION = "anthropic-list-2026-07-25";
 export const OPENAI_PRICING_TABLE_VERSION = "openai-list-2026-08-02";
@@ -56,46 +66,65 @@ export type PricePeriod = {
 	output: number;
 };
 
+/** One model's rates, plus the table that cites them. */
+type PriceEntry = {
+	/** The citation printed next to any dollar figure these rates produce. */
+	table: string;
+	periods: PricePeriod[];
+};
+
+const anthropic = (periods: PricePeriod[]): PriceEntry => ({
+	table: PRICING_TABLE_VERSION,
+	periods,
+});
+const openai = (periods: PricePeriod[]): PriceEntry => ({
+	table: OPENAI_PRICING_TABLE_VERSION,
+	periods,
+});
+const flat = (input: number, output: number): PricePeriod[] => [
+	{ from: null, to: null, input, output },
+];
+
 /**
  * Only rates we can actually cite are encoded. Inventing historical periods to
  * make the table look complete would fabricate cost for old records, so every
  * model with one known rate gets one open-ended period.
  */
-const PRICES: Record<string, PricePeriod[]> = {
-	"claude-fable-5": [{ from: null, to: null, input: 10, output: 50 }],
-	"claude-mythos-5": [{ from: null, to: null, input: 10, output: 50 }],
-	"claude-opus-5": [{ from: null, to: null, input: 5, output: 25 }],
-	"claude-opus-4-8": [{ from: null, to: null, input: 5, output: 25 }],
-	"claude-opus-4-7": [{ from: null, to: null, input: 5, output: 25 }],
-	"claude-opus-4-6": [{ from: null, to: null, input: 5, output: 25 }],
-	"claude-sonnet-5": [
+const PRICES: Record<string, PriceEntry> = {
+	"claude-fable-5": anthropic(flat(10, 50)),
+	"claude-mythos-5": anthropic(flat(10, 50)),
+	"claude-opus-5": anthropic(flat(5, 25)),
+	"claude-opus-4-8": anthropic(flat(5, 25)),
+	"claude-opus-4-7": anthropic(flat(5, 25)),
+	"claude-opus-4-6": anthropic(flat(5, 25)),
+	"claude-sonnet-5": anthropic([
 		{ from: null, to: SONNET_5_INTRO_ENDS_MS, input: 2, output: 10 },
 		{ from: SONNET_5_INTRO_ENDS_MS, to: null, input: 3, output: 15 },
-	],
-	"claude-sonnet-4-6": [{ from: null, to: null, input: 3, output: 15 }],
-	"claude-haiku-4-5": [{ from: null, to: null, input: 1, output: 5 }],
+	]),
+	"claude-sonnet-4-6": anthropic(flat(3, 15)),
+	"claude-haiku-4-5": anthropic(flat(1, 5)),
 	// Fast mode (research preview) — Claude API only, Opus 5 / Opus 4.8 only.
 	// Opus 4.7 fast mode was removed, so there is deliberately no 4-7 entry.
-	"claude-opus-5#fast": [{ from: null, to: null, input: 10, output: 50 }],
-	"claude-opus-4-8#fast": [{ from: null, to: null, input: 10, output: 50 }],
+	"claude-opus-5#fast": anthropic(flat(10, 50)),
+	"claude-opus-4-8#fast": anthropic(flat(10, 50)),
 	// OpenAI (Codex) — standard-context tier (<272K; observed context window is
 	// 258,400).
-	"gpt-5.5": [{ from: null, to: null, input: 5, output: 30 }],
-	"gpt-5.4": [{ from: null, to: null, input: 2.5, output: 15 }],
-	"gpt-5.4-mini": [{ from: null, to: null, input: 0.75, output: 4.5 }],
-	"gpt-5.3-codex": [{ from: null, to: null, input: 1.75, output: 14 }],
+	"gpt-5.5": openai(flat(5, 30)),
+	"gpt-5.4": openai(flat(2.5, 15)),
+	"gpt-5.4-mini": openai(flat(0.75, 4.5)),
+	"gpt-5.3-codex": openai(flat(1.75, 14)),
 	// The gpt-5.6 family launched 2026-07-29; Terra and Luna were repriced on
 	// 2026-07-30 (-20% / -80%). The one-day launch rates are not on the list
 	// page and are NOT encoded — a July-29 Terra/Luna record underprices for
 	// one day rather than carrying a rate we cannot cite (#72).
-	"gpt-5.6-sol": [{ from: null, to: null, input: 5, output: 30 }],
-	"gpt-5.6-terra": [{ from: null, to: null, input: 2, output: 12 }],
-	"gpt-5.6-luna": [{ from: null, to: null, input: 0.2, output: 1.2 }],
+	"gpt-5.6-sol": openai(flat(5, 30)),
+	"gpt-5.6-terra": openai(flat(2, 12)),
+	"gpt-5.6-luna": openai(flat(0.2, 1.2)),
 	// NOT on OpenAI's list page — an internal Codex routing label with no
 	// official price (openai/codex#20981). Rate is the aggregator consensus
 	// ($2.50 / $15.00), scoped in explicitly by ticket #72 because it carries
 	// real token volume in Codex rollouts.
-	"codex-auto-review": [{ from: null, to: null, input: 2.5, output: 15 }],
+	"codex-auto-review": openai(flat(2.5, 15)),
 };
 
 export type TokenCounts = {
@@ -137,9 +166,9 @@ export function priceAt(
 	atMs: number | null,
 ): PricePeriod | null {
 	if (atMs === null) return null;
-	const periods = PRICES[modelKey];
-	if (!periods) return null;
-	for (const p of periods) {
+	const entry = PRICES[modelKey];
+	if (!entry) return null;
+	for (const p of entry.periods) {
 		if ((p.from === null || atMs >= p.from) && (p.to === null || atMs < p.to)) {
 			return p;
 		}
@@ -150,6 +179,40 @@ export function priceAt(
 /** True when we hold at least one citable rate for this model, at any time. */
 export function isPricedModel(modelKey: string): boolean {
 	return PRICES[modelKey] !== undefined;
+}
+
+/**
+ * The table id that cites this model's rates, or `null` when it has none.
+ *
+ * The citation belongs to the rate, not to the harness that reported it: a
+ * read-time estimate is cited by the table it was drawn from, and one stack can
+ * carry Anthropic and OpenAI rows at once.
+ */
+export function pricingTableFor(modelKey: string): string | null {
+	return PRICES[modelKey]?.table ?? null;
+}
+
+/**
+ * Every rate that applies to `modelKey` anywhere inside `[fromMs, toMs]`.
+ *
+ * This is the read-time counterpart of `priceAt`. A published snapshot has no
+ * per-response timestamps left — it carries one merged token total over a
+ * window — so a re-pricer cannot ask "what did this response cost". It can only
+ * ask "which rates could this window have paid", and then choose. Returns an
+ * empty list for an unknown model and for a window that closes before the
+ * model's first citable rate opens.
+ */
+export function pricePeriodsInWindow(
+	modelKey: string,
+	fromMs: number,
+	toMs: number,
+): PricePeriod[] {
+	const entry = PRICES[modelKey];
+	if (!entry) return [];
+	return entry.periods.filter(
+		(p) =>
+			(p.from === null || p.from <= toMs) && (p.to === null || p.to > fromMs),
+	);
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@aistack/pricing':
+        specifier: workspace:*
+        version: link:packages/pricing
       '@convex-dev/better-auth':
         specifier: ^0.10.9
         version: 0.10.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.4))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@standard-schema/spec@1.1.0)(better-auth@1.4.10(@tanstack/react-start@1.145.3(crossws@0.4.10(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(better-call@1.1.7(zod@4.3.4))(convex@1.32.0(react@19.2.3))(nanostores@1.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
@@ -349,6 +352,9 @@ importers:
         specifier: ^2.9.0
         version: 2.9.0
     devDependencies:
+      '@aistack/pricing':
+        specifier: workspace:*
+        version: link:../pricing
       '@types/node':
         specifier: ^24
         version: 24.13.0
@@ -358,6 +364,8 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
+
+  packages/pricing: {}
 
 packages:
 

--- a/src/features/leaderboard/proto/PrototypeSwitcher.tsx
+++ b/src/features/leaderboard/proto/PrototypeSwitcher.tsx
@@ -17,15 +17,18 @@ import { type ClockKey, DENSITY_LABEL, type DensityKey } from "./fixtures";
 import { VARIANT_A_NAME } from "./VariantA";
 import { VARIANT_B_NAME } from "./VariantB";
 import { VARIANT_C_NAME } from "./VariantC";
+import { VARIANT_C2_NAME, VARIANT_C3_NAME } from "./VariantC2";
 
-export type VariantKey = "A" | "B" | "C";
+export type VariantKey = "A" | "B" | "C" | "C2" | "C3";
 
-export const VARIANT_KEYS: readonly VariantKey[] = ["A", "B", "C"];
+export const VARIANT_KEYS: readonly VariantKey[] = ["C2", "C3", "C", "A", "B"];
 
 const NAMES: Record<VariantKey, string> = {
 	A: VARIANT_A_NAME,
 	B: VARIANT_B_NAME,
 	C: VARIANT_C_NAME,
+	C2: VARIANT_C2_NAME,
+	C3: VARIANT_C3_NAME,
 };
 
 const CLOCK_LABEL: Record<ClockKey, string> = {

--- a/src/features/leaderboard/proto/PrototypeSwitcher.tsx
+++ b/src/features/leaderboard/proto/PrototypeSwitcher.tsx
@@ -21,7 +21,7 @@ import { VARIANT_C2_NAME, VARIANT_C3_NAME } from "./VariantC2";
 
 export type VariantKey = "A" | "B" | "C" | "C2" | "C3";
 
-export const VARIANT_KEYS: readonly VariantKey[] = ["C2", "C3", "C", "A", "B"];
+export const VARIANT_KEYS: readonly VariantKey[] = ["C3", "C2", "C", "A", "B"];
 
 const NAMES: Record<VariantKey, string> = {
 	A: VARIANT_A_NAME,

--- a/src/features/leaderboard/proto/PrototypeSwitcher.tsx
+++ b/src/features/leaderboard/proto/PrototypeSwitcher.tsx
@@ -1,0 +1,169 @@
+/**
+ * PROTOTYPE — throwaway. Wayfinder ticket #92 (map #76).
+ *
+ * The floating bar. Deliberately ugly against the site so nobody judges it as
+ * part of the design. Hidden in production builds.
+ *
+ * Four knobs, and each one is a question #92 asks:
+ *   variant  — the spine
+ *   density  — 4 / 50 / 500, the binding constraint
+ *   weight   — token-weighted or stack-weighted shares
+ *   clock    — move today forward five days and watch the board go quiet
+ */
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { Weight } from "./aggregate";
+import { type ClockKey, DENSITY_LABEL, type DensityKey } from "./fixtures";
+import { VARIANT_A_NAME } from "./VariantA";
+import { VARIANT_B_NAME } from "./VariantB";
+import { VARIANT_C_NAME } from "./VariantC";
+
+export type VariantKey = "A" | "B" | "C";
+
+export const VARIANT_KEYS: readonly VariantKey[] = ["A", "B", "C"];
+
+const NAMES: Record<VariantKey, string> = {
+	A: VARIANT_A_NAME,
+	B: VARIANT_B_NAME,
+	C: VARIANT_C_NAME,
+};
+
+const CLOCK_LABEL: Record<ClockKey, string> = {
+	now: "Aug 5",
+	quiet: "Aug 9",
+	dark: "Aug 12",
+};
+
+export function PrototypeSwitcher({
+	variant,
+	density,
+	weight,
+	clock,
+	livingCount,
+	staleCount,
+	onCycle,
+	onDensity,
+	onWeight,
+	onClock,
+}: {
+	readonly variant: VariantKey;
+	readonly density: DensityKey;
+	readonly weight: Weight;
+	readonly clock: ClockKey;
+	readonly livingCount: number;
+	readonly staleCount: number;
+	readonly onCycle: (step: number) => void;
+	readonly onDensity: (d: DensityKey) => void;
+	readonly onWeight: (w: Weight) => void;
+	readonly onClock: (c: ClockKey) => void;
+}) {
+	if (import.meta.env.PROD) return null;
+
+	return (
+		<div className="fixed bottom-5 left-1/2 z-50 w-[min(94vw,72rem)] -translate-x-1/2">
+			<div className="flex flex-wrap items-stretch border-2 border-white bg-black font-mono text-xs text-white shadow-[4px_4px_0_rgba(255,255,255,0.35)]">
+				<button
+					type="button"
+					onClick={() => onCycle(-1)}
+					aria-label="previous variant"
+					className="px-3 hover:bg-white hover:text-black"
+				>
+					<ChevronLeft className="h-4 w-4" />
+				</button>
+
+				<span className="flex min-w-[22rem] flex-1 items-center gap-2 border-x-2 border-white/40 px-4 py-3">
+					<strong className="text-[#c6ff3d]">{variant}</strong>
+					<span className="truncate">{NAMES[variant]}</span>
+				</span>
+
+				<button
+					type="button"
+					onClick={() => onCycle(1)}
+					aria-label="next variant"
+					className="border-r-2 border-white/40 px-3 hover:bg-white hover:text-black"
+				>
+					<ChevronRight className="h-4 w-4" />
+				</button>
+
+				<Group label="rows">
+					{(["real", "grown", "scale"] as const).map((k) => (
+						<Pill
+							key={k}
+							on={density === k}
+							onClick={() => onDensity(k)}
+							title={DENSITY_LABEL[k]}
+						>
+							{k === "real" ? "4" : k === "grown" ? "50" : "500"}
+						</Pill>
+					))}
+				</Group>
+
+				<Group label="share">
+					{(["tokens", "stacks"] as const).map((k) => (
+						<Pill key={k} on={weight === k} onClick={() => onWeight(k)}>
+							{k}
+						</Pill>
+					))}
+				</Group>
+
+				<Group label="today">
+					{(["now", "quiet", "dark"] as const).map((k) => (
+						<Pill key={k} on={clock === k} onClick={() => onClock(k)}>
+							{CLOCK_LABEL[k]}
+						</Pill>
+					))}
+				</Group>
+
+				<span className="flex items-center px-3 text-white/40">
+					{livingCount} living · {staleCount} quiet
+				</span>
+			</div>
+			<p className="mt-2 text-center font-mono text-[10px] text-white/50">
+				← → switch variant · 4 rows = the stacks actually measured on prod · Aug
+				9 leaves one ranked, Aug 12 leaves none
+			</p>
+		</div>
+	);
+}
+
+function Group({
+	label,
+	children,
+}: {
+	readonly label: string;
+	readonly children: React.ReactNode;
+}) {
+	return (
+		<span className="flex items-center gap-1 border-r-2 border-white/40 px-3">
+			<span className="pr-1 uppercase tracking-wider text-white/40">
+				{label}
+			</span>
+			{children}
+		</span>
+	);
+}
+
+function Pill({
+	on,
+	onClick,
+	title,
+	children,
+}: {
+	readonly on: boolean;
+	readonly onClick: () => void;
+	readonly title?: string;
+	readonly children: React.ReactNode;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			title={title}
+			className={`px-2 py-1 uppercase tracking-wider ${
+				on ? "bg-[#c6ff3d] text-black" : "text-white/60 hover:text-white"
+			}`}
+		>
+			{children}
+		</button>
+	);
+}

--- a/src/features/leaderboard/proto/VariantA.tsx
+++ b/src/features/leaderboard/proto/VariantA.tsx
@@ -1,0 +1,269 @@
+/**
+ * PROTOTYPE — throwaway. Wayfinder ticket #92 (map #76).
+ *
+ * VARIANT A — Leaderboard-first. The ranked table is the page.
+ *
+ * The position this variant argues: **a leaderboard with charts on it is two
+ * pages**. So there is no chart module here at all. The only graphic is a bar
+ * inside the tokens cell, drawn against the leader, and it is furniture on a
+ * number rather than a figure to read.
+ *
+ * It answers both ride-along questions by refusing them:
+ *   1. Which charts earn a place — none.
+ *   2. Token- or stack-weighted shares — neither. Every share on this page is
+ *      one stack's own model mix, which is a fact about that row and needs no
+ *      population weighting. The weight switch does nothing here, on purpose.
+ *
+ * Sessions rides along as a muted column. #82 held it in reserve as the swap
+ * for tokens; this is the variant with the room to judge whether the token
+ * column reads as meaningless beside it.
+ */
+
+import { Link } from "@tanstack/react-router";
+import { GridBackground } from "@/components/GridBackground";
+import { cn } from "@/lib/utils";
+import type { Aggregate, RankedStack } from "./aggregate";
+import { Pager } from "./bits";
+import * as f from "./format";
+
+const PAGE_SIZE = 10;
+
+export const VARIANT_A_NAME = "Leaderboard-first — the board is the page";
+
+export function VariantA({
+	agg,
+	page,
+	onPage,
+}: {
+	readonly agg: Aggregate;
+	readonly page: number;
+	readonly onPage: (p: number) => void;
+}) {
+	const totalPages = Math.max(1, Math.ceil(agg.living.length / PAGE_SIZE));
+	const safePage = Math.min(page, totalPages);
+	const rows = agg.living.slice(
+		(safePage - 1) * PAGE_SIZE,
+		safePage * PAGE_SIZE,
+	);
+
+	return (
+		<div className="min-h-screen bg-bg-canvas">
+			<GridBackground />
+			<section className="relative z-10 px-6 py-20 md:px-12">
+				<div className="mx-auto max-w-content">
+					<p className="font-mono text-sm text-accent-lime">
+						{"//"} LEADERBOARD
+					</p>
+					<h1 className="mt-5 text-5xl font-black uppercase leading-[0.9] tracking-tighter text-fg-primary md:text-8xl">
+						Who is
+						<br />
+						spending what
+					</h1>
+
+					{/* The one honest header line. Everything the page claims, in a
+					    sentence, with n in it. */}
+					<p className="mt-8 border-l-4 border-accent-lime pl-6 font-mono text-sm leading-relaxed text-fg-secondary">
+						Measured across{" "}
+						<strong className="text-fg-primary">{agg.stackCount}</strong> stacks
+						·{" "}
+						<strong className="text-fg-primary">
+							{f.tokens(agg.totalTokens)}
+						</strong>{" "}
+						tokens · at least{" "}
+						<strong className="text-fg-primary">
+							{f.usd(agg.spendLowerBound)}
+						</strong>{" "}
+						· 30 days each
+					</p>
+
+					<Board rows={rows} nowMs={agg.nowMs} />
+
+					<Pager
+						page={safePage}
+						totalPages={totalPages}
+						onPage={onPage}
+						className="mt-10"
+					/>
+
+					{agg.stale.length > 0 && <StaleGroup agg={agg} />}
+
+					<Footnotes agg={agg} />
+				</div>
+			</section>
+		</div>
+	);
+}
+
+const GRID =
+	"grid grid-cols-[3rem_minmax(0,2.2fr)_minmax(0,1.3fr)_minmax(0,1.1fr)_minmax(0,1.4fr)_5rem_5rem] gap-4 items-center";
+
+function Board({
+	rows,
+	nowMs,
+}: {
+	readonly rows: readonly RankedStack[];
+	readonly nowMs: number;
+}) {
+	return (
+		<div className="mt-12 border-2 border-stroke-strong">
+			<div
+				className={cn(
+					GRID,
+					"border-b-2 border-stroke-strong bg-bg-panel px-5 py-3 font-mono text-[11px] font-bold uppercase tracking-[0.2em] text-fg-muted",
+				)}
+			>
+				<span>#</span>
+				<span>Stack</span>
+				<span className="text-right">Tokens</span>
+				<span className="text-right">Spend</span>
+				<span>Top model</span>
+				<span className="text-right">Sessions</span>
+				<span className="text-right">Synced</span>
+			</div>
+			{rows.length === 0 && (
+				<p className="px-5 py-8 font-mono text-sm text-fg-muted">
+					Nothing to rank. Every measured stack has been quiet for more than
+					seven days, so they are all listed below instead.
+				</p>
+			)}
+			<ul>
+				{rows.map((s) => (
+					<li
+						key={s.id}
+						className={cn(
+							GRID,
+							"relative border-b border-stroke-subtle px-5 py-4 last:border-b-0 hover:bg-bg-panel",
+						)}
+					>
+						<span className="font-mono text-2xl font-black text-fg-muted">
+							{s.rank}
+						</span>
+
+						<span className="min-w-0">
+							<Link
+								to="/stacks/$slug"
+								params={{ slug: s.slug }}
+								className="block truncate font-mono text-sm font-bold text-fg-primary hover:text-accent-lime"
+							>
+								{s.name}
+							</Link>
+							<span className="mt-0.5 block truncate font-mono text-xs text-fg-muted">
+								@{s.handle} · {s.activeHarnesses.join(" + ")}
+							</span>
+						</span>
+
+						{/* The only graphic on the page: the row's share of the leader,
+						    behind the number it is about. */}
+						<span className="relative text-right">
+							<span
+								aria-hidden="true"
+								className="absolute inset-y-0 right-0 bg-accent-lime/15"
+								style={{ width: `${Math.max(s.ofLeader * 100, 0.4)}%` }}
+							/>
+							<span className="relative font-mono text-base font-black text-fg-primary">
+								{f.tokens(s.tokens)}
+							</span>
+						</span>
+
+						<span className="text-right">
+							{s.spendLowerBound === null ? (
+								<span className="font-mono text-base text-fg-muted">—</span>
+							) : (
+								<>
+									<span className="block font-mono text-base font-bold text-fg-primary">
+										{s.spendExact ? "" : "≥ "}
+										{f.usd(s.spendLowerBound)}
+									</span>
+									<span className="block font-mono text-[11px] text-fg-muted">
+										{f.pct(s.coverage, 1)} priced
+									</span>
+								</>
+							)}
+						</span>
+
+						<span className="min-w-0">
+							{s.topModel === null ? (
+								<span className="font-mono text-xs text-fg-muted">
+									no model named
+								</span>
+							) : (
+								<>
+									<span className="block truncate font-mono text-sm text-fg-primary">
+										{s.topModel.name}
+									</span>
+									<span className="block font-mono text-[11px] text-fg-muted">
+										{f.pct(s.topModel.share)} of this stack
+									</span>
+								</>
+							)}
+						</span>
+
+						<span className="text-right font-mono text-sm text-fg-secondary">
+							{f.count(s.sessions)}
+						</span>
+
+						<span className="text-right font-mono text-xs text-fg-muted">
+							{f.ago(s.lastSyncMs, nowMs)}
+						</span>
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+}
+
+function StaleGroup({ agg }: { readonly agg: Aggregate }) {
+	return (
+		<section className="mt-16">
+			<h2 className="font-mono text-[11px] font-bold uppercase tracking-[0.25em] text-fg-muted">
+				Not synced in the last 7 days — listed, not ranked
+			</h2>
+			<ul className="mt-4 border border-dashed border-stroke-subtle">
+				{agg.stale.slice(0, 12).map((s) => (
+					<li
+						key={s.id}
+						className="flex items-baseline justify-between gap-4 border-b border-stroke-subtle px-5 py-3 last:border-b-0"
+					>
+						<Link
+							to="/stacks/$slug"
+							params={{ slug: s.slug }}
+							className="min-w-0 truncate font-mono text-sm text-fg-secondary hover:text-accent-lime"
+						>
+							{s.name} <span className="text-fg-muted">@{s.handle}</span>
+						</Link>
+						<span className="shrink-0 font-mono text-xs text-fg-muted">
+							{f.tokens(s.tokens)} · last synced {f.shortDay(s.lastSyncMs)}
+						</span>
+					</li>
+				))}
+				{agg.stale.length > 12 && (
+					<li className="px-5 py-3 font-mono text-xs text-fg-muted">
+						and {agg.stale.length - 12} more
+					</li>
+				)}
+			</ul>
+		</section>
+	);
+}
+
+function Footnotes({ agg }: { readonly agg: Aggregate }) {
+	return (
+		<div className="mt-16 max-w-2xl space-y-3 border-t-2 border-stroke-strong pt-6 font-mono text-xs leading-relaxed text-fg-muted">
+			<p>
+				Rank is raw measured tokens over each stack's own last 30 days. The
+				windows are offset by up to {Math.round(agg.windowSpreadDays)} days and
+				cannot be aligned — a stack's window ends when it last synced.
+			</p>
+			<p>
+				Every spend figure is a lower bound. {agg.costPublishers} of{" "}
+				{agg.stackCount} stacks publish a cost at all, and{" "}
+				{f.pct(agg.spendCoverage, 1)} of their tokens carry a citable price. A
+				stack that keeps cost private shows —, never a zero.
+			</p>
+			<p>
+				{f.pct(agg.unattributedShare, 1)} of measured tokens carry no model
+				name. They count toward a stack's total and lead no row.
+			</p>
+		</div>
+	);
+}

--- a/src/features/leaderboard/proto/VariantB.tsx
+++ b/src/features/leaderboard/proto/VariantB.tsx
@@ -1,0 +1,312 @@
+/**
+ * PROTOTYPE — throwaway. Wayfinder ticket #92 (map #76).
+ *
+ * VARIANT B — Statistics-first. The page is "the state of AI coding spend",
+ * and the board is one module inside it.
+ *
+ * The position this variant argues: the citable thing is the **population**,
+ * not the ranking. A journalist quotes "builders spent at least $X across N
+ * measured stacks, and 62% of it went to one model" — none of which is a row.
+ *
+ * It takes both ride-along questions head on:
+ *   1. Every candidate chart from #92 is on the page, so the ones that do not
+ *      earn a place fail visibly rather than by argument.
+ *   2. The weight switch repaints every share, and the model chart prints the
+ *      *other* framing underneath as a muted line. At `real` density the two
+ *      sentences disagree so hard that the page cannot mean both.
+ *
+ * Charts come from `src/features/charts`, which is the real module (#91). #92
+ * calls the charts here throwaway — using the real ones costs nothing and shows
+ * the house palette against real proportions.
+ */
+
+import { Link } from "@tanstack/react-router";
+import { ArrowRight } from "lucide-react";
+import { BarsChart, type ChartBar } from "@/features/charts";
+import type { Aggregate, Weight } from "./aggregate";
+import { shareSentence, weightedValue } from "./aggregate";
+import * as f from "./format";
+
+export const VARIANT_B_NAME = "Statistics-first — the state of AI coding spend";
+
+export function VariantB({
+	agg,
+	weight,
+}: {
+	readonly agg: Aggregate;
+	readonly weight: Weight;
+}) {
+	const topModel = agg.models[0];
+	const otherWeight: Weight = weight === "tokens" ? "stacks" : "tokens";
+
+	const modelBars: ChartBar[] = agg.models.slice(0, 8).map((m) => ({
+		key: m.key,
+		label: m.key,
+		value: weightedValue(m, weight, agg.stackCount) * 100,
+	}));
+	const harnessBars: ChartBar[] = agg.harnesses.slice(0, 8).map((h) => ({
+		key: h.key,
+		label: h.key,
+		value: weightedValue(h, weight, agg.stackCount) * 100,
+	}));
+	const toolBars: ChartBar[] = agg.tools.slice(0, 10).map((t) => ({
+		key: t.key,
+		label: t.key,
+		value: t.stackCount,
+	}));
+	const spendBars: ChartBar[] = agg.all
+		.filter((s) => s.spendLowerBound !== null)
+		.slice(0, 12)
+		.map((s) => ({
+			key: s.id,
+			label: s.name,
+			value: s.spendLowerBound ?? 0,
+		}));
+	const rateBars: ChartBar[] = agg.all
+		.filter((s) => s.costPerMtok !== null)
+		.slice(0, 12)
+		.map((s) => ({
+			key: s.id,
+			label: s.name,
+			value: Number((s.costPerMtok ?? 0).toFixed(2)),
+		}));
+
+	const pctAxis = (n: number) => `${n.toFixed(0)}%`;
+
+	return (
+		<div className="min-h-screen bg-bg-canvas">
+			<section className="px-6 py-20 md:px-12">
+				<div className="mx-auto max-w-content">
+					<p className="font-mono text-sm text-accent-lime">{"//"} MEASURED</p>
+					<h1 className="mt-5 max-w-4xl text-5xl font-black uppercase leading-[0.9] tracking-tighter text-fg-primary md:text-7xl">
+						The state of AI coding spend
+					</h1>
+					<p className="mt-6 max-w-2xl text-xl leading-relaxed text-fg-secondary">
+						Not a survey. Every number below is counted on a builder's own
+						machine and published by them, across {agg.stackCount} stacks and
+						their last 30 days.
+					</p>
+
+					<Headline agg={agg} />
+
+					{/* Chart 1 — models. The ride-along question, made visible. */}
+					<Block
+						title="Models"
+						lead={
+							topModel
+								? `${topModel.key} — ${shareSentence(topModel, weight, agg.stackCount)}`
+								: "Nothing measured yet"
+						}
+						sub={
+							topModel
+								? `Read the other way: ${shareSentence(topModel, otherWeight, agg.stackCount)}.`
+								: undefined
+						}
+					>
+						<BarsChart
+							bars={modelBars}
+							ariaLabel="Models by share"
+							valueLabel={weight === "tokens" ? "% of tokens" : "% of stacks"}
+							formatValue={pctAxis}
+							caption={
+								weight === "tokens"
+									? `share of ${f.tokens(agg.totalTokens)} attributed tokens`
+									: `stacks it leads, of ${agg.stackCount} measured`
+							}
+						/>
+						<p className="mt-3 max-w-2xl font-mono text-xs leading-relaxed text-fg-muted">
+							{f.pct(agg.unattributedShare, 1)} of measured tokens carry no
+							model name and are left out of these shares.
+							{topModel &&
+								` ${topModel.key} appears on ${topModel.stackCount} of ${agg.stackCount} stacks and leads ${topModel.leadsCount}.`}
+						</p>
+					</Block>
+
+					{/* Chart 2 — harnesses. */}
+					<Block
+						title="Harnesses"
+						lead={
+							agg.harnesses[0]
+								? `${agg.harnesses[0].key} — ${shareSentence(agg.harnesses[0], weight, agg.stackCount)}`
+								: "Nothing measured yet"
+						}
+					>
+						<BarsChart
+							bars={harnessBars}
+							ariaLabel="Harnesses by share"
+							valueLabel={weight === "tokens" ? "% of tokens" : "% of stacks"}
+							formatValue={pctAxis}
+							caption="a harness that logged nothing is not counted"
+						/>
+					</Block>
+
+					{/* Chart 3 — spend distribution. At four stacks this is the board
+					    again, drawn sideways. That is the point of putting it here. */}
+					<Block
+						title="Spend distribution"
+						lead={`At least ${f.usd(agg.spendLowerBound)} across ${agg.costPublishers} stacks that publish a cost`}
+					>
+						<BarsChart
+							bars={spendBars}
+							ariaLabel="Published spend per stack"
+							valueLabel="USD, lower bound"
+							formatValue={f.usdCompact}
+							caption="30 days · every figure a lower bound"
+						/>
+					</Block>
+
+					{/* Chart 4 — cost per token. */}
+					<Block
+						title="Cost per million tokens"
+						lead="What a million tokens costs, stack by stack"
+						sub="A stack running cheap models on long contexts lands low. A stack on frontier models lands high."
+					>
+						<BarsChart
+							bars={rateBars}
+							ariaLabel="Cost per million tokens per stack"
+							valueLabel="USD per Mtok"
+							formatValue={(n) => `$${n.toFixed(2)}`}
+							caption="published cost over measured tokens"
+						/>
+					</Block>
+
+					{/* Chart 5 — tools. Stack-weighted by construction. */}
+					<Block
+						title="Tools"
+						lead={
+							agg.tools[0]
+								? `${agg.tools[0].key} — on ${agg.tools[0].stackCount} of ${agg.stackCount} stacks`
+								: "Nothing listed yet"
+						}
+						sub="A tool has no tokens, so this one can only ever count stacks."
+					>
+						<BarsChart
+							bars={toolBars}
+							ariaLabel="Tools by number of stacks listing them"
+							valueLabel="Stacks"
+							formatValue={(n) => n.toFixed(0)}
+							caption={`listed on a stack · ${agg.stackCount} stacks`}
+						/>
+					</Block>
+
+					{/* The board, as one module. */}
+					<section className="mt-20 border-t-2 border-stroke-strong pt-10">
+						<div className="flex items-baseline justify-between gap-4">
+							<h2 className="font-mono text-[11px] font-bold uppercase tracking-[0.25em] text-fg-muted">
+								Ranked by measured tokens
+							</h2>
+							<span className="inline-flex items-center gap-2 font-mono text-xs uppercase tracking-widest text-accent-lime">
+								Full board <ArrowRight className="size-3" />
+							</span>
+						</div>
+						<ol className="mt-4">
+							{agg.living.slice(0, 10).map((s) => (
+								<li
+									key={s.id}
+									className="flex items-baseline gap-4 border-b border-stroke-subtle py-3 last:border-b-0"
+								>
+									<span className="w-6 shrink-0 font-mono text-sm text-fg-muted">
+										{s.rank}
+									</span>
+									<Link
+										to="/stacks/$slug"
+										params={{ slug: s.slug }}
+										className="min-w-0 flex-1 truncate font-mono text-sm font-bold text-fg-primary hover:text-accent-lime"
+									>
+										{s.name}
+										<span className="ml-2 font-normal text-fg-muted">
+											@{s.handle}
+										</span>
+									</Link>
+									<span className="shrink-0 font-mono text-sm text-fg-primary">
+										{f.tokens(s.tokens)}
+									</span>
+									<span className="w-28 shrink-0 text-right font-mono text-sm text-fg-secondary">
+										{s.spendLowerBound === null
+											? "—"
+											: `${s.spendExact ? "" : "≥ "}${f.usd(s.spendLowerBound)}`}
+									</span>
+								</li>
+							))}
+						</ol>
+					</section>
+
+					<p className="mt-12 max-w-2xl font-mono text-xs leading-relaxed text-fg-muted">
+						Each stack's window ends when it last synced, so the{" "}
+						{agg.stackCount} windows are offset by up to{" "}
+						{Math.round(agg.windowSpreadDays)} days and cannot be aligned.
+						Unpublished stacks, flagged stacks and harnesses that logged nothing
+						are left out.
+					</p>
+				</div>
+			</section>
+		</div>
+	);
+}
+
+function Headline({ agg }: { readonly agg: Aggregate }) {
+	const items = [
+		{
+			label: "measured tokens",
+			value: f.tokens(agg.totalTokens),
+			accent: true,
+		},
+		{
+			label: `at least, across ${agg.costPublishers} stacks`,
+			value: f.usd(agg.spendLowerBound),
+			accent: false,
+		},
+		{ label: "stacks measured", value: f.count(agg.stackCount), accent: false },
+		{ label: "sessions", value: f.count(agg.totalSessions), accent: false },
+	];
+	return (
+		<div className="mt-12 grid grid-cols-2 border-2 border-stroke-strong md:grid-cols-4">
+			{items.map((it) => (
+				<div
+					key={it.label}
+					className="border-b-2 border-r-2 border-stroke-strong p-6 last:border-r-0 md:border-b-0"
+				>
+					<p
+						className={`font-mono text-3xl font-black md:text-4xl ${
+							it.accent ? "text-accent-lime" : "text-fg-primary"
+						}`}
+					>
+						{it.value}
+					</p>
+					<p className="mt-2 font-mono text-[11px] uppercase tracking-[0.2em] text-fg-muted">
+						{it.label}
+					</p>
+				</div>
+			))}
+		</div>
+	);
+}
+
+function Block({
+	title,
+	lead,
+	sub,
+	children,
+}: {
+	readonly title: string;
+	readonly lead: string;
+	readonly sub?: string;
+	readonly children: React.ReactNode;
+}) {
+	return (
+		<section className="mt-20">
+			<h2 className="font-mono text-[11px] font-bold uppercase tracking-[0.25em] text-fg-muted">
+				{title}
+			</h2>
+			<p className="mt-3 max-w-3xl text-2xl font-black leading-tight tracking-tight text-fg-primary">
+				{lead}
+			</p>
+			{sub && (
+				<p className="mt-2 max-w-2xl font-mono text-xs leading-relaxed text-fg-muted">
+					{sub}
+				</p>
+			)}
+			<div className="mt-6">{children}</div>
+		</section>
+	);
+}

--- a/src/features/leaderboard/proto/VariantC.tsx
+++ b/src/features/leaderboard/proto/VariantC.tsx
@@ -1,0 +1,318 @@
+/**
+ * PROTOTYPE — throwaway. Wayfinder ticket #92 (map #76).
+ *
+ * VARIANT C — Equal weight. A sticky statistics rail beside the ranked board.
+ *
+ * The position this variant argues: neither the population nor the ranking is
+ * the page — the **reading** is. A rank means nothing without the population it
+ * ranks inside, so the rail never scrolls away: whatever row you are looking
+ * at, the shares that row sits inside are on screen next to it.
+ *
+ * Structurally it is neither A nor B stacked. The rail is small-multiple sized
+ * on purpose, so no figure in it can grow into B's page, and the board is
+ * denser than A's so it cannot grow into A's.
+ *
+ * Ride-along answers:
+ *   1. Only two rankings earn a place — models and harnesses — because those
+ *      are the two the rail can carry at rail width. Spend distribution and
+ *      cost-per-token are the board's columns already.
+ *   2. The weight switch repaints the rail, and the rail states which weighting
+ *      it is under, in words, above the bars.
+ */
+
+import { Link } from "@tanstack/react-router";
+import type { Aggregate, Ranking, Weight } from "./aggregate";
+import { weightedValue } from "./aggregate";
+import { Pager } from "./bits";
+import * as f from "./format";
+
+const PAGE_SIZE = 10;
+
+export const VARIANT_C_NAME =
+	"Equal weight — sticky stats rail beside the board";
+
+export function VariantC({
+	agg,
+	weight,
+	page,
+	onPage,
+}: {
+	readonly agg: Aggregate;
+	readonly weight: Weight;
+	readonly page: number;
+	readonly onPage: (p: number) => void;
+}) {
+	const totalPages = Math.max(1, Math.ceil(agg.living.length / PAGE_SIZE));
+	const safePage = Math.min(page, totalPages);
+	const rows = agg.living.slice(
+		(safePage - 1) * PAGE_SIZE,
+		safePage * PAGE_SIZE,
+	);
+
+	return (
+		<div className="min-h-screen bg-bg-canvas">
+			<div className="border-b-2 border-stroke-strong px-6 py-10 md:px-12">
+				<div className="mx-auto flex max-w-content flex-col gap-6 md:flex-row md:items-end md:justify-between">
+					<div>
+						<p className="font-mono text-sm text-accent-lime">
+							{"//"} MEASURED · LAST 30 DAYS
+						</p>
+						<h1 className="mt-3 text-4xl font-black uppercase leading-none tracking-tighter text-fg-primary md:text-6xl">
+							What builders run
+						</h1>
+					</div>
+					<p className="max-w-md font-mono text-xs leading-relaxed text-fg-muted">
+						Counted on {agg.stackCount} builders' own machines and published by
+						them. Windows offset by up to {Math.round(agg.windowSpreadDays)}{" "}
+						days.
+					</p>
+				</div>
+			</div>
+
+			<div className="mx-auto max-w-content px-6 py-12 md:px-12">
+				<div className="grid grid-cols-1 gap-10 lg:grid-cols-[19rem_minmax(0,1fr)]">
+					<aside className="lg:sticky lg:top-8 lg:self-start">
+						<Rail agg={agg} weight={weight} />
+					</aside>
+
+					<main>
+						<div className="flex items-baseline justify-between gap-4">
+							<h2 className="font-mono text-[11px] font-bold uppercase tracking-[0.25em] text-fg-muted">
+								Ranked by measured tokens
+							</h2>
+							<span className="font-mono text-[11px] uppercase tracking-[0.2em] text-fg-muted">
+								{agg.livingCount} living · {agg.stale.length} quiet
+							</span>
+						</div>
+
+						{rows.length === 0 && (
+							<p className="mt-4 border-t border-stroke-subtle py-6 font-mono text-sm text-fg-muted">
+								Nothing to rank — every measured stack has been quiet for more
+								than seven days.
+							</p>
+						)}
+						<ol className="mt-4 border-t border-stroke-subtle">
+							{rows.map((s) => (
+								<li
+									key={s.id}
+									className="grid grid-cols-[2.5rem_minmax(0,1fr)_auto] items-baseline gap-x-4 gap-y-1 border-b border-stroke-subtle py-4 hover:bg-bg-panel"
+								>
+									<span className="row-span-2 font-mono text-xl font-black text-fg-muted">
+										{s.rank}
+									</span>
+									<Link
+										to="/stacks/$slug"
+										params={{ slug: s.slug }}
+										className="min-w-0 truncate font-mono text-sm font-bold text-fg-primary hover:text-accent-lime"
+									>
+										{s.name}
+										<span className="ml-2 font-normal text-fg-muted">
+											@{s.handle}
+										</span>
+									</Link>
+									<span className="whitespace-nowrap text-right font-mono text-base font-black text-fg-primary">
+										{f.tokens(s.tokens)}
+									</span>
+
+									<span className="min-w-0 truncate font-mono text-xs text-fg-muted">
+										{s.topModel
+											? `${s.topModel.name} ${f.pct(s.topModel.share)} · `
+											: "no model named · "}
+										{s.activeHarnesses.join(" + ")} · synced{" "}
+										{f.ago(s.lastSyncMs, agg.nowMs)}
+									</span>
+									<span className="whitespace-nowrap text-right font-mono text-xs text-fg-secondary">
+										{s.spendLowerBound === null ? (
+											<span className="text-fg-muted">cost not published</span>
+										) : (
+											<>
+												{s.spendExact ? "" : "≥ "}
+												{f.usd(s.spendLowerBound)}
+												<span className="text-fg-muted">
+													{" "}
+													· {f.pct(s.coverage, 1)} priced
+												</span>
+											</>
+										)}
+									</span>
+								</li>
+							))}
+						</ol>
+
+						<Pager
+							page={safePage}
+							totalPages={totalPages}
+							onPage={onPage}
+							className="mt-8"
+						/>
+
+						{agg.stale.length > 0 && (
+							<section className="mt-12">
+								<h3 className="font-mono text-[11px] font-bold uppercase tracking-[0.25em] text-fg-muted">
+									Quiet — no sync in 7 days, listed not ranked
+								</h3>
+								<ul className="mt-3 border-t border-dashed border-stroke-subtle">
+									{agg.stale.slice(0, 10).map((s) => (
+										<li
+											key={s.id}
+											className="flex items-baseline justify-between gap-4 border-b border-dashed border-stroke-subtle py-2"
+										>
+											<Link
+												to="/stacks/$slug"
+												params={{ slug: s.slug }}
+												className="min-w-0 truncate font-mono text-xs text-fg-secondary hover:text-accent-lime"
+											>
+												{s.name}
+											</Link>
+											<span className="shrink-0 font-mono text-xs text-fg-muted">
+												{f.tokens(s.tokens)} · {f.shortDay(s.lastSyncMs)}
+											</span>
+										</li>
+									))}
+									{agg.stale.length > 10 && (
+										<li className="py-2 font-mono text-xs text-fg-muted">
+											and {agg.stale.length - 10} more
+										</li>
+									)}
+								</ul>
+							</section>
+						)}
+					</main>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function Rail({
+	agg,
+	weight,
+}: {
+	readonly agg: Aggregate;
+	readonly weight: Weight;
+}) {
+	return (
+		<div className="space-y-8">
+			<dl className="border-2 border-stroke-strong">
+				<Figure
+					label="measured tokens"
+					value={f.tokens(agg.totalTokens)}
+					accent
+				/>
+				<Figure
+					label={`at least · ${agg.costPublishers} of ${agg.stackCount} publish cost`}
+					value={f.usd(agg.spendLowerBound)}
+				/>
+				<Figure label="stacks measured" value={f.count(agg.stackCount)} />
+				<Figure label="sessions" value={f.count(agg.totalSessions)} last />
+			</dl>
+
+			<MiniRanking
+				title="Models"
+				note={
+					weight === "tokens"
+						? "share of attributed tokens"
+						: `stacks it leads, of ${agg.stackCount}`
+				}
+				items={agg.models.slice(0, 6)}
+				weight={weight}
+				population={agg.stackCount}
+			/>
+
+			<MiniRanking
+				title="Harnesses"
+				note={
+					weight === "tokens"
+						? "share of attributed tokens"
+						: `stacks it leads, of ${agg.stackCount}`
+				}
+				items={agg.harnesses.slice(0, 5)}
+				weight={weight}
+				population={agg.stackCount}
+			/>
+
+			<p className="font-mono text-[11px] leading-relaxed text-fg-muted">
+				{f.pct(agg.unattributedShare, 1)} of measured tokens carry no model name
+				and are left out of these shares. Spend is always a lower bound.
+			</p>
+		</div>
+	);
+}
+
+function Figure({
+	label,
+	value,
+	accent,
+	last,
+}: {
+	readonly label: string;
+	readonly value: string;
+	readonly accent?: boolean;
+	readonly last?: boolean;
+}) {
+	return (
+		<div className={last ? "p-4" : "border-b-2 border-stroke-strong p-4"}>
+			<dd
+				className={`font-mono text-2xl font-black ${
+					accent ? "text-accent-lime" : "text-fg-primary"
+				}`}
+			>
+				{value}
+			</dd>
+			<dt className="mt-1 font-mono text-[10px] uppercase tracking-[0.2em] text-fg-muted">
+				{label}
+			</dt>
+		</div>
+	);
+}
+
+function MiniRanking({
+	title,
+	note,
+	items,
+	weight,
+	population,
+}: {
+	readonly title: string;
+	readonly note: string;
+	readonly items: readonly Ranking[];
+	readonly weight: Weight;
+	readonly population: number;
+}) {
+	if (items.length === 0) return null;
+	const value = (r: Ranking) => weightedValue(r, weight, population);
+	const max = Math.max(...items.map(value), 0.0001);
+
+	return (
+		<section>
+			<h3 className="font-mono text-[11px] font-bold uppercase tracking-[0.25em] text-fg-muted">
+				{title}
+			</h3>
+			<p className="mt-1 font-mono text-[10px] uppercase tracking-[0.15em] text-fg-muted/70">
+				{note}
+			</p>
+			<ul className="mt-3 space-y-2">
+				{items.map((r) => (
+					<li key={r.key}>
+						<div className="flex items-baseline justify-between gap-2">
+							<span className="min-w-0 truncate font-mono text-xs text-fg-primary">
+								{r.key}
+							</span>
+							<span className="shrink-0 font-mono text-xs text-fg-secondary">
+								{weight === "tokens"
+									? f.pct(r.tokenShare)
+									: `${r.leadsCount}/${population}`}
+							</span>
+						</div>
+						<div className="mt-1 h-1.5 bg-bg-panel">
+							<div
+								className="h-full bg-accent-lime"
+								style={{ width: `${(value(r) / max) * 100}%` }}
+							/>
+						</div>
+					</li>
+				))}
+			</ul>
+		</section>
+	);
+}

--- a/src/features/leaderboard/proto/VariantC2.tsx
+++ b/src/features/leaderboard/proto/VariantC2.tsx
@@ -1,0 +1,408 @@
+/**
+ * PROTOTYPE — throwaway. Wayfinder ticket #92 (map #76).
+ *
+ * VARIANT C2 / C3 — C, refined after the first review.
+ *
+ * Three changes on top of [C](./VariantC.tsx):
+ *
+ * 1. **A wide gutter.** The rail and the board were one gap apart and read as
+ *    one table with a sidebar glued to it. They are now far enough apart to
+ *    read as two things, and the rail narrows to hold the same line lengths.
+ * 2. **A trend sparkline per row.** The line is the stack's rolling 30-day
+ *    total as it stood on each sync — the same number the tokens column shows,
+ *    over time. It is a level, so it **can fall**, and one real stack falls.
+ * 3. **The quiet group, two ways.** C2 keeps the list. C3 replaces it with one
+ *    line. Flip between them to settle whether the list earns its place.
+ *
+ * The sparkline is the only place this page can go wrong quietly, so it is
+ * built to refuse rather than to guess:
+ *
+ *   - fewer than two readings draws **no line at all** and says so. A flat
+ *     stroke through one dot claims six days nobody measured.
+ *   - the trend is the change across the readings that exist, not across the
+ *     window, and the row prints how many readings it had.
+ *
+ * That matters here: on prod one of the four stacks has exactly one reading.
+ */
+
+import { Link } from "@tanstack/react-router";
+import { Sparkline } from "@/features/charts";
+import type { Aggregate, RankedStack, Ranking, Weight } from "./aggregate";
+import { weightedValue } from "./aggregate";
+import { Pager } from "./bits";
+import * as f from "./format";
+
+const PAGE_SIZE = 10;
+
+export const VARIANT_C2_NAME =
+	"C refined — wide gutter, sparklines, quiet list";
+export const VARIANT_C3_NAME = "C refined — same, quiet group as one line";
+
+export function VariantC2({
+	agg,
+	weight,
+	page,
+	onPage,
+	quietGroup,
+}: {
+	readonly agg: Aggregate;
+	readonly weight: Weight;
+	readonly page: number;
+	readonly onPage: (p: number) => void;
+	/** `list` shows every quiet stack. `line` states the count and stops. */
+	readonly quietGroup: "list" | "line";
+}) {
+	const totalPages = Math.max(1, Math.ceil(agg.living.length / PAGE_SIZE));
+	const safePage = Math.min(page, totalPages);
+	const rows = agg.living.slice(
+		(safePage - 1) * PAGE_SIZE,
+		safePage * PAGE_SIZE,
+	);
+
+	return (
+		<div className="min-h-screen bg-bg-canvas">
+			<div className="border-b-2 border-stroke-strong px-6 py-10 md:px-12">
+				<div className="mx-auto flex max-w-content flex-col gap-6 md:flex-row md:items-end md:justify-between">
+					<div>
+						<p className="font-mono text-sm text-accent-lime">
+							{"//"} MEASURED · LAST 30 DAYS
+						</p>
+						<h1 className="mt-3 text-4xl font-black uppercase leading-none tracking-tighter text-fg-primary md:text-6xl">
+							What builders run
+						</h1>
+					</div>
+					<p className="max-w-md font-mono text-xs leading-relaxed text-fg-muted">
+						Counted on {agg.stackCount} builders' own machines and published by
+						them. Windows offset by up to {Math.round(agg.windowSpreadDays)}{" "}
+						days.
+					</p>
+				</div>
+			</div>
+
+			<div className="mx-auto max-w-content px-6 py-14 md:px-12">
+				{/* The gutter is the change: 5rem at lg, 7rem at xl. The rail is
+				    narrower than in C so the line lengths stay the same. */}
+				<div className="grid grid-cols-1 gap-14 lg:grid-cols-[16rem_minmax(0,1fr)] lg:gap-20 xl:gap-28">
+					<aside className="lg:sticky lg:top-8 lg:self-start">
+						<Rail agg={agg} weight={weight} />
+					</aside>
+
+					<main>
+						<div className="flex items-baseline justify-between gap-4">
+							<h2 className="font-mono text-[11px] font-bold uppercase tracking-[0.25em] text-fg-muted">
+								Ranked by measured tokens
+							</h2>
+							<span className="font-mono text-[11px] uppercase tracking-[0.2em] text-fg-muted">
+								{agg.livingCount} ranked · {agg.stale.length} quiet
+							</span>
+						</div>
+
+						{rows.length === 0 && (
+							<p className="mt-4 border-t border-stroke-subtle py-6 font-mono text-sm text-fg-muted">
+								Nothing to rank — every measured stack has been quiet for more
+								than seven days.
+							</p>
+						)}
+
+						<ol className="mt-4 border-t border-stroke-subtle">
+							{rows.map((s) => (
+								<Row key={s.id} s={s} nowMs={agg.nowMs} />
+							))}
+						</ol>
+
+						<Pager
+							page={safePage}
+							totalPages={totalPages}
+							onPage={onPage}
+							className="mt-10"
+						/>
+
+						{agg.stale.length > 0 &&
+							(quietGroup === "list" ? (
+								<QuietList agg={agg} />
+							) : (
+								<QuietLine agg={agg} />
+							))}
+					</main>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function Row({
+	s,
+	nowMs,
+}: {
+	readonly s: RankedStack;
+	readonly nowMs: number;
+}) {
+	return (
+		<li className="grid grid-cols-[2.5rem_minmax(0,1fr)_7rem_auto] items-baseline gap-x-5 gap-y-1 border-b border-stroke-subtle py-4 hover:bg-bg-panel">
+			<span className="row-span-2 font-mono text-xl font-black text-fg-muted">
+				{s.rank}
+			</span>
+
+			<Link
+				to="/stacks/$slug"
+				params={{ slug: s.slug }}
+				className="min-w-0 truncate font-mono text-sm font-bold text-fg-primary hover:text-accent-lime"
+			>
+				{s.name}
+				<span className="ml-2 font-normal text-fg-muted">@{s.handle}</span>
+			</Link>
+
+			<span className="row-span-2 self-center">
+				<Trend s={s} />
+			</span>
+
+			<span className="whitespace-nowrap text-right font-mono text-base font-black text-fg-primary">
+				{f.tokens(s.tokens)}
+			</span>
+
+			<span className="min-w-0 truncate font-mono text-xs text-fg-muted">
+				{s.topModel
+					? `${s.topModel.name} ${f.pct(s.topModel.share)} · `
+					: "no model named · "}
+				{s.activeHarnesses.join(" + ")} · synced {f.ago(s.lastSyncMs, nowMs)}
+			</span>
+
+			<span className="whitespace-nowrap text-right font-mono text-xs text-fg-secondary">
+				{s.spendLowerBound === null ? (
+					<span className="text-fg-muted">cost not published</span>
+				) : (
+					<>
+						{s.spendExact ? "" : "≥ "}
+						{f.usd(s.spendLowerBound)}
+						<span className="text-fg-muted">
+							{" "}
+							· {f.pct(s.coverage, 1)} priced
+						</span>
+					</>
+				)}
+			</span>
+		</li>
+	);
+}
+
+/**
+ * The sparkline cell.
+ *
+ * One reading is not a trend, and the row says so rather than drawing a flat
+ * stroke that would claim days nobody measured.
+ */
+function Trend({ s }: { readonly s: RankedStack }) {
+	if (s.history.length < 2 || s.trend === null) {
+		return (
+			<span className="block text-right font-mono text-[10px] leading-tight text-fg-muted">
+				one reading
+				<br />
+				no trend yet
+			</span>
+		);
+	}
+	const up = s.trend >= 0;
+	return (
+		<span className="block">
+			<Sparkline
+				points={s.history}
+				ariaLabel={`${s.name} measured tokens across ${s.history.length} syncs`}
+				width={108}
+				height={26}
+			/>
+			<span className="mt-0.5 block font-mono text-[10px] leading-tight text-fg-muted">
+				<span className={up ? "text-accent-lime" : "text-fg-secondary"}>
+					{up ? "+" : "−"}
+					{f.pct(Math.abs(s.trend))}
+				</span>{" "}
+				over {s.history.length} syncs
+			</span>
+		</span>
+	);
+}
+
+/** C2 — the quiet stacks, listed. */
+function QuietList({ agg }: { readonly agg: Aggregate }) {
+	return (
+		<section className="mt-16">
+			<h3 className="font-mono text-[11px] font-bold uppercase tracking-[0.25em] text-fg-muted">
+				Quiet — no sync in 7 days, listed not ranked
+			</h3>
+			<ul className="mt-3 border-t border-dashed border-stroke-subtle">
+				{agg.stale.slice(0, 10).map((s) => (
+					<li
+						key={s.id}
+						className="flex items-baseline justify-between gap-4 border-b border-dashed border-stroke-subtle py-2"
+					>
+						<Link
+							to="/stacks/$slug"
+							params={{ slug: s.slug }}
+							className="min-w-0 truncate font-mono text-xs text-fg-secondary hover:text-accent-lime"
+						>
+							{s.name}
+						</Link>
+						<span className="shrink-0 font-mono text-xs text-fg-muted">
+							{f.tokens(s.tokens)} · {f.shortDay(s.lastSyncMs)}
+						</span>
+					</li>
+				))}
+				{agg.stale.length > 10 && (
+					<li className="py-2 font-mono text-xs text-fg-muted">
+						and {agg.stale.length - 10} more
+					</li>
+				)}
+			</ul>
+		</section>
+	);
+}
+
+/**
+ * C3 — the same fact, one line.
+ *
+ * It keeps the count, which is what makes the ranked board honest about what
+ * it left out, and drops the roll call of who has been idle.
+ */
+function QuietLine({ agg }: { readonly agg: Aggregate }) {
+	return (
+		<p className="mt-16 border-t border-dashed border-stroke-subtle pt-4 font-mono text-xs leading-relaxed text-fg-muted">
+			{agg.stale.length} more stack{agg.stale.length === 1 ? "" : "s"}{" "}
+			{agg.stale.length === 1 ? "has" : "have"} measured history but no sync in
+			the last seven days, so {agg.stale.length === 1 ? "it is" : "they are"}{" "}
+			not ranked. {f.tokens(agg.stale.reduce((a, s) => a + s.tokens, 0))} tokens
+			sit in that group.
+		</p>
+	);
+}
+
+function Rail({
+	agg,
+	weight,
+}: {
+	readonly agg: Aggregate;
+	readonly weight: Weight;
+}) {
+	return (
+		<div className="space-y-10">
+			<dl className="border-2 border-stroke-strong">
+				<Figure
+					label="measured tokens"
+					value={f.tokens(agg.totalTokens)}
+					accent
+				/>
+				<Figure
+					label={`at least · ${agg.costPublishers} of ${agg.stackCount} publish cost`}
+					value={f.usd(agg.spendLowerBound)}
+				/>
+				<Figure label="stacks measured" value={f.count(agg.stackCount)} />
+				<Figure label="sessions" value={f.count(agg.totalSessions)} last />
+			</dl>
+
+			<MiniRanking
+				title="Models"
+				note={
+					weight === "tokens"
+						? "share of attributed tokens"
+						: `stacks it leads, of ${agg.stackCount}`
+				}
+				items={agg.models.slice(0, 6)}
+				weight={weight}
+				population={agg.stackCount}
+			/>
+
+			<MiniRanking
+				title="Harnesses"
+				note={
+					weight === "tokens"
+						? "share of attributed tokens"
+						: `stacks it leads, of ${agg.stackCount}`
+				}
+				items={agg.harnesses.slice(0, 5)}
+				weight={weight}
+				population={agg.stackCount}
+			/>
+
+			<p className="font-mono text-[11px] leading-relaxed text-fg-muted">
+				{f.pct(agg.unattributedShare, 1)} of measured tokens carry no model name
+				and are left out of these shares. Spend is always a lower bound.
+			</p>
+		</div>
+	);
+}
+
+function Figure({
+	label,
+	value,
+	accent,
+	last,
+}: {
+	readonly label: string;
+	readonly value: string;
+	readonly accent?: boolean;
+	readonly last?: boolean;
+}) {
+	return (
+		<div className={last ? "p-4" : "border-b-2 border-stroke-strong p-4"}>
+			<dd
+				className={`font-mono text-2xl font-black ${
+					accent ? "text-accent-lime" : "text-fg-primary"
+				}`}
+			>
+				{value}
+			</dd>
+			<dt className="mt-1 font-mono text-[10px] uppercase tracking-[0.2em] text-fg-muted">
+				{label}
+			</dt>
+		</div>
+	);
+}
+
+function MiniRanking({
+	title,
+	note,
+	items,
+	weight,
+	population,
+}: {
+	readonly title: string;
+	readonly note: string;
+	readonly items: readonly Ranking[];
+	readonly weight: Weight;
+	readonly population: number;
+}) {
+	if (items.length === 0) return null;
+	const value = (r: Ranking) => weightedValue(r, weight, population);
+	const max = Math.max(...items.map(value), 0.0001);
+
+	return (
+		<section>
+			<h3 className="font-mono text-[11px] font-bold uppercase tracking-[0.25em] text-fg-muted">
+				{title}
+			</h3>
+			<p className="mt-1 font-mono text-[10px] uppercase tracking-[0.15em] text-fg-muted/70">
+				{note}
+			</p>
+			<ul className="mt-3 space-y-2">
+				{items.map((r) => (
+					<li key={r.key}>
+						<div className="flex items-baseline justify-between gap-2">
+							<span className="min-w-0 truncate font-mono text-xs text-fg-primary">
+								{r.key}
+							</span>
+							<span className="shrink-0 font-mono text-xs text-fg-secondary">
+								{weight === "tokens"
+									? f.pct(r.tokenShare)
+									: `${r.leadsCount}/${population}`}
+							</span>
+						</div>
+						<div className="mt-1 h-1.5 bg-bg-panel">
+							<div
+								className="h-full bg-accent-lime"
+								style={{ width: `${(value(r) / max) * 100}%` }}
+							/>
+						</div>
+					</li>
+				))}
+			</ul>
+		</section>
+	);
+}

--- a/src/features/leaderboard/proto/VariantC2.tsx
+++ b/src/features/leaderboard/proto/VariantC2.tsx
@@ -143,7 +143,7 @@ function Row({
 	readonly nowMs: number;
 }) {
 	return (
-		<li className="grid grid-cols-[2.5rem_minmax(0,1fr)_9rem_auto] items-baseline gap-x-5 gap-y-1 border-b border-stroke-subtle py-4 hover:bg-bg-panel">
+		<li className="grid grid-cols-[2rem_minmax(0,1fr)_9rem] items-baseline gap-x-4 gap-y-1 border-b border-stroke-subtle py-4 hover:bg-bg-panel md:grid-cols-[2.5rem_minmax(0,1fr)_9rem_14rem] md:gap-x-5">
 			<span className="row-span-2 font-mono text-xl font-black text-fg-muted">
 				{s.rank}
 			</span>
@@ -154,7 +154,9 @@ function Row({
 				className="min-w-0 truncate font-mono text-sm font-bold text-fg-primary hover:text-accent-lime"
 			>
 				{s.name}
-				<span className="ml-2 font-normal text-fg-muted">@{s.handle}</span>
+				<span className="ml-2 hidden font-normal text-fg-muted sm:inline">
+					@{s.handle}
+				</span>
 			</Link>
 
 			<Trend s={s} />
@@ -164,6 +166,7 @@ function Row({
 			</span>
 
 			<span className="min-w-0 truncate font-mono text-xs text-fg-muted">
+				<span className="md:hidden">{trendWords(s)} · </span>
 				{s.topModel
 					? `${s.topModel.name} ${f.pct(s.topModel.share)} · `
 					: "no model named · "}
@@ -188,6 +191,13 @@ function Row({
 	);
 }
 
+/** The trend in words, for the narrow layout that has no room to draw it. */
+function trendWords(s: RankedStack): string {
+	if (s.history.length < 2 || s.trend === null) return "1 sync";
+	const up = s.trend >= 0;
+	return `${up ? "+" : "−"}${f.pct(Math.abs(s.trend))} over ${s.history.length} syncs`;
+}
+
 /**
  * The sparkline cell.
  *
@@ -203,7 +213,7 @@ function Trend({ s }: { readonly s: RankedStack }) {
 		// wraps, whether the stack has one reading, and whether it publishes a
 		// cost. Nothing here may size itself off its own content.
 		<span
-			className="row-span-2 flex flex-col items-end justify-center self-center"
+			className="row-span-2 hidden flex-col items-end justify-center self-center md:flex"
 			style={{ height: `${CELL_HEIGHT}px` }}
 		>
 			<span

--- a/src/features/leaderboard/proto/VariantC2.tsx
+++ b/src/features/leaderboard/proto/VariantC2.tsx
@@ -34,6 +34,11 @@ import * as f from "./format";
 
 const PAGE_SIZE = 10;
 
+/** The trend cell is fixed at every size, so the column reads as a column. */
+const SPARK_WIDTH = 128;
+const SPARK_HEIGHT = 26;
+const CELL_HEIGHT = SPARK_HEIGHT + 16;
+
 export const VARIANT_C2_NAME =
 	"C refined — wide gutter, sparklines, quiet list";
 export const VARIANT_C3_NAME = "C refined — same, quiet group as one line";
@@ -138,7 +143,7 @@ function Row({
 	readonly nowMs: number;
 }) {
 	return (
-		<li className="grid grid-cols-[2.5rem_minmax(0,1fr)_7rem_auto] items-baseline gap-x-5 gap-y-1 border-b border-stroke-subtle py-4 hover:bg-bg-panel">
+		<li className="grid grid-cols-[2.5rem_minmax(0,1fr)_9rem_auto] items-baseline gap-x-5 gap-y-1 border-b border-stroke-subtle py-4 hover:bg-bg-panel">
 			<span className="row-span-2 font-mono text-xl font-black text-fg-muted">
 				{s.rank}
 			</span>
@@ -152,9 +157,7 @@ function Row({
 				<span className="ml-2 font-normal text-fg-muted">@{s.handle}</span>
 			</Link>
 
-			<span className="row-span-2 self-center">
-				<Trend s={s} />
-			</span>
+			<Trend s={s} />
 
 			<span className="whitespace-nowrap text-right font-mono text-base font-black text-fg-primary">
 				{f.tokens(s.tokens)}
@@ -192,30 +195,49 @@ function Row({
  * stroke that would claim days nobody measured.
  */
 function Trend({ s }: { readonly s: RankedStack }) {
-	if (s.history.length < 2 || s.trend === null) {
-		return (
-			<span className="block text-right font-mono text-[10px] leading-tight text-fg-muted">
-				one reading
-				<br />
-				no trend yet
-			</span>
-		);
-	}
-	const up = s.trend >= 0;
+	const drawable = s.history.length >= 2 && s.trend !== null;
+	const up = (s.trend ?? 0) >= 0;
 	return (
-		<span className="block">
-			<Sparkline
-				points={s.history}
-				ariaLabel={`${s.name} measured tokens across ${s.history.length} syncs`}
-				width={108}
-				height={26}
-			/>
-			<span className="mt-0.5 block font-mono text-[10px] leading-tight text-fg-muted">
-				<span className={up ? "text-accent-lime" : "text-fg-secondary"}>
-					{up ? "+" : "−"}
-					{f.pct(Math.abs(s.trend))}
-				</span>{" "}
-				over {s.history.length} syncs
+		// row-span-2 with a fixed height and a reserved SPARK_HEIGHT strip: the
+		// line sits on the same baseline in every row, whether the row below it
+		// wraps, whether the stack has one reading, and whether it publishes a
+		// cost. Nothing here may size itself off its own content.
+		<span
+			className="row-span-2 flex flex-col items-end justify-center self-center"
+			style={{ height: `${CELL_HEIGHT}px` }}
+		>
+			<span
+				className="flex w-full items-center justify-end"
+				style={{ height: `${SPARK_HEIGHT}px` }}
+			>
+				{drawable ? (
+					<Sparkline
+						points={s.history}
+						ariaLabel={`${s.name} measured tokens across ${s.history.length} syncs`}
+						width={SPARK_WIDTH}
+						height={SPARK_HEIGHT}
+					/>
+				) : (
+					// A rule, not a line: it says "no reading to draw" without
+					// claiming a flat trend across days nobody measured.
+					<span
+						aria-hidden="true"
+						className="w-8 border-t border-dashed border-stroke-strong"
+					/>
+				)}
+			</span>
+			<span className="mt-1 block whitespace-nowrap font-mono text-[10px] leading-none text-fg-muted">
+				{drawable ? (
+					<>
+						<span className={up ? "text-accent-lime" : "text-fg-secondary"}>
+							{up ? "+" : "−"}
+							{f.pct(Math.abs(s.trend ?? 0))}
+						</span>{" "}
+						· {s.history.length} syncs
+					</>
+				) : (
+					"1 sync · no trend"
+				)}
 			</span>
 		</span>
 	);

--- a/src/features/leaderboard/proto/aggregate.ts
+++ b/src/features/leaderboard/proto/aggregate.ts
@@ -1,0 +1,261 @@
+/**
+ * PROTOTYPE — throwaway. Wayfinder ticket #92 (map #76).
+ *
+ * Everything the three variants read. Kept out of the variants so they can
+ * disagree about layout without disagreeing about arithmetic.
+ *
+ * The exclusions come from #82 and are applied here, once:
+ *   - a harness reporting zero tokens is not a harness
+ *   - `unknown` is not a model name, so it never ranks and never leads a row
+ *   - a stack with `publishCost` off has no cost, not a cost of zero
+ *   - stale (no sync in 7 days) is listed, never ranked
+ *
+ * The one arithmetic decision this file makes is the **denominator for a model
+ * share**: attributed tokens, not all measured tokens. 14.8% of the biggest
+ * stack on the site carries no model name, and a set of shares that silently
+ * sums to 85% is a worse lie than a stated exclusion.
+ */
+
+import { LIVING_WINDOW_MS, type ProtoModel, type ProtoStack } from "./fixtures";
+
+/** Token-weighted asks "how much of the spend"; stack-weighted asks "how many
+ *  builders". #92 has to pick one for every share the page prints. */
+export type Weight = "tokens" | "stacks";
+
+export type RankedStack = ProtoStack & {
+	/** 1-based across the whole living set. `null` for a stale stack. */
+	readonly rank: number | null;
+	readonly living: boolean;
+	/** Highest-token model that is not `unknown`, or null when none is named. */
+	readonly topModel: { readonly name: string; readonly share: number } | null;
+	/** Share of the leader's tokens. Drives the in-row bar. */
+	readonly ofLeader: number;
+	/** Harnesses that actually logged something. */
+	readonly activeHarnesses: readonly string[];
+	/** Dollars per million measured tokens, or null without a published cost. */
+	readonly costPerMtok: number | null;
+};
+
+export type Ranking = {
+	readonly key: string;
+	/** Share of attributed tokens across the population, 0..1. */
+	readonly tokenShare: number;
+	/** How many stacks use it at all. */
+	readonly stackCount: number;
+	/** `stackCount` over the population, 0..1. */
+	readonly stackShare: number;
+	/** How many stacks it leads. The honest "top model on N of M" number. */
+	readonly leadsCount: number;
+};
+
+export type Aggregate = {
+	readonly nowMs: number;
+	readonly living: readonly RankedStack[];
+	readonly stale: readonly RankedStack[];
+	readonly all: readonly RankedStack[];
+	readonly stackCount: number;
+	readonly livingCount: number;
+	readonly totalTokens: number;
+	readonly totalSessions: number;
+	/** Sum of every published lower bound. Itself a lower bound. */
+	readonly spendLowerBound: number;
+	/** How many stacks publish a cost at all. */
+	readonly costPublishers: number;
+	/** Token-weighted price coverage across the stacks that publish a cost. */
+	readonly spendCoverage: number;
+	/** Share of measured tokens carrying no model name. */
+	readonly unattributedShare: number;
+	readonly models: readonly Ranking[];
+	readonly harnesses: readonly Ranking[];
+	readonly tools: readonly Ranking[];
+	/** Widest and narrowest sync date in the population, in ms. */
+	readonly windowSpreadDays: number;
+};
+
+const NAMED = (m: ProtoModel) => m.name !== "unknown";
+
+function topModelOf(s: ProtoStack): RankedStack["topModel"] {
+	const named = s.models.filter(NAMED);
+	if (named.length === 0 || s.tokens === 0) return null;
+	const best = named.reduce((a, b) => (b.tokens > a.tokens ? b : a));
+	return { name: best.name, share: best.tokens / s.tokens };
+}
+
+function rank(
+	entries: Map<string, { tokens: number; stacks: number; leads: number }>,
+	attributed: number,
+	population: number,
+): Ranking[] {
+	return [...entries.entries()]
+		.map(([key, v]) => ({
+			key,
+			tokenShare: attributed > 0 ? v.tokens / attributed : 0,
+			stackCount: v.stacks,
+			stackShare: population > 0 ? v.stacks / population : 0,
+			leadsCount: v.leads,
+		}))
+		.sort((a, b) => b.tokenShare - a.tokenShare || b.stackCount - a.stackCount);
+}
+
+export function aggregate(
+	stacks: readonly ProtoStack[],
+	nowMs: number,
+): Aggregate {
+	const decorated = stacks.map((s) => {
+		const living = nowMs - s.lastSyncMs <= LIVING_WINDOW_MS;
+		return { s, living };
+	});
+
+	const livingSorted = decorated
+		.filter((d) => d.living)
+		.sort((a, b) => b.s.tokens - a.s.tokens);
+	const staleSorted = decorated
+		.filter((d) => !d.living)
+		.sort((a, b) => b.s.tokens - a.s.tokens);
+
+	const leader = livingSorted[0]?.s.tokens ?? staleSorted[0]?.s.tokens ?? 1;
+
+	const decorate = (s: ProtoStack, r: number | null, living: boolean) => ({
+		...s,
+		rank: r,
+		living,
+		topModel: topModelOf(s),
+		ofLeader: leader > 0 ? s.tokens / leader : 0,
+		activeHarnesses: s.harnesses.filter((h) => h.tokens > 0).map((h) => h.name),
+		costPerMtok:
+			s.spendLowerBound !== null && s.tokens > 0
+				? s.spendLowerBound / (s.tokens / 1_000_000)
+				: null,
+	});
+
+	const living = livingSorted.map((d, i) => decorate(d.s, i + 1, true));
+	const stale = staleSorted.map((d) => decorate(d.s, null, false));
+	const all = [...living, ...stale];
+
+	// --- population figures -------------------------------------------------
+
+	let totalTokens = 0;
+	let attributed = 0;
+	let totalSessions = 0;
+	let spendLowerBound = 0;
+	let costPublishers = 0;
+	let coveredTokens = 0;
+	let publisherTokens = 0;
+
+	const models = new Map<
+		string,
+		{ tokens: number; stacks: number; leads: number }
+	>();
+	const harnesses = new Map<
+		string,
+		{ tokens: number; stacks: number; leads: number }
+	>();
+	const tools = new Map<
+		string,
+		{ tokens: number; stacks: number; leads: number }
+	>();
+
+	const bump = (
+		map: Map<string, { tokens: number; stacks: number; leads: number }>,
+		key: string,
+		tokens: number,
+		leads: boolean,
+	) => {
+		const cur = map.get(key) ?? { tokens: 0, stacks: 0, leads: 0 };
+		cur.tokens += tokens;
+		cur.stacks += 1;
+		if (leads) cur.leads += 1;
+		map.set(key, cur);
+	};
+
+	for (const s of all) {
+		totalTokens += s.tokens;
+		totalSessions += s.sessions;
+		if (s.spendLowerBound !== null) {
+			spendLowerBound += s.spendLowerBound;
+			costPublishers += 1;
+			coveredTokens += s.tokens * s.coverage;
+			publisherTokens += s.tokens;
+		}
+		for (const m of s.models) {
+			if (!NAMED(m)) continue;
+			attributed += m.tokens;
+			bump(models, m.name, m.tokens, s.topModel?.name === m.name);
+		}
+		// A zero-token harness is not a harness (#82).
+		const active = s.harnesses.filter((h) => h.tokens > 0);
+		const leadHarness = active.reduce(
+			(a, b) => (a === null || b.tokens > a.tokens ? b : a),
+			null as { name: string; tokens: number } | null,
+		);
+		for (const h of active) {
+			bump(harnesses, h.name, h.tokens, leadHarness?.name === h.name);
+		}
+		// A tool has no tokens, so it can only ever be stack-weighted.
+		for (const t of s.tools) bump(tools, t, 0, false);
+	}
+
+	const syncs = all.map((s) => s.lastSyncMs);
+	const spread =
+		syncs.length > 1
+			? (Math.max(...syncs) - Math.min(...syncs)) / (24 * 60 * 60 * 1000)
+			: 0;
+
+	return {
+		nowMs,
+		living,
+		stale,
+		all,
+		stackCount: all.length,
+		livingCount: living.length,
+		totalTokens,
+		totalSessions,
+		spendLowerBound,
+		costPublishers,
+		spendCoverage: publisherTokens > 0 ? coveredTokens / publisherTokens : 0,
+		unattributedShare:
+			totalTokens > 0 ? (totalTokens - attributed) / totalTokens : 0,
+		models: rank(models, attributed, all.length),
+		harnesses: rank(harnesses, attributed, all.length),
+		tools: [...rank(tools, 1, all.length)].sort(
+			(a, b) => b.stackCount - a.stackCount,
+		),
+		windowSpreadDays: spread,
+	};
+}
+
+/**
+ * The sentence a ranking makes under one weighting.
+ *
+ * This is the whole of #92's second ride-along question, in one function. The
+ * two sentences describe the same row and disagree completely, which is why the
+ * page cannot print both without saying which it means.
+ */
+export function shareSentence(
+	r: Ranking,
+	weight: Weight,
+	population: number,
+): string {
+	if (weight === "tokens") {
+		return `${Math.round(r.tokenShare * 100)}% of all measured tokens`;
+	}
+	// #92 wrote this sentence as "top model on 3 of 4", not "used by 4 of 4".
+	// Leading a stack is the claim about the population; merely appearing in one
+	// is nearly always true and says almost nothing.
+	return `top on ${r.leadsCount} of ${population} measured stacks`;
+}
+
+/**
+ * The value a chart plots under one weighting, 0..1.
+ *
+ * Stack-weighted plots *leads*, so the bar and the sentence make the same
+ * claim. `stackShare` stays on the row for the muted "and appears on N more".
+ */
+export function weightedValue(
+	r: Ranking,
+	weight: Weight,
+	population: number,
+): number {
+	if (weight === "tokens") return r.tokenShare;
+	return population > 0 ? r.leadsCount / population : 0;
+}

--- a/src/features/leaderboard/proto/aggregate.ts
+++ b/src/features/leaderboard/proto/aggregate.ts
@@ -34,6 +34,12 @@ export type RankedStack = ProtoStack & {
 	readonly activeHarnesses: readonly string[];
 	/** Dollars per million measured tokens, or null without a published cost. */
 	readonly costPerMtok: number | null;
+	/**
+	 * Change across the readings this stack has, as a share of the first one.
+	 * `null` with fewer than two readings — no trend exists, and a zero there
+	 * would claim a flat line nobody observed.
+	 */
+	readonly trend: number | null;
 };
 
 export type Ranking = {
@@ -125,6 +131,11 @@ export function aggregate(
 		costPerMtok:
 			s.spendLowerBound !== null && s.tokens > 0
 				? s.spendLowerBound / (s.tokens / 1_000_000)
+				: null,
+		trend:
+			s.history.length >= 2 && s.history[0].value > 0
+				? (s.history[s.history.length - 1].value - s.history[0].value) /
+					s.history[0].value
 				: null,
 	});
 

--- a/src/features/leaderboard/proto/bits.tsx
+++ b/src/features/leaderboard/proto/bits.tsx
@@ -1,0 +1,83 @@
+/**
+ * PROTOTYPE — throwaway. Wayfinder ticket #92 (map #76).
+ *
+ * The one thing all three variants share: a pager that stays one line at 50
+ * pages. Everything else about layout is a variant's own business.
+ */
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/** first · … · n-1 · n · n+1 · … · last */
+function pageWindow(page: number, total: number): (number | "gap")[] {
+	if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
+	const out: (number | "gap")[] = [1];
+	const from = Math.max(2, page - 1);
+	const to = Math.min(total - 1, page + 1);
+	if (from > 2) out.push("gap");
+	for (let i = from; i <= to; i++) out.push(i);
+	if (to < total - 1) out.push("gap");
+	out.push(total);
+	return out;
+}
+
+export function Pager({
+	page,
+	totalPages,
+	onPage,
+	className,
+}: {
+	readonly page: number;
+	readonly totalPages: number;
+	readonly onPage: (p: number) => void;
+	readonly className?: string;
+}) {
+	if (totalPages <= 1) return null;
+	return (
+		<div className={cn("flex items-center justify-center gap-2", className)}>
+			<button
+				type="button"
+				onClick={() => onPage(Math.max(1, page - 1))}
+				disabled={page <= 1}
+				aria-label="previous page"
+				className="flex size-9 items-center justify-center border border-stroke-strong text-fg-muted transition-colors hover:border-accent-lime hover:text-accent-lime disabled:cursor-not-allowed disabled:opacity-30"
+			>
+				<ChevronLeft className="size-4" />
+			</button>
+			{pageWindow(page, totalPages).map((p, i) =>
+				p === "gap" ? (
+					<span
+						// biome-ignore lint/suspicious/noArrayIndexKey: a gap has no identity
+						key={`gap-${i}`}
+						className="px-1 font-mono text-sm text-fg-muted"
+					>
+						…
+					</span>
+				) : (
+					<button
+						key={p}
+						type="button"
+						onClick={() => onPage(p)}
+						className={cn(
+							"flex h-9 min-w-9 items-center justify-center border px-2 font-mono text-sm font-bold transition-colors",
+							p === page
+								? "border-accent-lime bg-accent-lime text-accent-lime-contrast"
+								: "border-stroke-strong text-fg-muted hover:border-accent-lime hover:text-accent-lime",
+						)}
+					>
+						{p}
+					</button>
+				),
+			)}
+			<button
+				type="button"
+				onClick={() => onPage(Math.min(totalPages, page + 1))}
+				disabled={page >= totalPages}
+				aria-label="next page"
+				className="flex size-9 items-center justify-center border border-stroke-strong text-fg-muted transition-colors hover:border-accent-lime hover:text-accent-lime disabled:cursor-not-allowed disabled:opacity-30"
+			>
+				<ChevronRight className="size-4" />
+			</button>
+		</div>
+	);
+}

--- a/src/features/leaderboard/proto/fixtures.ts
+++ b/src/features/leaderboard/proto/fixtures.ts
@@ -56,6 +56,16 @@ export type ProtoStack = {
 	readonly models: readonly ProtoModel[];
 	readonly harnesses: readonly ProtoHarness[];
 	readonly tools: readonly string[];
+	/**
+	 * Every published snapshot inside the window, oldest first.
+	 *
+	 * The value is the **rolling 30-day total as it stood that day**, which is
+	 * what `measuredSnapshots` holds — so the last point always equals `tokens`.
+	 * It is a level and not a rate, so it can fall: a quiet week drops the far
+	 * end out of the window. #80 measured the best history on the site at 7
+	 * readings over 5 days, and one real stack has exactly one reading.
+	 */
+	readonly history: readonly { readonly at: number; readonly value: number }[];
 };
 
 const B = 1_000_000_000;
@@ -103,6 +113,13 @@ const REAL_STACKS: readonly ProtoStack[] = [
 			{ name: "claude-code", tokens: 12.03 * B },
 		],
 		tools: ["Codex", "Claude Code", "Linear", "Vercel", "Neon"],
+		history: [
+			{ at: day(7, 29), value: 240.1 * B },
+			{ at: day(7, 30), value: 255.4 * B },
+			{ at: day(7, 31), value: 267.9 * B },
+			{ at: day(8, 1), value: 279.2 * B },
+			{ at: day(8, 2), value: 291.35 * B },
+		],
 	},
 	{
 		id: "gvaste",
@@ -125,6 +142,12 @@ const REAL_STACKS: readonly ProtoStack[] = [
 		],
 		harnesses: [{ name: "codex", tokens: 5.88 * B }],
 		tools: ["Codex", "Cursor", "Supabase"],
+		// Falling. The window forgot a busy week at its far end, so the total
+		// dropped without anyone doing less today.
+		history: [
+			{ at: day(7, 27), value: 7.42 * B },
+			{ at: day(8, 1), value: 5.88 * B },
+		],
 	},
 	{
 		id: "brilliant-insane",
@@ -146,6 +169,8 @@ const REAL_STACKS: readonly ProtoStack[] = [
 		],
 		harnesses: [{ name: "codex", tokens: 4.77 * B }],
 		tools: ["Codex", "Claude Code", "Railway"],
+		// One reading. A line needs two, so this row can draw no trend at all.
+		history: [{ at: day(8, 2), value: 4.77 * B }],
 	},
 	{
 		id: "alper",
@@ -174,6 +199,15 @@ const REAL_STACKS: readonly ProtoStack[] = [
 			{ name: "gemini", tokens: 0 },
 		],
 		tools: ["Claude Code", "Codex", "Convex", "Better Auth", "Resend", "Biome"],
+		history: [
+			{ at: day(7, 28), value: 3.11 * B },
+			{ at: day(7, 29), value: 3.58 * B },
+			{ at: day(7, 30), value: 4.02 * B },
+			{ at: day(7, 31), value: 4.35 * B },
+			{ at: day(8, 1), value: 4.6 * B },
+			{ at: day(8, 2), value: 4.68 * B },
+			{ at: day(8, 3), value: 4.71 * B },
+		],
 	},
 ];
 
@@ -432,6 +466,20 @@ function generate(count: number, seed: number, nowMs: number): ProtoStack[] {
 		const creator = `${pick(r, FIRST)} ${pick(r, LAST)}`;
 		const handle = creator.toLowerCase().replace(/[^a-z]/g, "");
 
+		// A short walk backwards from the last sync, one reading per day, ending
+		// on today's total. A fifth of them trend down.
+		const readings = 1 + Math.floor(r() * 13);
+		const direction = r() < 0.2 ? -1 : 1;
+		const history: { at: number; value: number }[] = [];
+		let level = tokens;
+		for (let k = 0; k < readings; k++) {
+			history.unshift({
+				at: lastSyncMs - k * 24 * 60 * 60 * 1000,
+				value: Math.max(tokens * 0.05, level),
+			});
+			level -= direction * tokens * (0.02 + r() * 0.09);
+		}
+
 		out.push({
 			id: `gen-${seed}-${i}`,
 			name,
@@ -448,6 +496,7 @@ function generate(count: number, seed: number, nowMs: number): ProtoStack[] {
 			models,
 			harnesses,
 			tools,
+			history,
 		});
 	}
 	return out;

--- a/src/features/leaderboard/proto/fixtures.ts
+++ b/src/features/leaderboard/proto/fixtures.ts
@@ -1,0 +1,481 @@
+/**
+ * PROTOTYPE — throwaway. Wayfinder ticket #92 (map #76).
+ *
+ * The population the three variants are judged against.
+ *
+ * Three densities, because the binding constraint on #92 is **do not fit the
+ * design to four stacks**:
+ *
+ *   real   — the 4 stacks measured on prod on 2026-08-04, at their real numbers
+ *   grown  — ~50 stacks, the same 4 inside a plausible adopted population
+ *   scale  — ~500 stacks, same shape
+ *
+ * The `real` rows carry the repriced figures from the #92 body, which came out
+ * of the #93 investigation. They are the truth as of 2026-08-04, not what prod
+ * publishes today (prod still shows the 11x-wrong frozen cost).
+ *
+ * Slugs and handles for three of the four are placeholders — a prototype link
+ * does not have to resolve. `brilliant-insane` is the real slug.
+ *
+ * The model splits below reproduce the shares stated in #92 exactly. The tool
+ * lists are illustrative: no tool-adoption figure left the ticket.
+ */
+
+/** One model inside a stack's 30-day window. */
+export type ProtoModel = {
+	readonly name: string;
+	readonly tokens: number;
+};
+
+/** One harness inside a stack's window. A zero-token harness is kept here on
+ *  purpose — excluding it is the consumer's job, and #82 locked that rule. */
+export type ProtoHarness = {
+	readonly name: string;
+	readonly tokens: number;
+};
+
+export type ProtoStack = {
+	readonly id: string;
+	readonly name: string;
+	readonly slug: string;
+	readonly creator: string;
+	readonly handle: string;
+	/** 30-day measured tokens. The ranking metric, locked in #82. */
+	readonly tokens: number;
+	readonly sessions: number;
+	readonly lastSyncMs: number;
+	/** #82: a stack with the cost toggle off shows no cost at all, ever. */
+	readonly publishCost: boolean;
+	/** Always a lower bound (#93). `null` when `publishCost` is off. */
+	readonly spendLowerBound: number | null;
+	/** Share of this stack's tokens carrying a citable price. */
+	readonly coverage: number;
+	/** True when nothing had to be estimated — the CLI priced every response. */
+	readonly spendExact: boolean;
+	/** Descending by tokens. `unknown` is present and must not render. */
+	readonly models: readonly ProtoModel[];
+	readonly harnesses: readonly ProtoHarness[];
+	readonly tools: readonly string[];
+};
+
+const B = 1_000_000_000;
+
+/** UTC midnight for a 2026 day, so every fixture date is stable across zones. */
+function day(month: number, date: number): number {
+	return Date.UTC(2026, month - 1, date, 9, 0, 0);
+}
+
+/**
+ * The four stacks measured on prod, 2026-08-04.
+ *
+ * Every rendering case #92 named lives in here:
+ *   - one stack at 95% of all tokens .................. OrcDev
+ *   - a second model of `unknown`, 43B, must not render  OrcDev
+ *   - a stack with one harness ........................ GVASTE, Brilliant Insane
+ *   - a harness reporting all zeros ................... Alper's Agent Stack
+ *   - 100% coverage beside 85.2% coverage ............. Alper's beside OrcDev
+ *   - a stale stack in the group below ................ see CLOCKS below
+ */
+const REAL_STACKS: readonly ProtoStack[] = [
+	{
+		id: "orcdev",
+		name: "OrcDev",
+		slug: "orcdev-a1b2c3",
+		creator: "OrcDev",
+		handle: "orcdev",
+		tokens: 291.35 * B,
+		sessions: 1347,
+		lastSyncMs: day(8, 2),
+		publishCost: true,
+		spendLowerBound: 167_331,
+		coverage: 0.852,
+		spendExact: false,
+		models: [
+			{ name: "gpt-5.6-sol", tokens: 233.08 * B },
+			// 14.8% of the biggest stack on the site has no model name. This is
+			// the whole of the coverage gap, and it must never draw a bar.
+			{ name: "unknown", tokens: 43.12 * B },
+			{ name: "gpt-5.6-codex", tokens: 9.906 * B },
+			{ name: "claude-opus-5", tokens: 5.244 * B },
+		],
+		harnesses: [
+			{ name: "codex", tokens: 279.32 * B },
+			{ name: "claude-code", tokens: 12.03 * B },
+		],
+		tools: ["Codex", "Claude Code", "Linear", "Vercel", "Neon"],
+	},
+	{
+		id: "gvaste",
+		name: "GVASTE",
+		slug: "gvaste-d4e5f6",
+		creator: "GVASTE",
+		handle: "gvaste",
+		tokens: 5.88 * B,
+		sessions: 138,
+		lastSyncMs: day(8, 1),
+		publishCost: true,
+		// Published nothing before #93 — the CLI could not price gpt-5.6 at all.
+		spendLowerBound: 3_648,
+		coverage: 0.977,
+		spendExact: false,
+		models: [
+			{ name: "gpt-5.6-sol", tokens: 4.998 * B },
+			{ name: "gpt-5.6", tokens: 0.74676 * B },
+			{ name: "unknown", tokens: 0.13524 * B },
+		],
+		harnesses: [{ name: "codex", tokens: 5.88 * B }],
+		tools: ["Codex", "Cursor", "Supabase"],
+	},
+	{
+		id: "brilliant-insane",
+		name: "Brilliant Insane",
+		slug: "brilliant-insane",
+		creator: "Brilliant Insane",
+		handle: "brilliantinsane",
+		tokens: 4.77 * B,
+		sessions: 475,
+		lastSyncMs: day(8, 2),
+		publishCost: true,
+		spendLowerBound: 3_642,
+		coverage: 0.996,
+		spendExact: false,
+		models: [
+			{ name: "gpt-5.6-sol", tokens: 4.3407 * B },
+			{ name: "gpt-5.6-codex", tokens: 0.41022 * B },
+			{ name: "unknown", tokens: 0.01908 * B },
+		],
+		harnesses: [{ name: "codex", tokens: 4.77 * B }],
+		tools: ["Codex", "Claude Code", "Railway"],
+	},
+	{
+		id: "alper",
+		name: "Alper's Agent Stack",
+		slug: "alpers-agent-stack-g7h8i9",
+		creator: "Alper Ortac",
+		handle: "alper",
+		tokens: 4.71 * B,
+		sessions: 577,
+		lastSyncMs: day(8, 3),
+		publishCost: true,
+		// The only exact figure on the board: the CLI priced every response.
+		spendLowerBound: 6_042,
+		coverage: 1,
+		spendExact: true,
+		models: [
+			{ name: "claude-opus-5", tokens: 1.884 * B },
+			{ name: "claude-sonnet-5", tokens: 1.5543 * B },
+			{ name: "claude-haiku-4-5", tokens: 1.263693 * B },
+			{ name: "gpt-5.6-sol", tokens: 0.008007 * B },
+		],
+		harnesses: [
+			{ name: "claude-code", tokens: 4.702 * B },
+			{ name: "codex", tokens: 0.008 * B },
+			// A configured harness that logged nothing. #82 excludes it.
+			{ name: "gemini", tokens: 0 },
+		],
+		tools: ["Claude Code", "Codex", "Convex", "Better Auth", "Resend", "Biome"],
+	},
+];
+
+/**
+ * The two clocks.
+ *
+ * All four real stacks synced within 7 days of 2026-08-05, so `now` has an
+ * empty stale group. Moving the clock forward makes them fall out one by one,
+ * against their real sync dates — no invented stack needed:
+ *
+ *   now    Aug 5  — 4 ranked, 0 quiet
+ *   quiet  Aug 9  — 1 ranked, 3 quiet
+ *   dark   Aug 12 — 0 ranked, 4 quiet, and the board has nothing to rank
+ *
+ * `dark` is not a stunt. Four stacks are one quiet week away from it.
+ */
+export const CLOCKS = {
+	now: Date.UTC(2026, 7, 5, 12, 0, 0),
+	quiet: Date.UTC(2026, 7, 9, 12, 0, 0),
+	dark: Date.UTC(2026, 7, 12, 12, 0, 0),
+} as const;
+
+export type ClockKey = keyof typeof CLOCKS;
+
+/** Living means synced inside the last 7 days. Locked in #82. */
+export const LIVING_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Generated populations
+// ---------------------------------------------------------------------------
+
+/** A seeded LCG, so a reload draws the same population every time. */
+function rng(seed: number): () => number {
+	let s = seed >>> 0;
+	return () => {
+		s = (s * 1_664_525 + 1_013_904_223) >>> 0;
+		return s / 4_294_967_296;
+	};
+}
+
+const ADJECTIVES = [
+	"Quiet",
+	"Blunt",
+	"Iron",
+	"Paper",
+	"Neon",
+	"Slow",
+	"Loud",
+	"Small",
+	"Feral",
+	"Plain",
+	"Bright",
+	"Hollow",
+	"Rough",
+	"Sharp",
+	"Deep",
+	"Wide",
+	"Thin",
+	"Odd",
+	"Warm",
+	"Cold",
+	"Stray",
+	"Bold",
+	"Lean",
+	"Dense",
+];
+const NOUNS = [
+	"Compiler",
+	"Bench",
+	"Foundry",
+	"Ledger",
+	"Harbor",
+	"Anvil",
+	"Lantern",
+	"Signal",
+	"Quarry",
+	"Beacon",
+	"Cutter",
+	"Mill",
+	"Forge",
+	"Loom",
+	"Drift",
+	"Relay",
+	"Vault",
+	"Prism",
+	"Ember",
+	"Rift",
+	"Atlas",
+	"Cinder",
+	"Pylon",
+	"Marrow",
+];
+const FIRST = [
+	"Mara",
+	"Devi",
+	"Ilya",
+	"Nour",
+	"Sami",
+	"Tove",
+	"Ravi",
+	"Juno",
+	"Kian",
+	"Lena",
+	"Oyin",
+	"Paz",
+	"Rune",
+	"Suki",
+	"Theo",
+	"Vera",
+	"Yusuf",
+	"Zara",
+];
+const LAST = [
+	"Okafor",
+	"Lindqvist",
+	"Haddad",
+	"Moreau",
+	"Silva",
+	"Novak",
+	"Reyes",
+	"Ahmadi",
+	"Kowal",
+	"Berg",
+	"Tan",
+	"Iyer",
+	"Petrov",
+	"Duarte",
+	"Fischer",
+];
+
+/** The model catalog a generated stack draws from, with a rough house share. */
+const MODEL_POOL = [
+	{ name: "gpt-5.6-sol", weight: 30 },
+	{ name: "claude-opus-5", weight: 22 },
+	{ name: "claude-sonnet-5", weight: 20 },
+	{ name: "gpt-5.6-codex", weight: 14 },
+	{ name: "claude-haiku-4-5", weight: 10 },
+	{ name: "gpt-5.6", weight: 9 },
+	{ name: "gemini-3-pro", weight: 7 },
+	{ name: "grok-code-2", weight: 4 },
+	{ name: "kimi-k3", weight: 3 },
+	{ name: "deepseek-v4", weight: 3 },
+];
+
+const HARNESS_POOL = ["claude-code", "codex", "gemini-cli", "opencode", "amp"];
+
+const TOOL_POOL = [
+	"Claude Code",
+	"Codex",
+	"Cursor",
+	"Vercel",
+	"Supabase",
+	"Convex",
+	"Linear",
+	"Railway",
+	"Neon",
+	"Biome",
+	"Playwright",
+	"Resend",
+	"Sentry",
+	"Figma",
+	"Notion",
+	"PostHog",
+	"Tailscale",
+	"Fly.io",
+	"Better Auth",
+	"Turso",
+];
+
+/** Price per million tokens, only used to make generated spend self-consistent. */
+const RATE_PER_MTOK = 0.6;
+
+function pick<T>(r: () => number, list: readonly T[]): T {
+	return list[Math.floor(r() * list.length)];
+}
+
+function generate(count: number, seed: number, nowMs: number): ProtoStack[] {
+	const r = rng(seed);
+	const out: ProtoStack[] = [];
+
+	for (let i = 0; i < count; i++) {
+		// A long tail: the head is big, the body is not, and most of the
+		// population sits near the floor. Rank i is roughly i^-1.15.
+		const decay = 420 * (i + 1) ** -1.15;
+		const tokens = Math.max(0.04, decay * (0.45 + r() * 1.4)) * B;
+
+		// Model mix: three to six named models plus, sometimes, an unnamed slice.
+		const modelCount = 3 + Math.floor(r() * 4);
+		const chosen: string[] = [];
+		while (chosen.length < modelCount) {
+			const m = pick(r, MODEL_POOL);
+			if (!chosen.includes(m.name)) chosen.push(m.name);
+		}
+		// The leader takes a dominant share more often than not — that is what
+		// the real four look like, and it is what makes a token-weighted share
+		// read as a sentence about one stack.
+		const leadShare = 0.34 + r() * 0.55;
+		const unknownShare = r() < 0.45 ? r() * 0.22 : 0;
+		const rest = 1 - leadShare - unknownShare;
+		const restWeights = chosen.slice(1).map(() => 0.2 + r());
+		const restTotal = restWeights.reduce((a, b) => a + b, 0) || 1;
+
+		const models: ProtoModel[] = [
+			{ name: chosen[0], tokens: tokens * leadShare },
+			...chosen.slice(1).map((name, k) => ({
+				name,
+				tokens: (tokens * rest * restWeights[k]) / restTotal,
+			})),
+		];
+		if (unknownShare > 0) {
+			models.push({ name: "unknown", tokens: tokens * unknownShare });
+		}
+		models.sort((a, b) => b.tokens - a.tokens);
+
+		// Harnesses: one for a third of the population, two or three otherwise,
+		// and now and then one that logged nothing at all.
+		const harnessCount = r() < 0.34 ? 1 : 1 + Math.floor(r() * 3);
+		const names: string[] = [];
+		while (names.length < harnessCount) {
+			const h = pick(r, HARNESS_POOL);
+			if (!names.includes(h)) names.push(h);
+		}
+		const hWeights = names.map(() => 0.15 + r());
+		const hTotal = hWeights.reduce((a, b) => a + b, 0);
+		const harnesses: ProtoHarness[] = names.map((name, k) => ({
+			name,
+			tokens: (tokens * hWeights[k]) / hTotal,
+		}));
+		if (r() < 0.18) {
+			const idle = HARNESS_POOL.find((h) => !names.includes(h));
+			if (idle) harnesses.push({ name: idle, tokens: 0 });
+		}
+
+		const toolCount = 3 + Math.floor(r() * 6);
+		const tools: string[] = [];
+		while (tools.length < toolCount) {
+			const t = pick(r, TOOL_POOL);
+			if (!tools.includes(t)) tools.push(t);
+		}
+
+		// A fifth of the population has gone quiet. Their last sync is anywhere
+		// from just past the window to two months back.
+		const stale = r() < 0.22;
+		const ageDays = stale ? 8 + r() * 52 : r() * 6.5;
+		const lastSyncMs = nowMs - ageDays * 24 * 60 * 60 * 1000;
+
+		const coverage = 1 - unknownShare - (r() < 0.3 ? r() * 0.12 : 0);
+		// A quarter keep cost private. #82: they show no cost at all.
+		const publishCost = r() > 0.26;
+		const priced = tokens * coverage;
+		const spendLowerBound = publishCost
+			? Math.round(((priced / 1_000_000) * RATE_PER_MTOK * (0.6 + r())) / 1)
+			: null;
+
+		const name = `${pick(r, ADJECTIVES)} ${pick(r, NOUNS)}`;
+		const creator = `${pick(r, FIRST)} ${pick(r, LAST)}`;
+		const handle = creator.toLowerCase().replace(/[^a-z]/g, "");
+
+		out.push({
+			id: `gen-${seed}-${i}`,
+			name,
+			slug: `${name.toLowerCase().replace(/ /g, "-")}-${(seed + i).toString(36)}`,
+			creator,
+			handle,
+			tokens,
+			sessions: Math.max(1, Math.round((tokens / B) * (2 + r() * 9))),
+			lastSyncMs,
+			publishCost,
+			spendLowerBound,
+			coverage,
+			spendExact: coverage >= 0.999 && r() < 0.25,
+			models,
+			harnesses,
+			tools,
+		});
+	}
+	return out;
+}
+
+export type DensityKey = "real" | "grown" | "scale";
+
+export const DENSITY_LABEL: Record<DensityKey, string> = {
+	real: "4 — prod today",
+	grown: "50 — adopted",
+	scale: "500 — at scale",
+};
+
+/**
+ * The population for a density.
+ *
+ * The four real stacks stay in every population at their real numbers, so the
+ * cases they carry (an `unknown` second model, a zero-token harness, an exact
+ * cost beside three estimates) never disappear as the board grows.
+ */
+export function populationFor(
+	density: DensityKey,
+	nowMs: number,
+): readonly ProtoStack[] {
+	if (density === "real") return REAL_STACKS;
+	const count = density === "grown" ? 46 : 496;
+	return [
+		...REAL_STACKS,
+		...generate(count, density === "grown" ? 7 : 19, nowMs),
+	];
+}

--- a/src/features/leaderboard/proto/format.ts
+++ b/src/features/leaderboard/proto/format.ts
@@ -1,0 +1,63 @@
+/**
+ * PROTOTYPE — throwaway. Wayfinder ticket #92 (map #76).
+ *
+ * Fixed to `en-US` and UTC, the same rule the real chart module follows: the
+ * server cannot know a visitor's locale, and a mismatch is a hydration error.
+ */
+
+const money = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	maximumFractionDigits: 0,
+});
+
+const moneyCompact = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	notation: "compact",
+	maximumFractionDigits: 1,
+});
+
+const plain = new Intl.NumberFormat("en-US");
+
+const dayShort = new Intl.DateTimeFormat("en-US", {
+	timeZone: "UTC",
+	month: "short",
+	day: "numeric",
+});
+
+/** 291.4B, 5.9B, 231K. */
+export function tokens(n: number): string {
+	if (n >= 1e9) return `${(n / 1e9).toFixed(n >= 100e9 ? 1 : 2)}B`;
+	if (n >= 1e6) return `${(n / 1e6).toFixed(1)}M`;
+	return plain.format(Math.round(n));
+}
+
+export function usd(n: number): string {
+	return money.format(n);
+}
+
+export function usdCompact(n: number): string {
+	return moneyCompact.format(n);
+}
+
+export function count(n: number): string {
+	return plain.format(n);
+}
+
+export function pct(share: number, digits = 0): string {
+	return `${(share * 100).toFixed(digits)}%`;
+}
+
+export function shortDay(ms: number): string {
+	return dayShort.format(new Date(ms));
+}
+
+/** "2 days ago", "today". Rounded down, so it never overstates freshness. */
+export function ago(ms: number, nowMs: number): string {
+	const days = Math.floor((nowMs - ms) / (24 * 60 * 60 * 1000));
+	if (days <= 0) return "today";
+	if (days === 1) return "yesterday";
+	if (days < 60) return `${days}d ago`;
+	return `${Math.floor(days / 30)}mo ago`;
+}

--- a/src/features/measured/MeasuredSection.tsx
+++ b/src/features/measured/MeasuredSection.tsx
@@ -24,6 +24,7 @@ import {
 	OWNER_NOT_MEASURED_BODY,
 	OWNER_NOT_MEASURED_TITLE,
 	PRIVACY_FOOTNOTE,
+	pricedShareLine,
 	SYNC_CMD,
 	SYNC_CMD_COMMENT,
 	stalenessLine,
@@ -83,6 +84,7 @@ function Reading({ snapshot }: { snapshot: MeasuredSnapshot }) {
 	// The COMBINED headline (#66 decision 2): tokens, sessions and dollars sum
 	// honestly across harnesses; each harness keeps its own section below.
 	const cost = totalUSD(snapshot);
+	const pricedShare = pricedShareLine(snapshot);
 	const multiHarness = snapshot.harnesses.length > 1;
 
 	return (
@@ -91,12 +93,12 @@ function Reading({ snapshot }: { snapshot: MeasuredSnapshot }) {
 			<div>
 				<p className="font-mono text-5xl font-black leading-none text-fg-primary md:text-6xl">
 					{cost !== null
-						? `≈${fmtUSD(cost)}`
+						? `≥${fmtUSD(cost)}`
 						: fmtTokens(snapshot.activity.totalTokens)}
 				</p>
 				<p className="mt-2 text-sm text-fg-muted">
 					{cost !== null
-						? `at API prices, over the last ${snapshot.window.days} days`
+						? `at least, at API prices, over the last ${snapshot.window.days} days`
 						: `tokens over the last ${snapshot.window.days} days`}
 				</p>
 
@@ -119,6 +121,11 @@ function Reading({ snapshot }: { snapshot: MeasuredSnapshot }) {
 						<p className={cn(MONO_LABEL, "text-fg-muted")}>
 							prices: {snapshot.pricingTable}
 						</p>
+					)}
+					{/* What the figure above leaves out. Silent at full coverage —
+					    "priced 100%" is noise, and the ≥ already carries the rest. */}
+					{pricedShare !== null && (
+						<p className={cn(MONO_LABEL, "text-fg-muted")}>{pricedShare}</p>
 					)}
 				</div>
 			</div>

--- a/src/features/measured/__tests__/copy.test.ts
+++ b/src/features/measured/__tests__/copy.test.ts
@@ -13,6 +13,7 @@ import {
 	keptPrivate,
 	leadModelLine,
 	modelLabel,
+	pricedShareLine,
 	totalUSD,
 } from "../copy";
 import { buildHarness, buildSnapshot, withoutCost } from "./fixture";
@@ -27,17 +28,33 @@ describe("the dollar figure", () => {
 		expect(totalUSD(withoutCost())).toBeNull();
 	});
 
-	it("is absent when the snapshot carries no pricing table", () => {
+	it("is absent when no table cites the figure", () => {
 		// A price the reader cannot date is a price we do not print. Without this
 		// the display would show dollars with no version beside them.
-		const s = buildSnapshot({ pricingTable: null });
+		const base = buildSnapshot();
+		const s = buildSnapshot({
+			cost: base.cost && { ...base.cost, pricingTables: [] },
+		});
 		expect(s.models.some((m) => m.apiEquivalentUSD !== undefined)).toBe(true);
 		expect(totalUSD(s)).toBeNull();
 	});
 
-	it("never rounds an empty set to zero", () => {
-		const s = buildSnapshot({ models: [] });
-		expect(totalUSD(s)).toBeNull();
+	it("never rounds an unpriceable window to zero", () => {
+		// The server returns no cost block at all when nothing carries a citable
+		// price, so there is no zero for the display to round to.
+		expect(totalUSD(buildSnapshot({ models: [], cost: null }))).toBeNull();
+	});
+
+	it("says what share of the tokens the figure covers", () => {
+		const base = buildSnapshot();
+		const partial = buildSnapshot({
+			cost: base.cost && { ...base.cost, coverage: 0.8529 },
+		});
+		expect(pricedShareLine(partial)).toBe("priced 85% of measured tokens");
+	});
+
+	it("stays silent on a fully priced window", () => {
+		expect(pricedShareLine(buildSnapshot())).toBeNull();
 	});
 
 	it("reads as dollars, not cents", () => {

--- a/src/features/measured/__tests__/fixture.ts
+++ b/src/features/measured/__tests__/fixture.ts
@@ -30,25 +30,58 @@ const CATALOG: Record<string, string> = {
 export const HOUR = 60 * 60 * 1000;
 export const DAY = 24 * HOUR;
 
+const tokensOf = (m: HarnessSnapshot["models"][number]) =>
+	m.tokens.input + m.tokens.output + m.tokens.cacheWrite + m.tokens.cacheRead;
+
+/**
+ * The cost block the query derives from these models (#93). Every model here
+ * was priced by the CLI that produced the fixture, so the whole reading is
+ * published rather than estimated — and coverage is whatever share of the
+ * tokens those rows carry.
+ */
+function costOf(
+	models: HarnessSnapshot["models"],
+	pricingTable: string | null,
+): MeasuredSnapshot["cost"] {
+	const priced = models.filter((m) => m.apiEquivalentUSD !== undefined);
+	if (priced.length === 0) return null;
+	const measuredTokens = models.reduce((a, m) => a + tokensOf(m), 0);
+	const pricedTokens = priced.reduce((a, m) => a + tokensOf(m), 0);
+	const usd = priced.reduce((a, m) => a + (m.apiEquivalentUSD ?? 0), 0);
+	return {
+		lowerBoundUSD: usd,
+		publishedUSD: usd,
+		estimatedUSD: 0,
+		coverage: measuredTokens > 0 ? pricedTokens / measuredTokens : 0,
+		pricedTokens,
+		measuredTokens,
+		pricingTables: pricingTable ? [pricingTable] : [],
+	};
+}
+
 /** One harness's own section, resolved the way the query resolves it. */
 export function buildHarness(
 	overrides: Partial<HarnessSnapshot> = {},
 ): HarnessSnapshot {
 	const payload = raw as unknown as Omit<
 		HarnessSnapshot,
-		"receivedAt" | "isFresh" | "models"
+		"receivedAt" | "isFresh" | "models" | "cost"
 	> & { models: Array<Omit<HarnessSnapshot["models"][number], never>> };
 	const receivedAt = Date.now() - 2 * HOUR;
+
+	const models = payload.models.map((m) => ({
+		...m,
+		catalogSlug: CATALOG[m.id] ? m.id : null,
+		catalogName: CATALOG[m.id] ?? null,
+		costEstimated: false,
+	}));
 
 	return {
 		...payload,
 		receivedAt,
 		isFresh: true,
-		models: payload.models.map((m) => ({
-			...m,
-			catalogSlug: CATALOG[m.id] ? m.id : null,
-			catalogName: CATALOG[m.id] ?? null,
-		})),
+		models,
+		cost: costOf(models, payload.pricingTable),
 		...overrides,
 	};
 }
@@ -68,6 +101,7 @@ export function buildSnapshot(
 		isFresh: h.isFresh,
 		window: h.window,
 		pricingTable: h.pricingTable,
+		cost: h.cost,
 		activity: h.activity,
 		models: h.models,
 		harnesses: [h],
@@ -85,10 +119,12 @@ export function withoutCost(
 	return {
 		...base,
 		pricingTable: null,
+		cost: null,
 		models: stripModels(base.models),
 		harnesses: base.harnesses.map((h) => ({
 			...h,
 			pricingTable: null,
+			cost: null,
 			models: stripModels(h.models),
 		})),
 	};

--- a/src/features/measured/__tests__/measured-section.test.tsx
+++ b/src/features/measured/__tests__/measured-section.test.tsx
@@ -49,9 +49,9 @@ function setup(
 describe("the reading", () => {
 	it("leads with the dollar figure and dates it", () => {
 		setup(buildSnapshot());
-		expect(screen.getByText("≈$5,840")).toBeInTheDocument();
+		expect(screen.getByText("≥$5,840")).toBeInTheDocument();
 		expect(
-			screen.getByText("at API prices, over the last 30 days"),
+			screen.getByText("at least, at API prices, over the last 30 days"),
 		).toBeInTheDocument();
 		expect(
 			screen.getByText(/prices: anthropic-list-2026-07-25/),
@@ -75,9 +75,17 @@ describe("the reading", () => {
 		expect(document.body.textContent).not.toContain("$");
 	});
 
-	it("prints no dollars at all when the pricing table is missing", () => {
-		// The per-model column has to go too, not just the headline.
-		setup(buildSnapshot({ pricingTable: null }));
+	it("prints no dollars at all when no table cites them", () => {
+		// The per-model column has to go too, not just the headline. A cost block
+		// that names no table is the one shape that must never reach the page:
+		// a price the reader cannot date is a price we do not print.
+		const base = buildSnapshot();
+		setup(
+			buildSnapshot({
+				pricingTable: null,
+				cost: base.cost && { ...base.cost, pricingTables: [] },
+			}),
+		);
 		expect(document.body.textContent).not.toContain("$");
 		expect(screen.getByText("4.27B")).toBeInTheDocument();
 	});
@@ -223,7 +231,7 @@ describe("a stack that has never synced, seen by its owner", () => {
 		expect(
 			screen.queryByText("Your stack has not been measured yet."),
 		).not.toBeInTheDocument();
-		expect(screen.getByText("≈$5,840")).toBeInTheDocument();
+		expect(screen.getByText("≥$5,840")).toBeInTheDocument();
 	});
 });
 

--- a/src/features/measured/copy.ts
+++ b/src/features/measured/copy.ts
@@ -6,7 +6,9 @@
  * against the owner's real payload in #40 and must not be relaxed here:
  *
  *   - A dollar figure NEVER renders without its pricing table version, so
- *     `totalUSD` returns null when `pricingTable` is null (#33 decision 11).
+ *     `totalUSD` returns null when no table cites it (#33 decision 11).
+ *   - A dollar figure is a LOWER BOUND and reads as one, with the share of
+ *     tokens it covers beside it (#93).
  *   - `catalogSlug: null` is not an error. The raw vendor id renders, because
  *     that row may be the largest one (#33 decision 3).
  *   - Withheld names read as "kept private", plain counts, non-zero only, and
@@ -68,19 +70,41 @@ export function fmtShare(share: number): string {
 /**
  * The dollars the whole window cost at API prices, or null.
  *
- * Null in two cases, and the display must treat both the same way: the client
- * withheld cost (`publishCost: false`), or the snapshot carries no pricing
- * table. The second case is the stricter rule — a price the reader cannot date
- * is a price we do not print.
+ * A LOWER BOUND, never an equality (#93). The server fills the gaps a stale CLI
+ * price table left behind, and both facts the wire loses — the cache-write TTL
+ * split and the per-response timestamps — resolve downward. Tokens no table can
+ * price are simply missing from it, which is what `coverageLine` reports.
+ *
+ * Null in two cases, and the display treats both the same way: the owner has
+ * cost publishing off, or nothing in the window carries a citable price. The
+ * empty-table guard is the stricter rule — a price the reader cannot date is a
+ * price we do not print.
  */
 export function totalUSD(s: {
-	pricingTable: string | null;
-	models: Array<{ apiEquivalentUSD?: number }>;
+	cost: {
+		lowerBoundUSD: number;
+		pricingTables: string[];
+	} | null;
 }): number | null {
-	if (!s.pricingTable) return null;
-	const priced = s.models.filter((m) => m.apiEquivalentUSD !== undefined);
-	if (priced.length === 0) return null;
-	return priced.reduce((sum, m) => sum + (m.apiEquivalentUSD ?? 0), 0);
+	if (!s.cost || s.cost.pricingTables.length === 0) return null;
+	return s.cost.lowerBoundUSD;
+}
+
+/**
+ * "priced 85% of measured tokens" — the caveat that makes the figure above it
+ * readable, or null on a fully priced window.
+ *
+ * Named for the price, not for "coverage": `coverageCaveat` above already means
+ * SCAN coverage, and the two must not share a word.
+ *
+ * Rounded DOWN, because a rounded-up share claims more of the spend is
+ * accounted for than is.
+ */
+export function pricedShareLine(s: {
+	cost: { coverage: number } | null;
+}): string | null {
+	if (!s.cost || s.cost.coverage >= 1) return null;
+	return `priced ${Math.floor(s.cost.coverage * 100)}% of measured tokens`;
 }
 
 /** The catalog name, falling back to the raw vendor id the client published. */

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as SyncRouteImport } from './routes/sync'
 import { Route as SigninPublishRouteImport } from './routes/signin-publish'
 import { Route as SigninRouteImport } from './routes/signin'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
+import { Route as LeaderboardRouteImport } from './routes/leaderboard'
 import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
 import { Route as AuthCallbackRouteImport } from './routes/auth-callback'
 import { Route as AdminRouteImport } from './routes/admin'
@@ -71,6 +72,11 @@ const SigninRoute = SigninRouteImport.update({
 const ResetPasswordRoute = ResetPasswordRouteImport.update({
   id: '/reset-password',
   path: '/reset-password',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LeaderboardRoute = LeaderboardRouteImport.update({
+  id: '/leaderboard',
+  path: '/leaderboard',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ForgotPasswordRoute = ForgotPasswordRouteImport.update({
@@ -216,6 +222,7 @@ export interface FileRoutesByFullPath {
   '/admin': typeof AdminRoute
   '/auth-callback': typeof AuthCallbackRoute
   '/forgot-password': typeof ForgotPasswordRoute
+  '/leaderboard': typeof LeaderboardRoute
   '/reset-password': typeof ResetPasswordRoute
   '/signin': typeof SigninRoute
   '/signin-publish': typeof SigninPublishRoute
@@ -251,6 +258,7 @@ export interface FileRoutesByTo {
   '/admin': typeof AdminRoute
   '/auth-callback': typeof AuthCallbackRoute
   '/forgot-password': typeof ForgotPasswordRoute
+  '/leaderboard': typeof LeaderboardRoute
   '/reset-password': typeof ResetPasswordRoute
   '/signin': typeof SigninRoute
   '/signin-publish': typeof SigninPublishRoute
@@ -287,6 +295,7 @@ export interface FileRoutesById {
   '/admin': typeof AdminRoute
   '/auth-callback': typeof AuthCallbackRoute
   '/forgot-password': typeof ForgotPasswordRoute
+  '/leaderboard': typeof LeaderboardRoute
   '/reset-password': typeof ResetPasswordRoute
   '/signin': typeof SigninRoute
   '/signin-publish': typeof SigninPublishRoute
@@ -324,6 +333,7 @@ export interface FileRouteTypes {
     | '/admin'
     | '/auth-callback'
     | '/forgot-password'
+    | '/leaderboard'
     | '/reset-password'
     | '/signin'
     | '/signin-publish'
@@ -359,6 +369,7 @@ export interface FileRouteTypes {
     | '/admin'
     | '/auth-callback'
     | '/forgot-password'
+    | '/leaderboard'
     | '/reset-password'
     | '/signin'
     | '/signin-publish'
@@ -394,6 +405,7 @@ export interface FileRouteTypes {
     | '/admin'
     | '/auth-callback'
     | '/forgot-password'
+    | '/leaderboard'
     | '/reset-password'
     | '/signin'
     | '/signin-publish'
@@ -430,6 +442,7 @@ export interface RootRouteChildren {
   AdminRoute: typeof AdminRoute
   AuthCallbackRoute: typeof AuthCallbackRoute
   ForgotPasswordRoute: typeof ForgotPasswordRoute
+  LeaderboardRoute: typeof LeaderboardRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
   SigninRoute: typeof SigninRoute
   SigninPublishRoute: typeof SigninPublishRoute
@@ -500,6 +513,13 @@ declare module '@tanstack/react-router' {
       path: '/reset-password'
       fullPath: '/reset-password'
       preLoaderRoute: typeof ResetPasswordRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/leaderboard': {
+      id: '/leaderboard'
+      path: '/leaderboard'
+      fullPath: '/leaderboard'
+      preLoaderRoute: typeof LeaderboardRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/forgot-password': {
@@ -713,6 +733,7 @@ const rootRouteChildren: RootRouteChildren = {
   AdminRoute: AdminRoute,
   AuthCallbackRoute: AuthCallbackRoute,
   ForgotPasswordRoute: ForgotPasswordRoute,
+  LeaderboardRoute: LeaderboardRoute,
   ResetPasswordRoute: ResetPasswordRoute,
   SigninRoute: SigninRoute,
   SigninPublishRoute: SigninPublishRoute,

--- a/src/routes/leaderboard.tsx
+++ b/src/routes/leaderboard.tsx
@@ -40,7 +40,7 @@ import { VariantC2 } from "@/features/leaderboard/proto/VariantC2";
 import { coerceEnum, coercePage } from "@/lib/searchParams";
 
 const DEFAULTS = {
-	variant: "C2" as VariantKey,
+	variant: "C3" as VariantKey,
 	density: "real" as DensityKey,
 	weight: "tokens" as Weight,
 	clock: "now" as ClockKey,
@@ -59,7 +59,7 @@ export const Route = createFileRoute("/leaderboard")({
 		clock?: ClockKey;
 		page?: number;
 	} => ({
-		variant: coerceEnum(search.variant, VARIANT_KEYS, "C2"),
+		variant: coerceEnum(search.variant, VARIANT_KEYS, "C3"),
 		density: coerceEnum(
 			search.density,
 			["real", "grown", "scale"] as const,

--- a/src/routes/leaderboard.tsx
+++ b/src/routes/leaderboard.tsx
@@ -36,10 +36,11 @@ import {
 import { VariantA } from "@/features/leaderboard/proto/VariantA";
 import { VariantB } from "@/features/leaderboard/proto/VariantB";
 import { VariantC } from "@/features/leaderboard/proto/VariantC";
+import { VariantC2 } from "@/features/leaderboard/proto/VariantC2";
 import { coerceEnum, coercePage } from "@/lib/searchParams";
 
 const DEFAULTS = {
-	variant: "A" as VariantKey,
+	variant: "C2" as VariantKey,
 	density: "real" as DensityKey,
 	weight: "tokens" as Weight,
 	clock: "now" as ClockKey,
@@ -58,7 +59,7 @@ export const Route = createFileRoute("/leaderboard")({
 		clock?: ClockKey;
 		page?: number;
 	} => ({
-		variant: coerceEnum(search.variant, VARIANT_KEYS, "A"),
+		variant: coerceEnum(search.variant, VARIANT_KEYS, "C2"),
 		density: coerceEnum(
 			search.density,
 			["real", "grown", "scale"] as const,
@@ -137,6 +138,15 @@ function LeaderboardPrototype() {
 					weight={weight}
 					page={page}
 					onPage={(p) => set({ page: p })}
+				/>
+			)}
+			{(variant === "C2" || variant === "C3") && (
+				<VariantC2
+					agg={agg}
+					weight={weight}
+					page={page}
+					onPage={(p) => set({ page: p })}
+					quietGroup={variant === "C2" ? "list" : "line"}
 				/>
 			)}
 			<div className="h-32" />

--- a/src/routes/leaderboard.tsx
+++ b/src/routes/leaderboard.tsx
@@ -1,0 +1,157 @@
+/**
+ * PROTOTYPE — throwaway. Wayfinder ticket #92 (map #76).
+ *
+ * Three spines for `/leaderboard`, switchable from the floating bar:
+ *
+ *   ?variant=A  leaderboard-first — the board is the page
+ *   ?variant=B  statistics-first — the state of AI coding spend
+ *   ?variant=C  equal weight — a sticky stats rail beside the board
+ *
+ * Sub-shape B (a new route) because the page does not exist yet. Nothing here
+ * is wired to Convex: the whole point is judging the design at 4, 50 and 500
+ * rows, and prod has 4. The read side arrives with #83.
+ *
+ * DELETE THIS FILE before anything merges to main. The winner gets rewritten.
+ */
+
+import {
+	createFileRoute,
+	stripSearchParams,
+	useNavigate,
+	useSearch,
+} from "@tanstack/react-router";
+import { useCallback, useEffect, useMemo } from "react";
+import { aggregate, type Weight } from "@/features/leaderboard/proto/aggregate";
+import {
+	CLOCKS,
+	type ClockKey,
+	type DensityKey,
+	populationFor,
+} from "@/features/leaderboard/proto/fixtures";
+import {
+	PrototypeSwitcher,
+	VARIANT_KEYS,
+	type VariantKey,
+} from "@/features/leaderboard/proto/PrototypeSwitcher";
+import { VariantA } from "@/features/leaderboard/proto/VariantA";
+import { VariantB } from "@/features/leaderboard/proto/VariantB";
+import { VariantC } from "@/features/leaderboard/proto/VariantC";
+import { coerceEnum, coercePage } from "@/lib/searchParams";
+
+const DEFAULTS = {
+	variant: "A" as VariantKey,
+	density: "real" as DensityKey,
+	weight: "tokens" as Weight,
+	clock: "now" as ClockKey,
+	page: 1,
+};
+
+export const Route = createFileRoute("/leaderboard")({
+	component: LeaderboardPrototype,
+	// Every key optional, or `search` becomes required on every Link in the app.
+	validateSearch: (
+		search: Record<string, unknown>,
+	): {
+		variant?: VariantKey;
+		density?: DensityKey;
+		weight?: Weight;
+		clock?: ClockKey;
+		page?: number;
+	} => ({
+		variant: coerceEnum(search.variant, VARIANT_KEYS, "A"),
+		density: coerceEnum(
+			search.density,
+			["real", "grown", "scale"] as const,
+			"real",
+		),
+		weight: coerceEnum(search.weight, ["tokens", "stacks"] as const, "tokens"),
+		clock: coerceEnum(search.clock, ["now", "quiet", "dark"] as const, "now"),
+		page: coercePage(search.page),
+	}),
+	search: { middlewares: [stripSearchParams(DEFAULTS)] },
+});
+
+function LeaderboardPrototype() {
+	const navigate = useNavigate();
+	const search = useSearch({ from: "/leaderboard" });
+
+	const variant = search.variant ?? DEFAULTS.variant;
+	const density = search.density ?? DEFAULTS.density;
+	const weight = search.weight ?? DEFAULTS.weight;
+	const clock = search.clock ?? DEFAULTS.clock;
+	const page = search.page ?? DEFAULTS.page;
+
+	const set = useCallback(
+		(next: Partial<typeof DEFAULTS>) => {
+			navigate({
+				to: "/leaderboard",
+				search: (prev) => ({ ...prev, ...next }),
+				replace: true,
+			});
+		},
+		[navigate],
+	);
+
+	const nowMs = CLOCKS[clock];
+	const agg = useMemo(
+		() => aggregate(populationFor(density, nowMs), nowMs),
+		[density, nowMs],
+	);
+
+	const cycle = useCallback(
+		(step: number) => {
+			const i = VARIANT_KEYS.indexOf(variant);
+			const next =
+				VARIANT_KEYS[(i + step + VARIANT_KEYS.length) % VARIANT_KEYS.length];
+			set({ variant: next, page: 1 });
+		},
+		[variant, set],
+	);
+
+	useEffect(() => {
+		const onKey = (e: KeyboardEvent) => {
+			const el = document.activeElement;
+			if (
+				el instanceof HTMLInputElement ||
+				el instanceof HTMLTextAreaElement ||
+				(el instanceof HTMLElement && el.isContentEditable)
+			) {
+				return;
+			}
+			if (e.key === "ArrowLeft") cycle(-1);
+			if (e.key === "ArrowRight") cycle(1);
+		};
+		window.addEventListener("keydown", onKey);
+		return () => window.removeEventListener("keydown", onKey);
+	}, [cycle]);
+
+	return (
+		<>
+			{variant === "A" && (
+				<VariantA agg={agg} page={page} onPage={(p) => set({ page: p })} />
+			)}
+			{variant === "B" && <VariantB agg={agg} weight={weight} />}
+			{variant === "C" && (
+				<VariantC
+					agg={agg}
+					weight={weight}
+					page={page}
+					onPage={(p) => set({ page: p })}
+				/>
+			)}
+			<div className="h-32" />
+			<PrototypeSwitcher
+				variant={variant}
+				density={density}
+				weight={weight}
+				clock={clock}
+				livingCount={agg.livingCount}
+				staleCount={agg.stale.length}
+				onCycle={cycle}
+				onDensity={(d) => set({ density: d, page: 1 })}
+				onWeight={(w) => set({ weight: w })}
+				onClock={(c) => set({ clock: c, page: 1 })}
+			/>
+		</>
+	);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,8 +33,8 @@ export default defineConfig({
       {
         extends: true,
         test: {
-          name: 'cli',
-          include: ['packages/cli/**/*.test.ts'],
+          name: 'packages',
+          include: ['packages/**/*.test.ts'],
           environment: 'node',
         },
       },


### PR DESCRIPTION
Closes #93.

## The defect

A snapshot's cost was frozen at whatever price table the syncing CLI shipped. `PRICES` lived in `packages/cli` and Convex had no copy. One day of table drift produced this on prod:

| stack | published before | published after | coverage |
|---|---|---|---|
| OrcDev | $14,764 | **≥$168,771** | 85.2% |
| GVASTE | *nothing* | **≥$3,648** | 97.7% |
| Brilliant Insane | $256 | **≥$4,063** | 100% |

The "after" column is this branch run over the three real prod readings.

## What changed

**`packages/pricing` is the one price table.** The CLI and Convex both import it. It is private and never published — tsup bundles it into the CLI's `dist`, and `pnpm publish --dry-run` is clean. The CLI keeps its exact current behavior; only its import path moved. The table id now rides on the rate, so a read-time estimate cites the table it came from rather than the one the payload named.

**`convex/lib/reprice.ts` fills gaps only.** A model the CLI priced keeps its dollars — that figure is per-response and cache-TTL aware, so it is exact. Only a model with no dollars gets an estimate. One reading can be part exact and part estimated.

**Every estimate is biased low, on purpose.** Two facts are gone by the time a payload lands, and both resolve downward:

1. The wire carries one merged `cacheWrite`. The 5m tier costs 1.25x input and the 1h tier 2.0x, and the split is lost — so everything charges the 5m rate. Measured against a stack the CLI priced exactly, this comes out **8.1% low** for Claude Code. Codex is exact, because every Codex row has `cacheWrite: 0`.
2. There are no per-response timestamps, so a window straddling a repricing (`claude-sonnet-5`, 2026-09-01) pays the **cheaper** rate.

A one-directional bias is what makes the "at least" framing sound. Do not add a heuristic that can overstate.

**Coverage travels with every cost.** `cost.coverage` is the share of measured tokens carrying a citable price. `unknown` can never be priced, which is what caps OrcDev at 85.2%. The stack page prints `priced 85% of measured tokens` beside the figure and leads with `≥`.

**Consent is the flag.** `publishCost` off strips every dollar, including ones already stored in a payload. The old proxy — `pricingTable !== null` — is gone.

The narrow hard-coded `READTIME_OPENAI_PRICES` from #72 is deleted; the shared table subsumes it and covers Anthropic ids too.

## Unblocks

#83 (leaderboard spend column) and #81 (stack page), which both need `cost.lowerBoundUSD` and `cost.coverage`.

## Tests

`packages/pricing/src/index.test.ts` (moved, plus the new window lookup), `convex/lib/reprice.test.ts` (12 cases: the drift case, a fully-priced snapshot unchanged, `unknown` capping coverage, the flag gate, the cheap cache tier, the straddled boundary), and the updated `convex/measured.test.ts` block. Full suite: 1406 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPaGJivZLF7XeqckSkFDa1