### PR TITLE
Task: build live stack-page stats (alp82/aistack#81)

### DIFF
--- a/convex/measured.test.ts
+++ b/convex/measured.test.ts
@@ -591,6 +591,368 @@ describe('getCurrentByStackSlug', () => {
   })
 })
 
+// ---------------------------------------------------------------------------
+// Read — the series (#81)
+// ---------------------------------------------------------------------------
+
+describe('getHistoryByStackSlug', () => {
+  const HOUR = 60 * 60 * 1000
+
+  /** Tokens split across the four input classes, so totals stay checkable. */
+  function models(over: Array<{ id: string; share: number; usd?: number }>) {
+    return over.map((m) => ({
+      id: m.id,
+      tokenShare: m.share,
+      tokens: { input: 1, output: 1, cacheWrite: 0, cacheRead: 0 },
+      ...(m.usd === undefined ? {} : { apiEquivalentUSD: m.usd }),
+    }))
+  }
+
+  test('returns one point per sync, oldest first', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, shortId } = await seedStack(t)
+    const now = Date.now()
+
+    for (const [ago, tokens] of [
+      [3 * DAY, 100],
+      [2 * DAY, 220],
+      [1 * DAY, 180],
+    ] as const) {
+      await t.mutation(internal.measured.publishSnapshot, {
+        stackId,
+        payload: payload({
+          capturedAt: now - ago,
+          activity: { ...payload().activity, totalTokens: tokens },
+        }),
+      })
+    }
+
+    const history = await t.query(api.measured.getHistoryByStackSlug, {
+      slug: `my-stack-${shortId}`,
+    })
+    // A rolling window is a level, so it may fall. The series says so.
+    expect(history?.points.map((p) => p.tokens)).toEqual([100, 220, 180])
+    expect(history?.points.map((p) => p.at)).toEqual([
+      now - 3 * DAY,
+      now - 2 * DAY,
+      now - 1 * DAY,
+    ])
+  })
+
+  test('returns null for an unpublished stack, and for one that never synced', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, shortId } = await seedStack(t, { published: false })
+    await t.mutation(internal.measured.publishSnapshot, { stackId, payload: payload() })
+    expect(
+      await t.query(api.measured.getHistoryByStackSlug, { slug: `my-stack-${shortId}` }),
+    ).toBeNull()
+
+    const other = await seedStack(t)
+    expect(
+      await t.query(api.measured.getHistoryByStackSlug, {
+        slug: `my-stack-${other.shortId}`,
+      }),
+    ).toBeNull()
+  })
+
+  test('two syncs a minute apart are one reading, not two', async () => {
+    // Real, from prod: 15:35 and 15:36 on 2026-08-01.
+    const t = convexTest(schema, modules)
+    const { stackId, shortId } = await seedStack(t)
+    const at = Date.now() - HOUR
+
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payload({ capturedAt: at }),
+    })
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payload({
+        capturedAt: at + 61_000,
+        activity: { ...payload().activity, totalTokens: 2_000_000 },
+      }),
+    })
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      // Same minute as the second: an amended sync, not a new reading.
+      payload: payload({
+        capturedAt: at + 61_500,
+        activity: { ...payload().activity, totalTokens: 3_000_000 },
+      }),
+    })
+
+    const history = await t.query(api.measured.getHistoryByStackSlug, {
+      slug: `my-stack-${shortId}`,
+    })
+    expect(history?.points).toHaveLength(2)
+    expect(history?.points[1].tokens).toBe(3_000_000)
+  })
+
+  test('carries a harness that did not sync into the next reading', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, shortId } = await seedStack(t)
+    const now = Date.now()
+
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payload({
+        capturedAt: now - 2 * DAY,
+        activity: { ...payload().activity, totalTokens: 1_000, sessions: 10 },
+      }),
+    })
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payload({
+        capturedAt: now - HOUR,
+        harness: { name: 'codex', version: '0.9' },
+        activity: { ...payload().activity, totalTokens: 40, sessions: 2 },
+      }),
+    })
+
+    const history = await t.query(api.measured.getHistoryByStackSlug, {
+      slug: `my-stack-${shortId}`,
+    })
+    const last = history?.points[1]
+    // Claude Code did not sync in this minute, and dropping it would make the
+    // stack look like it shrank by three orders of magnitude.
+    expect(last?.tokens).toBe(1_040)
+    expect(last?.sessions).toBe(12)
+    expect(last?.harnesses.map((h) => h.name).sort()).toEqual([
+      'claude-code',
+      'codex',
+    ])
+    // The carried reading says when it was actually taken.
+    const cc = last?.harnesses.find((h) => h.name === 'claude-code')
+    expect(cc?.capturedAt).toBe(now - 2 * DAY)
+    expect(last?.at).toBe(now - HOUR)
+  })
+
+  test('the newest point states exactly what the headline states', async () => {
+    // The page shows the headline and the trail together. If these two merges
+    // could disagree, the number would restate itself differently every scroll.
+    const t = convexTest(schema, modules)
+    const { stackId, shortId } = await seedStack(t)
+    const now = Date.now()
+
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payload({
+        capturedAt: now - 3 * DAY,
+        models: models([{ id: 'claude-opus-5', share: 1, usd: 5 }]),
+      }),
+    })
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payload({
+        capturedAt: now - 2 * DAY,
+        harness: { name: 'codex', version: '0.9' },
+        activity: { ...payload().activity, totalTokens: 500_000, sessions: 4 },
+        models: models([{ id: 'gpt-5.5', share: 1, usd: 3 }]),
+      }),
+    })
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payload({
+        capturedAt: now - HOUR,
+        models: models([
+          { id: 'claude-opus-5', share: 0.8, usd: 8 },
+          { id: 'claude-haiku-4-5', share: 0.2, usd: 1 },
+        ]),
+      }),
+    })
+
+    const slug = `my-stack-${shortId}`
+    const current = await t.query(api.measured.getCurrentByStackSlug, { slug })
+    const history = await t.query(api.measured.getHistoryByStackSlug, { slug })
+    const points = history?.points ?? []
+    const last = points[points.length - 1]
+
+    expect(last.tokens).toBe(current?.activity.totalTokens)
+    expect(last.sessions).toBe(current?.activity.sessions)
+    expect(last.usd).toBe(
+      current?.models.reduce((a, m) => a + (m.apiEquivalentUSD ?? 0), 0),
+    )
+    expect(last.models.map((m) => m.id)).toEqual(current?.models.map((m) => m.id))
+    expect(last.models.map((m) => m.tokenShare)).toEqual(
+      current?.models.map((m) => m.tokenShare),
+    )
+  })
+
+  test('seeds the carry-forward from before the window', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, shortId } = await seedStack(t)
+    const now = Date.now()
+
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payload({
+        capturedAt: now - 200 * DAY,
+        activity: { ...payload().activity, totalTokens: 1_000 },
+      }),
+    })
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payload({
+        capturedAt: now - HOUR,
+        harness: { name: 'codex', version: '0.9' },
+        activity: { ...payload().activity, totalTokens: 40 },
+      }),
+    })
+
+    const history = await t.query(api.measured.getHistoryByStackSlug, {
+      slug: `my-stack-${shortId}`,
+      days: 30,
+    })
+    // One point — the old row is out of the window — but it still contributes,
+    // exactly as it does to the headline.
+    expect(history?.points).toHaveLength(1)
+    expect(history?.points[0].tokens).toBe(1_040)
+    expect(history?.windowDays).toBe(30)
+  })
+
+  test('narrows to one harness, unmerged, when asked', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, shortId } = await seedStack(t)
+    const now = Date.now()
+
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payload({
+        capturedAt: now - 2 * DAY,
+        activity: { ...payload().activity, totalTokens: 1_000 },
+      }),
+    })
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payload({
+        capturedAt: now - HOUR,
+        harness: { name: 'codex', version: '0.9' },
+        activity: { ...payload().activity, totalTokens: 40 },
+      }),
+    })
+
+    const history = await t.query(api.measured.getHistoryByStackSlug, {
+      slug: `my-stack-${shortId}`,
+      harness: 'codex',
+    })
+    expect(history?.harness).toBe('codex')
+    expect(history?.points).toHaveLength(1)
+    expect(history?.points[0].tokens).toBe(40)
+    expect(history?.points[0].harnesses.map((h) => h.name)).toEqual(['codex'])
+  })
+
+  test('resolves the catalog at read time and keeps an unknown id as itself', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, shortId } = await seedStack(t)
+    await t.run(async (ctx) => {
+      await ctx.db.insert('models', {
+        name: 'Claude Opus 5',
+        slug: 'claude-opus-5',
+        shortId: 'mopus5',
+        provider: 'anthropic',
+        category: 'language',
+        reviewStatus: 'approved',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      })
+    })
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payload({
+        capturedAt: Date.now() - HOUR,
+        models: models([
+          { id: 'claude-opus-5', share: 0.5, usd: 1 },
+          { id: 'some-unlisted-model', share: 0.5, usd: 1 },
+        ]),
+      }),
+    })
+
+    const history = await t.query(api.measured.getHistoryByStackSlug, {
+      slug: `my-stack-${shortId}`,
+    })
+    expect(history?.points[0].models).toEqual([
+      {
+        id: 'claude-opus-5',
+        catalogSlug: 'claude-opus-5',
+        catalogName: 'Claude Opus 5',
+        tokenShare: 0.5,
+      },
+      {
+        id: 'some-unlisted-model',
+        catalogSlug: null,
+        catalogName: null,
+        tokenShare: 0.5,
+      },
+    ])
+  })
+
+  test('publishes no cost for a reading that published no pricing table', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, shortId } = await seedStack(t)
+    const now = Date.now()
+
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payload({
+        capturedAt: now - DAY,
+        pricingTable: null,
+        models: models([{ id: 'claude-opus-5', share: 1 }]),
+      }),
+    })
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payload({
+        capturedAt: now - HOUR,
+        models: models([{ id: 'claude-opus-5', share: 1, usd: 7 }]),
+      }),
+    })
+
+    const history = await t.query(api.measured.getHistoryByStackSlug, {
+      slug: `my-stack-${shortId}`,
+    })
+    expect(history?.points[0].usd).toBeNull()
+    expect(history?.points[0].pricingTable).toBeNull()
+    expect(history?.points[1].usd).toBe(7)
+    expect(history?.points[1].pricingTable).toBe('anthropic-list-2026-07-25')
+  })
+
+  test('reprices an old unpriced row at read time, and says which table did it', async () => {
+    // #72: rows landed before the CLI knew the price. Snapshots are immutable,
+    // so the fix is at read time — and the trail must reprice too, or a page
+    // shows dollars today and a gap for the same reading in its own history.
+    const t = convexTest(schema, modules)
+    const { stackId, shortId } = await seedStack(t)
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payload({
+        capturedAt: Date.now() - HOUR,
+        pricingTable: 'openai-list-2026-07-25',
+        models: [
+          {
+            id: 'gpt-5.6-luna',
+            tokenShare: 1,
+            tokens: {
+              input: 1_000_000,
+              output: 1_000_000,
+              cacheWrite: 0,
+              cacheRead: 0,
+            },
+          },
+        ],
+      }),
+    })
+
+    const history = await t.query(api.measured.getHistoryByStackSlug, {
+      slug: `my-stack-${shortId}`,
+    })
+    // 1M input at $0.20 + 1M output at $1.20.
+    expect(history?.points[0].usd).toBeCloseTo(1.4, 6)
+    expect(history?.points[0].pricingTable).toBe(
+      'openai-list-2026-07-25 + openai-list-2026-08-02',
+    )
+  })
+})
+
 describe('countLivingStacks', () => {
   test('counts distinct stacks whose newest sync landed within 7 days', async () => {
     const t = convexTest(schema, modules)

--- a/convex/measured.ts
+++ b/convex/measured.ts
@@ -213,6 +213,33 @@ const ResolvedModel = v.object({
 })
 
 /**
+ * The models catalog, read once and indexed in memory.
+ *
+ * READ ONCE, NOT ONCE PER MODEL. A single reading resolves a handful of ids, so
+ * a per-id indexed read was fine; the series (#81) resolves every reading in the
+ * window, and a per-id read there would multiply one page view by the number of
+ * syncs. One collect answers all of them, and it is what the alias fallback
+ * already did on every miss.
+ */
+type ModelCatalog = {
+  bySlug: Map<string, Doc<'models'>>
+  byAlias: Map<string, Doc<'models'>>
+}
+
+async function loadModelCatalog(ctx: QueryCtx): Promise<ModelCatalog> {
+  const rows = await ctx.db.query('models').collect()
+  const bySlug = new Map<string, Doc<'models'>>()
+  const byAlias = new Map<string, Doc<'models'>>()
+  for (const row of rows) {
+    if (!bySlug.has(row.slug)) bySlug.set(row.slug, row)
+    for (const alias of row.aliases ?? []) {
+      if (!byAlias.has(alias)) byAlias.set(alias, row)
+    }
+  }
+  return { bySlug, byAlias }
+}
+
+/**
  * Resolve published model ids against the catalog at read time.
  *
  * Matches the slug first, then the `aliases` array — the analyzer publishes a
@@ -223,29 +250,18 @@ const ResolvedModel = v.object({
  * is the honest failure: the alternative — dropping it — is exactly the silent
  * disappearance #33 decision 3 exempted model ids to prevent.
  */
-async function resolveModels(
-  ctx: QueryCtx,
+function resolveModels(
+  catalog: ModelCatalog,
   models: Doc<'measuredSnapshots'>['payload']['models']
 ) {
-  return await Promise.all(
-    models.map(async (m) => {
-      const bySlug = await ctx.db
-        .query('models')
-        .withIndex('by_slug', (q) => q.eq('slug', m.id))
-        .first()
-      const match =
-        bySlug ??
-        (await ctx.db
-          .query('models')
-          .collect()
-          .then((all) => all.find((row) => row.aliases?.includes(m.id)) ?? null))
-      return {
-        ...m,
-        catalogSlug: match?.slug ?? null,
-        catalogName: match?.name ?? null,
-      }
-    })
-  )
+  return models.map((m) => {
+    const match = catalog.bySlug.get(m.id) ?? catalog.byAlias.get(m.id) ?? null
+    return {
+      ...m,
+      catalogSlug: match?.slug ?? null,
+      catalogName: match?.name ?? null,
+    }
+  })
 }
 
 /**
@@ -435,12 +451,12 @@ const CurrentMeasured = v.object({
   harnesses: v.array(HarnessSnapshot),
 })
 
-async function toHarnessSnapshot(
-  ctx: QueryCtx,
+function toHarnessSnapshot(
+  catalog: ModelCatalog,
   snapshot: Doc<'measuredSnapshots'>
 ) {
   const p = snapshot.payload
-  const resolved = await resolveModels(ctx, p.models)
+  const resolved = resolveModels(catalog, p.models)
   const { models, repricedTokens } =
     p.pricingTable !== null
       ? applyReadTimePrices(resolved)
@@ -509,6 +525,87 @@ function mergeModels(lists: Resolved[][]): Resolved[] {
     .sort((a, b) => tokensOf(b) - tokensOf(a) || a.id.localeCompare(b.id))
 }
 
+type HarnessReading = ReturnType<typeof toHarnessSnapshot>
+
+/**
+ * Merge a set of per-harness readings into the one figure the page states.
+ *
+ * Split out of `getCurrentByStackSlug` for #81: the series is this same merge
+ * evaluated at every sync, so the headline is the last point of its own trail by
+ * construction rather than by agreement between two pieces of arithmetic.
+ */
+function mergeHarnesses(harnesses: HarnessReading[]) {
+  const totalTokens = harnesses.reduce((a, h) => a + h.activity.totalTokens, 0)
+  // Cache-hit share recomputes from the summed model tokens — the same
+  // input-class formula each client used, over the merged absolute counts.
+  const models = mergeModels(harnesses.map((h) => h.models))
+  let cacheRead = 0
+  let inputClass = 0
+  for (const m of models) {
+    cacheRead += m.tokens.cacheRead
+    inputClass += m.tokens.input + m.tokens.cacheRead + m.tokens.cacheWrite
+  }
+  const pricingTables = [
+    ...new Set(
+      harnesses.map((h) => h.pricingTable).filter((t): t is string => t !== null)
+    ),
+  ]
+
+  return {
+    receivedAt: Math.max(...harnesses.map((h) => h.receivedAt)),
+    capturedAt: Math.max(...harnesses.map((h) => h.capturedAt)),
+    isFresh: harnesses.some((h) => h.isFresh),
+    window: {
+      days: Math.max(...harnesses.map((h) => h.window.days)),
+      from: harnesses.map((h) => h.window.from).sort()[0],
+      to: harnesses.map((h) => h.window.to).sort()[harnesses.length - 1],
+    },
+    pricingTable: pricingTables.length > 0 ? pricingTables.join(' + ') : null,
+    activity: {
+      sessions: harnesses.reduce((a, h) => a + h.activity.sessions, 0),
+      activeDays: Math.max(...harnesses.map((h) => h.activity.activeDays)),
+      projects: Math.max(...harnesses.map((h) => h.activity.projects)),
+      totalTokens,
+      cacheHitShare: inputClass ? cacheRead / inputClass : 0,
+      subagentShare: totalTokens
+        ? harnesses.reduce(
+            (a, h) => a + h.activity.subagentShare * h.activity.totalTokens,
+            0
+          ) / totalTokens
+        : 0,
+    },
+    models,
+    harnesses,
+  }
+}
+
+/**
+ * The dollars a merged reading cost, or null.
+ *
+ * The same rule the display carries (`src/features/measured/copy.ts`): a price
+ * the reader cannot date is a price this site does not print, and a reading with
+ * no priced row at all publishes no cost.
+ */
+function mergedUSD(merged: {
+  pricingTable: string | null
+  models: Array<{ apiEquivalentUSD?: number }>
+}): number | null {
+  if (merged.pricingTable === null) return null
+  const priced = merged.models.filter((m) => m.apiEquivalentUSD !== undefined)
+  if (priced.length === 0) return null
+  return priced.reduce((sum, m) => sum + (m.apiEquivalentUSD ?? 0), 0)
+}
+
+/** The published stack behind a public slug, or null. */
+async function publishedStackBySlug(ctx: QueryCtx, slug: string) {
+  const stack = await ctx.db
+    .query('stacks')
+    .withIndex('by_shortId', (q) => q.eq('shortId', extractShortId(slug)))
+    .first()
+  if (!stack || !stack.published) return null
+  return stack
+}
+
 /**
  * The current measured layer for a published stack, by public slug.
  *
@@ -521,65 +618,211 @@ export const getCurrentByStackSlug = query({
   args: { slug: v.string() },
   returns: v.union(CurrentMeasured, v.null()),
   handler: async (ctx, args) => {
-    const shortId = extractShortId(args.slug)
-    const stack = await ctx.db
-      .query('stacks')
-      .withIndex('by_shortId', (q) => q.eq('shortId', shortId))
-      .first()
-    if (!stack || !stack.published) return null
+    const stack = await publishedStackBySlug(ctx, args.slug)
+    if (!stack) return null
 
     const snapshots = await newestSnapshotsPerHarness(ctx, stack._id)
     if (snapshots.length === 0) return null
 
-    const harnesses = []
-    for (const snapshot of snapshots) {
-      harnesses.push(await toHarnessSnapshot(ctx, snapshot))
-    }
+    const catalog = await loadModelCatalog(ctx)
+    return mergeHarnesses(snapshots.map((s) => toHarnessSnapshot(catalog, s)))
+  },
+})
 
-    const totalTokens = harnesses.reduce(
-      (a, h) => a + h.activity.totalTokens,
-      0
+// ---------------------------------------------------------------------------
+// Read — the series (#81, building the #80 design)
+// ---------------------------------------------------------------------------
+
+/** The default lookback: the span the GC keeps at full grain. */
+const HISTORY_DEFAULT_DAYS = 90
+const HISTORY_MAX_DAYS = 365
+/**
+ * The most points one answer carries. A stack that syncs on every session can
+ * pass this inside a week, and a page cannot draw a thousand readings anyway.
+ * The newest are kept and `truncated` says so — a silently cut series would let
+ * "N readings since X" name a day the series does not reach back to.
+ */
+const HISTORY_MAX_POINTS = 180
+/** Rows captured inside the same minute are one sync, not several readings. */
+const SYNC_BUCKET_MS = 60_000
+
+/**
+ * One model at one reading. Deliberately thinner than `ResolvedModel`: the trail
+ * behind a model row is a share over time, and shipping every reading's absolute
+ * token counts and dollars would multiply the payload for numbers no reading but
+ * the newest displays.
+ */
+const HistoryModel = v.object({
+  id: v.string(),
+  catalogSlug: v.union(v.string(), v.null()),
+  catalogName: v.union(v.string(), v.null()),
+  tokenShare: v.number(),
+})
+
+/**
+ * One reading of the whole stack — the figure the page stated at that moment.
+ *
+ * `at` is the sync minute, `harnesses[].capturedAt` is when that harness last
+ * spoke. The two differ whenever a harness did not sync in this minute, which is
+ * how the display can say which reading actually moved.
+ */
+const HistoryPoint = v.object({
+  at: v.number(),
+  tokens: v.number(),
+  usd: v.union(v.number(), v.null()),
+  sessions: v.number(),
+  activeDays: v.number(),
+  projects: v.number(),
+  windowDays: v.number(),
+  from: v.string(),
+  to: v.string(),
+  pricingTable: v.union(v.string(), v.null()),
+  harnesses: v.array(
+    v.object({
+      name: v.string(),
+      version: v.union(v.string(), v.null()),
+      capturedAt: v.number(),
+      tokens: v.number(),
+      usd: v.union(v.number(), v.null()),
+    })
+  ),
+  models: v.array(HistoryModel),
+})
+
+const MeasuredHistory = v.object({
+  /** The lookback the series covers, in days. */
+  windowDays: v.number(),
+  /** True when older readings exist but were dropped to bound the answer. */
+  truncated: v.boolean(),
+  /** Only this harness, when the caller asked for one. */
+  harness: v.union(v.string(), v.null()),
+  points: v.array(HistoryPoint),
+})
+
+/** Strip a merged reading down to what a point on the trail needs. */
+function toHistoryPoint(
+  at: number,
+  merged: ReturnType<typeof mergeHarnesses>
+) {
+  return {
+    at,
+    tokens: merged.activity.totalTokens,
+    usd: mergedUSD(merged),
+    sessions: merged.activity.sessions,
+    activeDays: merged.activity.activeDays,
+    projects: merged.activity.projects,
+    windowDays: merged.window.days,
+    from: merged.window.from,
+    to: merged.window.to,
+    pricingTable: merged.pricingTable,
+    harnesses: merged.harnesses.map((h) => ({
+      name: h.harness.name,
+      version: h.harness.version,
+      capturedAt: h.capturedAt,
+      tokens: h.activity.totalTokens,
+      usd: mergedUSD(h),
+    })),
+    models: merged.models.map((m) => ({
+      id: m.id,
+      catalogSlug: m.catalogSlug,
+      catalogName: m.catalogName,
+      tokenShare: m.tokenShare,
+    })),
+  }
+}
+
+/**
+ * The measured history of a published stack, by public slug.
+ *
+ * WHAT A POINT IS. Not one row: one sync, merged exactly the way the headline
+ * merges (`mergeHarnesses`), over the newest reading of every harness AS OF that
+ * moment. So the last point equals `getCurrentByStackSlug` — the page's big
+ * number is the end of its own trail, and no figure on the page restates a
+ * different arithmetic. A harness that did not sync in a given minute carries
+ * its previous reading forward, which is the same thing the headline does today;
+ * `harnesses[].capturedAt` keeps that visible.
+ *
+ * WHY IT NEEDS A SEED. The carry-forward starts before the window: a stack whose
+ * Codex reading is four months old still shows Codex in every point, so the
+ * series does not open by silently dropping a harness the headline includes.
+ *
+ * `harness` narrows the series to one harness through
+ * `by_stack_harness_capturedAt`, with no carry-forward and no merge — that is
+ * one machine's own trail, which is the only honest way to read a per-harness
+ * number (call shares and freshness never merge, #66).
+ *
+ * Rows inside 90 days are one per sync and rows beyond it are one per UTC day
+ * (`gcSnapshots`), so the spacing is irregular by construction. The series
+ * carries real timestamps and the display scales time, rather than pretending
+ * the readings are evenly spaced.
+ */
+export const getHistoryByStackSlug = query({
+  args: {
+    slug: v.string(),
+    days: v.optional(v.number()),
+    harness: v.optional(v.string()),
+  },
+  returns: v.union(MeasuredHistory, v.null()),
+  handler: async (ctx, args) => {
+    const stack = await publishedStackBySlug(ctx, args.slug)
+    if (!stack) return null
+
+    const windowDays = Math.min(
+      HISTORY_MAX_DAYS,
+      Math.max(1, Math.round(args.days ?? HISTORY_DEFAULT_DAYS))
     )
-    // Cache-hit share recomputes from the summed model tokens — the same
-    // input-class formula each client used, over the merged absolute counts.
-    const models = mergeModels(harnesses.map((h) => h.models))
-    let cacheRead = 0
-    let inputClass = 0
-    for (const m of models) {
-      cacheRead += m.tokens.cacheRead
-      inputClass += m.tokens.input + m.tokens.cacheRead + m.tokens.cacheWrite
-    }
-    const pricingTables = [
-      ...new Set(
-        harnesses.map((h) => h.pricingTable).filter((t): t is string => t !== null)
-      ),
-    ]
+    const cutoff = Date.now() - windowDays * 24 * 60 * 60 * 1000
 
+    const rows = args.harness
+      ? await ctx.db
+          .query('measuredSnapshots')
+          .withIndex('by_stack_harness_capturedAt', (q) =>
+            q.eq('stackId', stack._id).eq('harness', args.harness as string)
+          )
+          .collect()
+      : await ctx.db
+          .query('measuredSnapshots')
+          .withIndex('by_stack_capturedAt', (q) => q.eq('stackId', stack._id))
+          .collect()
+    if (rows.length === 0) return null
+
+    const catalog = await loadModelCatalog(ctx)
+    const ordered = [...rows].sort((a, b) => a.capturedAt - b.capturedAt)
+
+    // Fold the rows forward, holding the newest reading of each harness. Rows
+    // older than the window are folded in but emit no point: they are the seed
+    // the first point inside the window carries.
+    const held = new Map<string, HarnessReading>()
+    const points: ReturnType<typeof toHistoryPoint>[] = []
+    let bucket: number | null = null
+    let bucketAt = 0
+
+    const flush = () => {
+      if (bucket === null) return
+      if (bucketAt >= cutoff) {
+        points.push(toHistoryPoint(bucketAt, mergeHarnesses([...held.values()])))
+      }
+      bucket = null
+    }
+
+    for (const row of ordered) {
+      const key = Math.floor(row.capturedAt / SYNC_BUCKET_MS)
+      if (key !== bucket) {
+        flush()
+        bucket = key
+        bucketAt = row.capturedAt
+      }
+      held.set(harnessOf(row), toHarnessSnapshot(catalog, row))
+    }
+    flush()
+
+    if (points.length === 0) return null
+    const truncated = points.length > HISTORY_MAX_POINTS
     return {
-      receivedAt: Math.max(...harnesses.map((h) => h.receivedAt)),
-      capturedAt: Math.max(...harnesses.map((h) => h.capturedAt)),
-      isFresh: harnesses.some((h) => h.isFresh),
-      window: {
-        days: Math.max(...harnesses.map((h) => h.window.days)),
-        from: harnesses.map((h) => h.window.from).sort()[0],
-        to: harnesses.map((h) => h.window.to).sort()[harnesses.length - 1],
-      },
-      pricingTable: pricingTables.length > 0 ? pricingTables.join(' + ') : null,
-      activity: {
-        sessions: harnesses.reduce((a, h) => a + h.activity.sessions, 0),
-        activeDays: Math.max(...harnesses.map((h) => h.activity.activeDays)),
-        projects: Math.max(...harnesses.map((h) => h.activity.projects)),
-        totalTokens,
-        cacheHitShare: inputClass ? cacheRead / inputClass : 0,
-        subagentShare: totalTokens
-          ? harnesses.reduce(
-              (a, h) => a + h.activity.subagentShare * h.activity.totalTokens,
-              0
-            ) / totalTokens
-          : 0,
-      },
-      models,
-      harnesses,
+      windowDays,
+      truncated,
+      harness: args.harness ?? null,
+      points: truncated ? points.slice(-HISTORY_MAX_POINTS) : points,
     }
   },
 })
@@ -723,8 +966,9 @@ export const getReconcileSuggestions = query({
       (stack.modelSubscriptions ?? []).map((m) => m.modelSlug)
     )
     const suggestedSlugs = new Set<string>()
+    const catalog = await loadModelCatalog(ctx)
     for (const snapshot of snapshots) {
-      const resolved = await resolveModels(ctx, snapshot.payload.models)
+      const resolved = resolveModels(catalog, snapshot.payload.models)
       const repriced =
         snapshot.payload.pricingTable !== null
           ? applyReadTimePrices(resolved).models

--- a/convex/measured.ts
+++ b/convex/measured.ts
@@ -773,11 +773,12 @@ export const getHistoryByStackSlug = query({
     )
     const cutoff = Date.now() - windowDays * 24 * 60 * 60 * 1000
 
-    const rows = args.harness
+    const only = args.harness
+    const rows = only
       ? await ctx.db
           .query('measuredSnapshots')
           .withIndex('by_stack_harness_capturedAt', (q) =>
-            q.eq('stackId', stack._id).eq('harness', args.harness as string)
+            q.eq('stackId', stack._id).eq('harness', only)
           )
           .collect()
       : await ctx.db

--- a/src/components/ui/__tests__/hover-card.test.tsx
+++ b/src/components/ui/__tests__/hover-card.test.tsx
@@ -276,3 +276,49 @@ describe("TC-HC-07: inline mode also portals the surface out of container", () =
 		expect(surfaceInContainer).toBeNull();
 	});
 });
+
+// ---------------------------------------------------------------------------
+// TC-HC-08  (wrapper) — a keyboard reader reaches the card
+//
+// The card is mouse-only otherwise: a focusable trigger (the #81 headline block
+// is a button) would deal a card nobody could read. Focus opens it and blur
+// closes it, on the same wrapper that owns the mouse handlers.
+// ---------------------------------------------------------------------------
+describe("TC-HC-08: content shows on focus and hides on blur", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("focusing a control inside the trigger opens the card", async () => {
+		render(
+			<HoverCard
+				mode="wrapper"
+				renderContent={() => <div data-testid="focus-content" />}
+			>
+				<button type="button" data-testid="trigger">
+					T
+				</button>
+			</HoverCard>,
+		);
+
+		const trigger = screen.getByTestId("trigger");
+		expect(screen.queryByTestId("focus-content")).toBeNull();
+
+		act(() => {
+			fireEvent.focus(trigger);
+		});
+		expect(screen.queryByTestId("focus-content")).not.toBeNull();
+
+		act(() => {
+			fireEvent.blur(trigger);
+		});
+		await act(async () => {
+			vi.runAllTimers();
+		});
+		expect(screen.queryByTestId("focus-content")).toBeNull();
+	});
+});

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -213,8 +213,10 @@ const HoverCard = (props: HoverCardProps) => {
 		};
 	}, [isVisible, getCurrentAnchorElement, updateAnchorFromElement]);
 
+	// Takes any synthetic event, because focus opens the card too and only the
+	// event's currentTarget is read.
 	const handleMouseEnter = useCallback(
-		(event: React.MouseEvent<HTMLElement>, index?: number) => {
+		(event: React.SyntheticEvent<HTMLElement>, index?: number) => {
 			if (hideTimeoutRef.current) {
 				clearTimeout(hideTimeoutRef.current);
 				hideTimeoutRef.current = null;
@@ -462,11 +464,16 @@ const HoverCard = (props: HoverCardProps) => {
 	if (props.mode === "wrapper") {
 		return (
 			<div className={cn("relative inline-block", className)}>
+				{/* Focus opens the card as hover does, so a keyboard reader reaches
+				    content a mouse reader gets for free. React's onFocus is focusin,
+				    so a focusable child inside the trigger counts. */}
 				<div
 					ref={triggerRef}
 					onMouseEnter={(e) => handleMouseEnter(e)}
 					onMouseMove={(e) => handleMouseMove(e)}
 					onMouseLeave={handleMouseLeave}
+					onFocus={(e) => handleMouseEnter(e)}
+					onBlur={handleMouseLeave}
 				>
 					{props.children}
 				</div>

--- a/src/features/charts/Sparkline.tsx
+++ b/src/features/charts/Sparkline.tsx
@@ -1,13 +1,13 @@
 /**
- * A sparkline for one row of a list.
+ * A sparkline for one row of a list, or one behind a headline.
  *
- * No axes, no grid, no tooltip and no tab stop: the row around it already
+ * No axes, no grid, no tooltip and no tab stop: whatever surrounds it already
  * carries the numbers and the name. It is a shape, not a chart to read values
- * off. Fixed width and height, so the server needs no measurement and a list of
- * a hundred rows does not schedule a hundred resize observers.
+ * off. Fixed width and height by default, so the server needs no measurement and
+ * a list of a hundred rows does not schedule a hundred resize observers.
  */
 
-import { defineChart, lineY } from "@tanstack/charts";
+import { areaY, defineChart, lineY } from "@tanstack/charts";
 import { Chart } from "@tanstack/react-charts";
 import { scaleLinear, scaleUtc } from "d3-scale";
 import { useMemo } from "react";
@@ -20,10 +20,26 @@ type SparklineProps = {
 	readonly width?: number;
 	readonly height?: number;
 	readonly className?: string;
+	/**
+	 * The paint the line wears. Defaults to the page accent, which is right for a
+	 * sparkline standing on its own. A sparkline inside a row that already wears a
+	 * palette slot must be handed THAT slot: one entity, one color.
+	 */
+	readonly paint?: string;
+	/** Fill under the line. Reads as texture, never as a second series. */
+	readonly area?: boolean;
+	/**
+	 * Fill the container's width instead of holding a fixed one, for a trail used
+	 * as a backdrop. The server draws it at `width` and the browser widens it on
+	 * mount, so the SVG is still complete in the first HTML.
+	 */
+	readonly fluid?: boolean;
 };
 
 const DEFAULT_WIDTH = 120;
 const DEFAULT_HEIGHT = 28;
+/** Same weight as the area under a `TimeSeriesChart` line. */
+const AREA_OPACITY = 0.16;
 
 function Sparkline({
 	points,
@@ -31,6 +47,9 @@ function Sparkline({
 	width = DEFAULT_WIDTH,
 	height = DEFAULT_HEIGHT,
 	className,
+	paint = ACCENT_PAINT,
+	area = false,
+	fluid = false,
 }: SparklineProps) {
 	const rows = useMemo(
 		() =>
@@ -43,7 +62,19 @@ function Sparkline({
 	const definition = useMemo(
 		() =>
 			defineChart({
-				marks: [lineY(rows, { x: "at", y: "value", stroke: ACCENT_PAINT })],
+				marks: [
+					...(area
+						? [
+								areaY(rows, {
+									x: "at",
+									y: "value",
+									fill: paint,
+									fillOpacity: AREA_OPACITY,
+								}),
+							]
+						: []),
+					lineY(rows, { x: "at", y: "value", stroke: paint }),
+				],
 				x: { scale: scaleUtc },
 				y: { scale: scaleLinear },
 				// No axes, no grid, no implicit margin: the line fills the box.
@@ -51,7 +82,7 @@ function Sparkline({
 				margin: 2,
 				keyboard: false,
 			}),
-		[rows],
+		[rows, paint, area],
 	);
 
 	// A line needs two readings. One draws nothing worth a box.
@@ -61,7 +92,7 @@ function Sparkline({
 		<Chart
 			definition={definition}
 			ariaLabel={ariaLabel}
-			width={width}
+			{...(fluid ? { initialWidth: width } : { width })}
 			height={height}
 			className={className}
 		/>

--- a/src/features/charts/__tests__/ssr.test.tsx
+++ b/src/features/charts/__tests__/ssr.test.tsx
@@ -12,6 +12,7 @@ import { renderToString } from "react-dom/server";
 import { describe, expect, test } from "vitest";
 import { BarsChart } from "../BarsChart";
 import type { ChartSeries } from "../data";
+import { CHART_PAINTS } from "../palette";
 import { Sparkline } from "../Sparkline";
 import { StackedAreaChart } from "../StackedAreaChart";
 import { TimeSeriesChart } from "../TimeSeriesChart";
@@ -81,6 +82,31 @@ describe("server rendering", () => {
 		expect(count(html, "path")).toBe(1);
 		expect(count(html, "text")).toBe(0);
 		expect(html).toContain('viewBox="0 0 120 28"');
+	});
+
+	test("a sparkline wears the accent, or the slot its row already wears", () => {
+		// A sparkline inside a row that is already painted from the palette must
+		// wear that same slot: two paints for one entity is two entities.
+		expect(
+			renderToString(<Sparkline points={days(4, 10)} ariaLabel="a" />),
+		).toContain("var(--accent-lime");
+		expect(
+			renderToString(
+				<Sparkline
+					points={days(4, 10)}
+					ariaLabel="a"
+					paint={CHART_PAINTS[2]}
+				/>,
+			),
+		).toContain("var(--chart-3");
+	});
+
+	test("a backdrop sparkline fills its box and carries a fill under the line", () => {
+		const html = renderToString(
+			<Sparkline points={days(4, 10)} ariaLabel="a" area fluid height={140} />,
+		);
+		// Two paths: the fill and the line. A bare sparkline draws only the line.
+		expect(count(html, "path")).toBe(2);
 	});
 });
 

--- a/src/features/measured/MeasuredSection.tsx
+++ b/src/features/measured/MeasuredSection.tsx
@@ -7,23 +7,23 @@ import { api } from "../../../convex/_generated/api";
 import { CommandBlock } from "./CommandLine";
 import {
 	coverageCaveat,
-	fmtShare,
 	fmtTokens,
-	fmtUSD,
 	type HarnessSnapshot,
 	harnessLine,
 	KICKER,
 	keptPrivate,
+	lastCheckLine,
 	MEASURED_ANCHOR,
-	type MeasuredModel,
 	type MeasuredSnapshot,
+	MIX_KICKER,
 	MONO_LABEL,
-	modelLabel,
 	NEVER_SYNCED_BODY,
 	NEVER_SYNCED_TITLE,
+	notchNote,
 	OWNER_NOT_MEASURED_BODY,
 	OWNER_NOT_MEASURED_TITLE,
 	PRIVACY_FOOTNOTE,
+	readingsLine,
 	SYNC_CMD,
 	SYNC_CMD_COMMENT,
 	stalenessLine,
@@ -31,19 +31,33 @@ import {
 	totalUSD,
 	windowSentence,
 } from "./copy";
+import {
+	type MeasuredHistoryPoint,
+	modelTrails,
+	tokenDelta,
+	tokenTrail,
+} from "./history";
+import { MetricBlock } from "./MetricBlock";
+import { ModelShareRows } from "./ModelShareRows";
 
 /**
- * Journey section 01 — the public measured display.
+ * Journey section 01 — the public measured display, living (#81, map #76).
  *
- * Wayfinder ticket #46 (map #29), building variant B locked by #40; #58 moved
- * it to the front of the journey. What ran now literally comes first.
+ * #46 built the still version off #40's variant B; #58 moved it to the front of
+ * the journey; #80 gave it its history as variant I. What ran now literally
+ * comes first, and it moves.
  *
- * Public and unauthenticated: `getCurrentByStackSlug` answers for any published
- * stack and returns null for one that has never synced. That null renders an
- * INVITATION addressed to the reader, never a demerit on the author — every
- * stack but one is in that state, and a page that scolded them for it would be
- * scolding almost everybody. The one exception is the owner looking at their
- * own unsynced stack: they get the two commands that close the gap (#58).
+ * TWO QUERIES, AND ONE OF THEM IS OPTIONAL. The current reading renders the
+ * whole section: headline, model rows, stats, caveats. The series only ADDS the
+ * watermark, the delta, the readings line and the notch. A stack with one sync,
+ * or a page whose series has not answered yet, is a complete page and not a
+ * broken one — which matters because two to five readings is what stacks have.
+ *
+ * Public and unauthenticated. A null current reading renders an INVITATION
+ * addressed to the reader, never a demerit on the author — every stack but a few
+ * is in that state, and a page that scolded them would be scolding almost
+ * everybody. The one exception is the owner looking at their own unsynced stack:
+ * they get the command that closes the gap (#58).
  */
 export function MeasuredSection({
 	index,
@@ -55,6 +69,7 @@ export function MeasuredSection({
 	isOwner: boolean;
 }) {
 	const snapshot = useQuery(api.measured.getCurrentByStackSlug, { slug });
+	const history = useQuery(api.measured.getHistoryByStackSlug, { slug });
 
 	return (
 		<Section index={index} id={MEASURED_ANCHOR}>
@@ -73,38 +88,61 @@ export function MeasuredSection({
 					<NeverMeasured />
 				)
 			) : (
-				<Reading snapshot={snapshot} />
+				<Reading snapshot={snapshot} points={history?.points ?? []} />
 			)}
 		</Section>
 	);
 }
 
-function Reading({ snapshot }: { snapshot: MeasuredSnapshot }) {
+function Reading({
+	snapshot,
+	points,
+}: {
+	snapshot: MeasuredSnapshot;
+	points: readonly MeasuredHistoryPoint[];
+}) {
 	// The COMBINED headline (#66 decision 2): tokens, sessions and dollars sum
 	// honestly across harnesses; each harness keeps its own section below.
 	const cost = totalUSD(snapshot);
 	const multiHarness = snapshot.harnesses.length > 1;
+	const trails = modelTrails(snapshot.models, points);
+	const firstAt = points.length > 0 ? points[0].at : null;
+	const sinceLast = lastCheckLine(tokenDelta(points), fmtTokens);
 
 	return (
 		<div className="grid gap-10 md:grid-cols-[minmax(0,22rem)_1fr]">
 			{/* The reading. The one place on the page a measured dollar appears. */}
 			<div>
-				<p className="font-mono text-5xl font-black leading-none text-fg-primary md:text-6xl">
-					{cost !== null
-						? `≈${fmtUSD(cost)}`
-						: fmtTokens(snapshot.activity.totalTokens)}
-				</p>
-				<p className="mt-2 text-sm text-fg-muted">
-					{cost !== null
-						? `at API prices, over the last ${snapshot.window.days} days`
-						: `tokens over the last ${snapshot.window.days} days`}
-				</p>
+				<MetricBlock
+					tokens={snapshot.activity.totalTokens}
+					usd={cost}
+					windowDays={snapshot.window.days}
+					trail={tokenTrail(points)}
+				/>
 
-				<p className="mt-6 max-w-sm text-sm leading-relaxed text-fg-muted">
+				<div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 px-3">
+					{sinceLast && (
+						<span
+							className={cn(
+								MONO_LABEL,
+								"inline-flex items-center border border-stroke-subtle px-1.5 py-0.5 text-[10px] tracking-wider text-fg-muted",
+							)}
+						>
+							{sinceLast}
+						</span>
+					)}
+					{firstAt !== null && (
+						<span className={cn(MONO_LABEL, "text-fg-muted")}>
+							{readingsLine(points.length, firstAt)}
+						</span>
+					)}
+				</div>
+
+				<p className="mt-6 max-w-sm px-3 text-sm leading-relaxed text-fg-muted">
 					{windowSentence(snapshot.window.days)}
 				</p>
 
-				<div className="mt-6 space-y-1">
+				<div className="mt-6 space-y-1 px-3">
 					<p className={cn(MONO_LABEL, "text-fg-muted")}>
 						{snapshot.window.from} → {snapshot.window.to}
 					</p>
@@ -125,11 +163,16 @@ function Reading({ snapshot }: { snapshot: MeasuredSnapshot }) {
 
 			{/* The split, then the activity stats. */}
 			<div>
-				<div className="space-y-3">
-					{snapshot.models.map((m) => (
-						<ModelRow key={m.id} model={m} showCost={cost !== null} />
-					))}
+				<div className="mb-4 flex flex-wrap items-baseline justify-between gap-x-6 gap-y-1">
+					<p className={cn(MONO_LABEL, "text-accent-lime")}>{MIX_KICKER}</p>
+					{firstAt !== null && points.length > 1 && (
+						<p className="font-mono text-[11px] text-fg-muted">
+							{notchNote(firstAt)}
+						</p>
+					)}
 				</div>
+
+				<ModelShareRows trails={trails} firstAt={firstAt} />
 
 				<div className="mt-8 grid grid-cols-2 gap-px border border-stroke-subtle bg-stroke-subtle sm:grid-cols-4">
 					<Stat
@@ -199,43 +242,6 @@ function HarnessFootnote({
 					{prefix}
 					{stalenessLine(timeAgo(harness.receivedAt))}
 				</p>
-			)}
-		</div>
-	);
-}
-
-/**
- * One model's share of the window.
- *
- * `catalogName` is null for a model the catalog has never heard of, and its
- * tokens are as real as any other row's — on the owner's own window that row is
- * the biggest one. It renders as the raw vendor id, with no error state.
- */
-function ModelRow({
-	model,
-	showCost,
-}: {
-	model: MeasuredModel;
-	showCost: boolean;
-}) {
-	return (
-		<div className="flex items-center gap-4">
-			<span className="w-44 shrink-0 truncate font-mono text-xs text-fg-primary">
-				{modelLabel(model)}
-			</span>
-			<span className="h-2 flex-1 bg-bg-panel">
-				<span
-					className="block h-full bg-accent-lime"
-					style={{ width: `${Math.max(1, model.tokenShare * 100)}%` }}
-				/>
-			</span>
-			<span className="w-14 shrink-0 text-right font-mono text-xs text-fg-muted">
-				{fmtShare(model.tokenShare)}
-			</span>
-			{showCost && model.apiEquivalentUSD !== undefined && (
-				<span className="w-20 shrink-0 text-right font-mono text-xs text-fg-primary">
-					{fmtUSD(model.apiEquivalentUSD)}
-				</span>
 			)}
 		</div>
 	);

--- a/src/features/measured/MetricBlock.tsx
+++ b/src/features/measured/MetricBlock.tsx
@@ -63,16 +63,15 @@ export function MetricBlock({
 				<TokenTip tokens={tokens} usd={usd} tip={deck.tip} />
 			)}
 		>
-			<button
-				type="button"
-				onClick={deck.next}
-				aria-label={DECK_LABEL}
-				className="group relative block w-full cursor-pointer border border-transparent px-3 py-3 text-left transition-colors hover:border-stroke-subtle hover:bg-bg-panel/40"
-			>
-				{/* The watermark stretches to the block's bottom edge. Letterboxed, its
-				    fill stopped mid-block and read as a box drawn around part of the
-				    text and not the rest. */}
-				<span
+			<div className="group relative w-full">
+				{/* The watermark runs off the block's bottom edge, which is why it is
+				    drawn taller than the block and cropped. Letterboxed inside the
+				    block, its fill stopped mid-way and read as a box drawn around part
+				    of the text and not the rest.
+
+				    It sits OUTSIDE the button: the chart renders a `div`, and a button
+				    may only contain phrasing content. */}
+				<div
 					aria-hidden="true"
 					className="pointer-events-none absolute inset-0 overflow-hidden opacity-[0.16]"
 				>
@@ -82,47 +81,61 @@ export function MetricBlock({
 						area
 						fluid
 						width={400}
-						height={150}
-						className="h-full w-full"
+						height={WATERMARK_HEIGHT}
 					/>
-				</span>
+				</div>
 
-				<span className="relative block font-mono text-5xl font-black leading-none text-fg-primary md:text-6xl">
-					{fmtTokens(tokens)}
-				</span>
+				<button
+					type="button"
+					onClick={deck.next}
+					aria-label={DECK_LABEL}
+					className="relative block w-full cursor-pointer border border-transparent px-3 py-3 text-left transition-colors hover:border-stroke-subtle hover:bg-bg-panel/40"
+				>
+					<span className="relative block font-mono text-5xl font-black leading-none text-fg-primary md:text-6xl">
+						{fmtTokens(tokens)}
+					</span>
 
-				{/* Both captions share one grid cell: the row keeps the height of the
+					{/* Both captions share one grid cell: the row keeps the height of the
 				    taller one at rest, so nothing below it can move. */}
-				<span className="relative mt-2 grid">
-					<span
-						className={cn(
-							MONO_LABEL,
-							"col-start-1 row-start-1 flex items-center text-fg-muted transition-opacity duration-150 group-hover:opacity-0",
-						)}
-					>
-						{TOKENS_CAPTION(windowDays)}
+					<span className="relative mt-2 grid">
+						<span
+							className={cn(
+								MONO_LABEL,
+								"col-start-1 row-start-1 flex items-center text-fg-muted transition-opacity duration-150 group-hover:opacity-0",
+							)}
+						>
+							{TOKENS_CAPTION(windowDays)}
+						</span>
+						<span
+							aria-hidden="true"
+							className={cn(
+								MONO_LABEL,
+								"pointer-events-none col-start-1 row-start-1 flex items-center gap-2 font-semibold text-accent-lime opacity-0 transition-opacity duration-150 group-hover:opacity-100",
+							)}
+						>
+							<Dices size={18} />
+							{DECK_HINT}
+						</span>
 					</span>
-					<span
-						aria-hidden="true"
-						className={cn(
-							MONO_LABEL,
-							"pointer-events-none col-start-1 row-start-1 flex items-center gap-2 font-semibold text-accent-lime opacity-0 transition-opacity duration-150 group-hover:opacity-100",
-						)}
-					>
-						<Dices size={18} />
-						{DECK_HINT}
-					</span>
-				</span>
 
-				{/* Roomier than the caption gap above, so the swapped row never crowds
+					{/* Roomier than the caption gap above, so the swapped row never crowds
 				    the second number. */}
-				<span className="relative mt-6 block font-mono text-2xl font-black leading-none text-fg-secondary md:text-3xl">
-					{usd !== null ? `≈${fmtUSD(usd)}` : COST_PRIVATE}
-				</span>
-				<span className={cn(MONO_LABEL, "relative mt-1.5 block text-fg-muted")}>
-					{usd !== null ? COST_CAPTION : COST_PRIVATE_CAPTION}
-				</span>
-			</button>
+					<span className="relative mt-6 block font-mono text-2xl font-black leading-none text-fg-secondary md:text-3xl">
+						{usd !== null ? `≈${fmtUSD(usd)}` : COST_PRIVATE}
+					</span>
+					<span
+						className={cn(MONO_LABEL, "relative mt-1.5 block text-fg-muted")}
+					>
+						{usd !== null ? COST_CAPTION : COST_PRIVATE_CAPTION}
+					</span>
+				</button>
+			</div>
 		</HoverCard>
 	);
 }
+
+/**
+ * Taller than the block on purpose: cropped by the wrapper, the fill bleeds off
+ * the bottom edge instead of ending in a line across the middle of the text.
+ */
+const WATERMARK_HEIGHT = 200;

--- a/src/features/measured/MetricBlock.tsx
+++ b/src/features/measured/MetricBlock.tsx
@@ -78,7 +78,7 @@ export function MetricBlock({
 				>
 					<Sparkline
 						points={trail}
-						ariaLabel=""
+						ariaLabel="tokens at every reading"
 						area
 						fluid
 						width={400}

--- a/src/features/measured/MetricBlock.tsx
+++ b/src/features/measured/MetricBlock.tsx
@@ -1,0 +1,128 @@
+import { Dices } from "lucide-react";
+import HoverCard from "@/components/ui/hover-card";
+import type { ChartPointInput } from "@/features/charts";
+import { Sparkline } from "@/features/charts";
+import { cn } from "@/lib/utils";
+import {
+	COST_CAPTION,
+	COST_PRIVATE,
+	COST_PRIVATE_CAPTION,
+	DECK_HINT,
+	DECK_LABEL,
+	fmtTokens,
+	fmtUSD,
+	MONO_LABEL,
+	TOKENS_CAPTION,
+} from "./copy";
+import { TokenTip, useTipDeck } from "./tokens/TokenTips";
+
+/**
+ * The headline: the number people come for, with its history behind it.
+ *
+ * Locked by #80 and unchanged here:
+ *
+ *   - TOKENS LEAD. Spend sits below, smaller, over the same width — it is
+ *     optional by design (`publishCost`), so it can never be the thing the
+ *     layout rests on.
+ *   - HISTORY IS A WATERMARK, stretched to the block's bottom edge, never a row
+ *     of its own. It costs no vertical space and it never competes with the
+ *     number it stands behind.
+ *   - CLICKING THE BLOCK deals the next framing. A control beside the number sat
+ *     too far from what it changed, so the whole block is the control.
+ *   - THE ROW MUST NOT RESIZE. Both captions live in one grid cell, so the row
+ *     keeps the height of the taller one and only opacity changes on hover.
+ *
+ * The card itself is a hover surface and mounts through a portal, so it never
+ * exists in the server HTML and the deck's shuffle stays invisible to hydration.
+ */
+export function MetricBlock({
+	tokens,
+	usd,
+	windowDays,
+	trail,
+}: {
+	readonly tokens: number;
+	readonly usd: number | null;
+	readonly windowDays: number;
+	/** Every reading so far. Fewer than two draws no watermark. */
+	readonly trail: readonly ChartPointInput[];
+}) {
+	const deck = useTipDeck();
+
+	return (
+		<HoverCard
+			mode="wrapper"
+			position="below"
+			width={340}
+			height="auto"
+			maxRotation={5}
+			maxOffset={8}
+			offset={12}
+			className="w-full"
+			renderContent={() => (
+				<TokenTip tokens={tokens} usd={usd} tip={deck.tip} />
+			)}
+		>
+			<button
+				type="button"
+				onClick={deck.next}
+				aria-label={DECK_LABEL}
+				className="group relative block w-full cursor-pointer border border-transparent px-3 py-3 text-left transition-colors hover:border-stroke-subtle hover:bg-bg-panel/40"
+			>
+				{/* The watermark stretches to the block's bottom edge. Letterboxed, its
+				    fill stopped mid-block and read as a box drawn around part of the
+				    text and not the rest. */}
+				<span
+					aria-hidden="true"
+					className="pointer-events-none absolute inset-0 overflow-hidden opacity-[0.16]"
+				>
+					<Sparkline
+						points={trail}
+						ariaLabel=""
+						area
+						fluid
+						width={400}
+						height={150}
+						className="h-full w-full"
+					/>
+				</span>
+
+				<span className="relative block font-mono text-5xl font-black leading-none text-fg-primary md:text-6xl">
+					{fmtTokens(tokens)}
+				</span>
+
+				{/* Both captions share one grid cell: the row keeps the height of the
+				    taller one at rest, so nothing below it can move. */}
+				<span className="relative mt-2 grid">
+					<span
+						className={cn(
+							MONO_LABEL,
+							"col-start-1 row-start-1 flex items-center text-fg-muted transition-opacity duration-150 group-hover:opacity-0",
+						)}
+					>
+						{TOKENS_CAPTION(windowDays)}
+					</span>
+					<span
+						aria-hidden="true"
+						className={cn(
+							MONO_LABEL,
+							"pointer-events-none col-start-1 row-start-1 flex items-center gap-2 font-semibold text-accent-lime opacity-0 transition-opacity duration-150 group-hover:opacity-100",
+						)}
+					>
+						<Dices size={18} />
+						{DECK_HINT}
+					</span>
+				</span>
+
+				{/* Roomier than the caption gap above, so the swapped row never crowds
+				    the second number. */}
+				<span className="relative mt-6 block font-mono text-2xl font-black leading-none text-fg-secondary md:text-3xl">
+					{usd !== null ? `≈${fmtUSD(usd)}` : COST_PRIVATE}
+				</span>
+				<span className={cn(MONO_LABEL, "relative mt-1.5 block text-fg-muted")}>
+					{usd !== null ? COST_CAPTION : COST_PRIVATE_CAPTION}
+				</span>
+			</button>
+		</HoverCard>
+	);
+}

--- a/src/features/measured/ModelShareRows.tsx
+++ b/src/features/measured/ModelShareRows.tsx
@@ -1,0 +1,196 @@
+import HoverCard from "@/components/ui/hover-card";
+import { Sparkline } from "@/features/charts";
+import { cn } from "@/lib/utils";
+import { fmtDay, fmtShare, MONO_LABEL, readingsLine } from "./copy";
+import type { ModelTrail } from "./history";
+
+/**
+ * Where the tokens went — one row per model, locked as variant I by #80.
+ *
+ * THE CURRENT SHARE IS THE LOUDEST THING IN THE ROW: a solid, full-color bar.
+ * History recedes to a single hatched notch marking where that share stood at
+ * the first reading, and the whole trail lives in the card the bar opens. Five
+ * earlier structures put history in front and every one of them buried the
+ * number the reader came for.
+ *
+ * A model the catalog has never heard of renders as its raw vendor id (#33
+ * decision 3). On the owner's own window that row is the biggest one, so it is
+ * not an error state.
+ */
+export function ModelShareRows({
+	trails,
+	firstAt,
+}: {
+	readonly trails: readonly ModelTrail[];
+	/** The day the notch speaks for, or null when there is only one reading. */
+	readonly firstAt: number | null;
+}) {
+	return (
+		<div className="divide-y divide-stroke-subtle border-y border-stroke-subtle">
+			{trails.map((trail) => (
+				<ModelRow key={trail.id} trail={trail} firstAt={firstAt} />
+			))}
+		</div>
+	);
+}
+
+function ModelRow({
+	trail,
+	firstAt,
+}: {
+	readonly trail: ModelTrail;
+	readonly firstAt: number | null;
+}) {
+	return (
+		<div className="flex items-center gap-3 py-3">
+			<span
+				aria-hidden="true"
+				className="size-3 shrink-0"
+				style={{ background: trail.paint }}
+			/>
+			<span className="w-40 shrink-0 truncate text-sm text-fg-primary">
+				{trail.label}
+			</span>
+
+			{/* The bar is the hover target: the trail lives in the card, so the row
+			    itself stays one solid bar and a number. */}
+			<HoverCard
+				mode="wrapper"
+				position="below"
+				width={300}
+				height="auto"
+				maxRotation={4}
+				maxOffset={6}
+				offset={10}
+				className="flex-1"
+				renderContent={() => <TrailCard trail={trail} firstAt={firstAt} />}
+			>
+				<div className="relative h-7 w-full cursor-help bg-bg-panel">
+					<div
+						className="absolute inset-y-0 left-0"
+						style={{
+							width: `${Math.max(1, trail.share * 100)}%`,
+							background: trail.paint,
+						}}
+					/>
+					{trail.moved && <WasHereNotch at={trail.first} />}
+				</div>
+			</HoverCard>
+
+			<span className="w-14 shrink-0 text-right font-mono text-sm font-bold text-fg-primary">
+				{fmtShare(trail.share)}
+			</span>
+			<span className="w-12 shrink-0 text-right font-mono text-[11px] text-fg-muted">
+				{trail.moved && Math.abs(trail.driftPoints) >= 0.5 ? (
+					<>
+						{trail.driftPoints > 0 ? "↑" : "↓"}
+						{Math.abs(Math.round(trail.driftPoints))}
+					</>
+				) : (
+					"-"
+				)}
+			</span>
+		</div>
+	);
+}
+
+/**
+ * Where this share stood at the first reading.
+ *
+ * Hatched rather than solid, and taller than the bar, so it reads as a ruler
+ * mark laid over the data and never as a slice of it. The stripes are opaque, so
+ * it stays legible over the filled part of the bar and over the empty track.
+ */
+function WasHereNotch({ at }: { at: number }) {
+	return (
+		<span
+			aria-hidden="true"
+			data-testid="share-notch"
+			className="absolute -top-1 -bottom-1 w-[6px] -translate-x-1/2"
+			style={{
+				left: `${Math.min(100, Math.max(0, at * 100))}%`,
+				backgroundImage:
+					"repeating-linear-gradient(135deg, var(--fg-primary) 0 2px, var(--bg-canvas) 2px 4px)",
+			}}
+		/>
+	);
+}
+
+/**
+ * One model's history, on hover: the trail, and one plain sentence saying which
+ * way it went.
+ *
+ * The sentence carries no arithmetic on purpose. "More Opus 5 than before" is
+ * what a reader wants; the exact drift is already on the row, and repeating it
+ * here only makes the card read like a report. Public voice throughout — the
+ * reader is a stranger, so it is "this machine", never "you".
+ */
+function TrailCard({
+	trail,
+	firstAt,
+}: {
+	readonly trail: ModelTrail;
+	readonly firstAt: number | null;
+}) {
+	const many = trail.points.length > 1;
+	return (
+		<div className="border-[3px] border-stroke-strong bg-bg-panel p-4 shadow-[6px_6px_0_var(--stroke-strong)]">
+			<div className="mb-3 flex items-center gap-2 border-b-2 border-stroke-strong pb-2">
+				<span
+					aria-hidden="true"
+					className="size-3 shrink-0"
+					style={{ background: trail.paint }}
+				/>
+				<span className="flex-1 truncate text-sm font-bold text-fg-primary">
+					{trail.label}
+				</span>
+				<span className="font-mono text-sm font-black text-fg-primary">
+					{fmtShare(trail.share)}
+				</span>
+			</div>
+
+			{many && firstAt !== null ? (
+				<>
+					<Sparkline
+						points={trail.points}
+						ariaLabel={`${trail.label} share over ${trail.points.length} readings`}
+						paint={trail.paint}
+						area
+						fluid
+						width={264}
+						height={44}
+						className="w-full"
+					/>
+					<p className={cn(MONO_LABEL, "mt-1.5 text-[10px] text-fg-muted")}>
+						{readingsLine(trail.points.length, firstAt)}
+					</p>
+
+					<p className="mt-3 text-sm leading-relaxed text-fg-secondary">
+						{trail.moved ? (
+							<>
+								This machine is using{" "}
+								<span
+									className={
+										trail.driftPoints > 0
+											? "text-accent-lime"
+											: "text-orange-400"
+									}
+								>
+									{trail.driftPoints > 0 ? "more" : "less"}
+								</span>{" "}
+								{trail.label} than before. The notch marks where it started, on{" "}
+								{fmtDay(firstAt)}.
+							</>
+						) : (
+							<>{trail.label} has held about the same share throughout.</>
+						)}
+					</p>
+				</>
+			) : (
+				<p className="text-sm leading-relaxed text-fg-secondary">
+					One reading so far. The next sync starts this line.
+				</p>
+			)}
+		</div>
+	);
+}

--- a/src/features/measured/__tests__/history.fixture.ts
+++ b/src/features/measured/__tests__/history.fixture.ts
@@ -1,0 +1,328 @@
+/**
+ * The real measured history, shaped the way `measured.getHistoryByStackSlug`
+ * returns it.
+ *
+ * Every reading below is copied from the production `measuredSnapshots` table
+ * as it stood on 2026-08-04 — the whole history that exists: seven readings over
+ * five days, two of them 60 seconds apart, and a second harness three orders of
+ * magnitude smaller than the first. #80 designed against these numbers, so the
+ * display is tested against them too.
+ *
+ * The spend readings run 6071 → 5938 → 6040 → 6040 → 5719 → 5956 → 6030: a
+ * rolling 30-day window is a level, so it falls as often as it rises.
+ */
+import type { MeasuredSnapshot } from "../copy";
+import type { MeasuredHistory, MeasuredHistoryPoint } from "../history";
+import { buildHarness, buildSnapshot } from "./fixture";
+
+type Row = {
+	harness: string;
+	version: string | null;
+	tokens: number;
+	sessions: number;
+	activeDays: number;
+	pricingTable: string | null;
+	/** [id, share, usd] as published. */
+	models: Array<[string, number, number | null]>;
+};
+
+const CATALOG: Record<string, string> = {
+	"claude-opus-5": "Claude Opus 5",
+	"claude-opus-4-8": "Claude Opus 4.8",
+	"claude-sonnet-5": "Claude Sonnet 5",
+	"claude-sonnet-4-6": "Claude Sonnet 4.6",
+	"claude-haiku-4-5": "Claude Haiku 4.5",
+	"gpt-5.5": "GPT-5.5",
+};
+
+const at = (iso: string) => new Date(`${iso}Z`).getTime();
+
+function cc(
+	tokens: number,
+	sessions: number,
+	models: Array<[string, number, number | null]>,
+): Row {
+	return {
+		harness: "claude-code",
+		version: "2.1.220",
+		tokens,
+		sessions,
+		activeDays: 23,
+		pricingTable: "anthropic-list-2026-07-25",
+		models,
+	};
+}
+
+const codex = (tokens: number, sessions: number): Row => ({
+	harness: "codex",
+	version: "0.52.0",
+	tokens,
+	sessions,
+	activeDays: 4,
+	pricingTable: "openai-list-2026-07-25",
+	models: [["gpt-5.5", 1, 11]],
+});
+
+/** The seven real syncs, in order, as rows-per-minute. */
+const SYNCS: Array<{ at: number; rows: Row[] }> = [
+	{
+		at: at("2026-07-30T12:34"),
+		rows: [
+			cc(4_692_280_159, 456, [
+				["claude-opus-5", 0.3547, 1400.35],
+				["claude-fable-5", 0.3373, 3376.59],
+				["claude-opus-4-8", 0.1825, 1002.33],
+				["claude-sonnet-5", 0.1091, 254.74],
+				["claude-haiku-4-5", 0.0127, 17.72],
+				["claude-sonnet-4-6", 0.0036, 19.54],
+			]),
+		],
+	},
+	{
+		at: at("2026-07-31T10:26"),
+		rows: [
+			cc(4_559_930_701, 465, [
+				["claude-opus-5", 0.3655, 1404.12],
+				["claude-fable-5", 0.3505, 3418.58],
+				["claude-opus-4-8", 0.1599, 843.92],
+				["claude-sonnet-5", 0.1117, 253.3],
+				["claude-haiku-4-5", 0.0119, 16.23],
+				["claude-sonnet-4-6", 0.0004, 1.36],
+			]),
+		],
+	},
+	{
+		at: at("2026-08-01T15:35"),
+		rows: [
+			cc(4_604_112_000, 509, [
+				["claude-fable-5", 0.3702, 3489],
+				["claude-opus-5", 0.3611, 1411],
+				["claude-opus-4-8", 0.1598, 872],
+				["claude-sonnet-5", 0.0975, 249],
+				["claude-haiku-4-5", 0.0111, 17],
+				["claude-sonnet-4-6", 0.0003, 2],
+			]),
+			codex(8_120_000, 16),
+		],
+	},
+	{
+		// 60 seconds after the one above. Two readings, not one.
+		at: at("2026-08-01T15:36"),
+		rows: [
+			cc(4_604_390_000, 510, [
+				["claude-fable-5", 0.3702, 3489],
+				["claude-opus-5", 0.3611, 1411],
+				["claude-opus-4-8", 0.1598, 872],
+				["claude-sonnet-5", 0.0975, 249],
+				["claude-haiku-4-5", 0.0111, 17],
+				["claude-sonnet-4-6", 0.0003, 2],
+			]),
+			codex(8_120_000, 16),
+		],
+	},
+	{
+		at: at("2026-08-02T16:13"),
+		rows: [
+			cc(4_427_010_000, 521, [
+				["claude-fable-5", 0.3808, 3312],
+				["claude-opus-5", 0.3779, 1389],
+				["claude-opus-4-8", 0.1512, 761],
+				["claude-sonnet-5", 0.0785, 240],
+				["claude-haiku-4-5", 0.0112, 17],
+				["claude-sonnet-4-6", 0.0004, 0],
+			]),
+			codex(8_140_000, 16),
+		],
+	},
+	{
+		at: at("2026-08-03T17:35"),
+		rows: [
+			cc(4_605_220_000, 550, [
+				["claude-opus-5", 0.3902, 1447],
+				["claude-fable-5", 0.3861, 3401],
+				["claude-opus-4-8", 0.1327, 856],
+				["claude-sonnet-5", 0.0801, 235],
+				["claude-haiku-4-5", 0.0106, 17],
+				["claude-sonnet-4-6", 0.0003, 0],
+			]),
+			codex(8_390_000, 23),
+		],
+	},
+	{
+		at: at("2026-08-03T22:09"),
+		rows: [
+			cc(4_701_330_000, 554, [
+				["claude-opus-5", 0.4011, 1462],
+				["claude-fable-5", 0.3802, 3419],
+				["claude-opus-4-8", 0.1298, 878],
+				["claude-sonnet-5", 0.0782, 238],
+				["claude-haiku-4-5", 0.0104, 17],
+				["claude-sonnet-4-6", 0.0003, 0],
+			]),
+			codex(8_390_000, 23),
+		],
+	},
+];
+
+/** The server's merge, mirrored so the fixture stays a shape and not a stub. */
+function mergePoint(sync: { at: number; rows: Row[] }): MeasuredHistoryPoint {
+	const tokens = sync.rows.reduce((a, r) => a + r.tokens, 0);
+	const priced = sync.rows.filter((r) => r.pricingTable !== null);
+	const usd =
+		priced.length === 0
+			? null
+			: priced.reduce(
+					(a, r) => a + r.models.reduce((b, m) => b + (m[2] ?? 0), 0),
+					0,
+				);
+	const weighted = new Map<string, number>();
+	for (const row of sync.rows) {
+		for (const [id, share] of row.models) {
+			weighted.set(id, (weighted.get(id) ?? 0) + share * row.tokens);
+		}
+	}
+	const models = [...weighted.entries()]
+		.map(([id, w]) => ({
+			id,
+			catalogSlug: CATALOG[id] ? id : null,
+			catalogName: CATALOG[id] ?? null,
+			tokenShare: tokens ? w / tokens : 0,
+		}))
+		.sort((a, b) => b.tokenShare - a.tokenShare);
+
+	return {
+		at: sync.at,
+		tokens,
+		usd,
+		sessions: sync.rows.reduce((a, r) => a + r.sessions, 0),
+		activeDays: Math.max(...sync.rows.map((r) => r.activeDays)),
+		projects: 12,
+		windowDays: 30,
+		from: "2026-07-05",
+		to: "2026-08-03",
+		pricingTable: [...new Set(sync.rows.map((r) => r.pricingTable))]
+			.filter((p): p is string => p !== null)
+			.join(" + "),
+		harnesses: sync.rows.map((r) => ({
+			name: r.harness,
+			version: r.version,
+			capturedAt: sync.at,
+			tokens: r.tokens,
+			usd:
+				r.pricingTable === null
+					? null
+					: r.models.reduce((a, m) => a + (m[2] ?? 0), 0),
+		})),
+		models,
+	};
+}
+
+/**
+ * The real history, optionally cut to its first `readings` syncs — one reading
+ * and two readings are the states almost every stack is actually in.
+ */
+export function buildHistory({
+	readings = SYNCS.length,
+	claudeCodeOnly = false,
+	withoutCost = false,
+}: {
+	readings?: number;
+	claudeCodeOnly?: boolean;
+	withoutCost?: boolean;
+} = {}): MeasuredHistory {
+	const syncs = SYNCS.slice(0, readings).map((s) => ({
+		at: s.at,
+		rows: claudeCodeOnly
+			? s.rows.filter((r) => r.harness === "claude-code")
+			: s.rows,
+	}));
+	const points = syncs.map(mergePoint).map((p) =>
+		withoutCost
+			? {
+					...p,
+					usd: null,
+					pricingTable: null,
+					harnesses: p.harnesses.map((h) => ({ ...h, usd: null })),
+				}
+			: p,
+	);
+	return { windowDays: 90, truncated: false, harness: null, points };
+}
+
+export const NEWEST_AT = SYNCS[SYNCS.length - 1].at;
+
+/**
+ * The current reading that goes with a history — the newest point, as
+ * `getCurrentByStackSlug` returns it.
+ *
+ * The server guarantees these two agree: the headline is the merge of the newest
+ * reading per harness, and the last point of the series is the same merge. The
+ * fixture holds that guarantee so no test can encode a page whose big number
+ * disagrees with the end of its own trail.
+ */
+export function currentFromHistory(history: MeasuredHistory): MeasuredSnapshot {
+	const point = history.points.at(-1);
+	if (!point) throw new Error("a history with no readings has no current");
+	const base = buildSnapshot();
+	const template = base.harnesses[0];
+
+	const models = point.models.map((m) => ({
+		...m,
+		tokens: {
+			input: Math.round(point.tokens * m.tokenShare * 0.01),
+			output: Math.round(point.tokens * m.tokenShare * 0.01),
+			cacheWrite: Math.round(point.tokens * m.tokenShare * 0.03),
+			cacheRead: Math.round(point.tokens * m.tokenShare * 0.95),
+		},
+		...(point.usd === null
+			? {}
+			: { apiEquivalentUSD: point.usd * m.tokenShare }),
+	}));
+
+	return {
+		receivedAt: base.receivedAt,
+		capturedAt: point.at,
+		isFresh: true,
+		window: { days: point.windowDays, from: point.from, to: point.to },
+		pricingTable: point.pricingTable,
+		activity: {
+			...base.activity,
+			sessions: point.sessions,
+			activeDays: point.activeDays,
+			projects: point.projects,
+			totalTokens: point.tokens,
+		},
+		models,
+		harnesses: point.harnesses.map((h, i) =>
+			buildHarness({
+				capturedAt: h.capturedAt,
+				harness: { name: h.name, version: h.version },
+				pricingTable: point.pricingTable,
+				activity: {
+					...template.activity,
+					sessions: h.tokens === point.tokens ? point.sessions : 16,
+					totalTokens: h.tokens,
+				},
+				// The second harness carries nothing withheld, so a kept-private
+				// assertion can only be reading the first one's real counts.
+				...(i === 0
+					? {}
+					: {
+							inventory: {
+								...template.inventory,
+								withheld: {
+									builtinTools: 0,
+									mcpServers: 0,
+									skills: 0,
+									subagents: 0,
+									slashCommands: 0,
+								},
+							},
+						}),
+				models: models.filter((m) =>
+					h.name === "codex" ? m.id.startsWith("gpt") : !m.id.startsWith("gpt"),
+				),
+			}),
+		),
+	};
+}

--- a/src/features/measured/__tests__/history.test.ts
+++ b/src/features/measured/__tests__/history.test.ts
@@ -1,0 +1,135 @@
+/**
+ * The derivations behind the living stack page (#81, building #80's variant I).
+ *
+ * Three of these guard decisions rather than arithmetic:
+ *
+ *   1. THE ROWS ARE THE NEWEST READING'S MODELS. A model the machine no longer
+ *      reports gets no row, because a 0% bar beside a downward arrow says a
+ *      listed thing went unused, which #40 forbids.
+ *   2. THE NOTCH IS WHERE THE SHARE STARTED, and it only exists once there are
+ *      two readings to compare.
+ *   3. A ROLLING WINDOW IS A LEVEL, so the token delta can be negative and the
+ *      page must not read that as a fault.
+ */
+import { describe, expect, it } from "vitest";
+import type { MeasuredHistory } from "../history";
+import { modelTrails, tokenDelta, tokenTrail } from "../history";
+import { buildHistory } from "./history.fixture";
+
+/** The page ranks rows off the current reading and adds the series to them. */
+const trailsOf = (history: MeasuredHistory) =>
+	modelTrails(history.points.at(-1)?.models ?? [], history.points);
+
+describe("modelTrails", () => {
+	it("ranks the models of the newest reading, biggest first", () => {
+		const trails = trailsOf(buildHistory({ claudeCodeOnly: true }));
+		expect(trails.map((t) => t.label)).toEqual([
+			"Claude Opus 5",
+			"claude-fable-5",
+			"Claude Opus 4.8",
+			"Claude Sonnet 5",
+			"Claude Haiku 4.5",
+			"Claude Sonnet 4.6",
+		]);
+	});
+
+	it("renders a model the catalog has never heard of as its raw id", () => {
+		// claude-fable-5 is the second-largest row in the real window. Dropping it
+		// or marking it an error would lose a third of the machine's tokens.
+		const trails = trailsOf(buildHistory({ claudeCodeOnly: true }));
+		const fable = trails.find((t) => t.id === "claude-fable-5");
+		expect(fable?.label).toBe("claude-fable-5");
+		expect(fable?.share).toBeCloseTo(0.3802, 4);
+	});
+
+	it("carries each model's whole trail, one value per reading", () => {
+		const history = buildHistory({ claudeCodeOnly: true });
+		const opus5 = trailsOf(history).find((t) => t.id === "claude-opus-5");
+		expect(opus5?.points).toHaveLength(history.points.length);
+		expect(opus5?.points[0].value).toBeCloseTo(0.3547, 4);
+		expect(opus5?.points.at(-1)?.value).toBeCloseTo(0.4011, 4);
+	});
+
+	it("marks where a share started, and says which way it moved", () => {
+		// The real five days: Opus 5 rose 35% → 40%, Opus 4.8 fell 18% → 13%.
+		const trails = trailsOf(buildHistory({ claudeCodeOnly: true }));
+		const opus5 = trails.find((t) => t.id === "claude-opus-5");
+		const opus48 = trails.find((t) => t.id === "claude-opus-4-8");
+
+		expect(opus5?.first).toBeCloseTo(0.3547, 4);
+		expect(opus5?.driftPoints).toBeCloseTo(4.64, 2);
+		expect(opus5?.moved).toBe(true);
+		expect(opus48?.driftPoints).toBeCloseTo(-5.27, 2);
+		expect(opus48?.moved).toBe(true);
+	});
+
+	it("has nothing to mark on a stack that has synced once", () => {
+		const trails = trailsOf(
+			buildHistory({ readings: 1, claudeCodeOnly: true }),
+		);
+		expect(trails).toHaveLength(6);
+		for (const trail of trails) {
+			expect(trail.moved).toBe(false);
+			expect(trail.driftPoints).toBe(0);
+			expect(trail.points).toHaveLength(1);
+		}
+	});
+
+	it("gives every row its own paint, and never repaints a survivor", () => {
+		const trails = trailsOf(buildHistory({ claudeCodeOnly: true }));
+		const paints = trails.map((t) => t.paint);
+		expect(new Set(paints).size).toBe(paints.length);
+		// The lead model keeps slot one whether or not the tail exists.
+		const shorter = trailsOf(
+			buildHistory({ readings: 1, claudeCodeOnly: true }),
+		);
+		expect(shorter[0].paint).toBe(trails[0].paint);
+	});
+
+	it("folds a seventh model into one row rather than inventing a hue", () => {
+		const history = buildHistory({ claudeCodeOnly: true });
+		const last = history.points.at(-1);
+		if (!last) throw new Error("fixture has no readings");
+		const points = [
+			...history.points.slice(0, -1),
+			{
+				...last,
+				models: [
+					...last.models.map((m) => ({ ...m, tokenShare: m.tokenShare * 0.9 })),
+					{
+						id: "gpt-5.5",
+						catalogSlug: "gpt-5-5",
+						catalogName: "GPT-5.5",
+						tokenShare: 0.1,
+					},
+				],
+			},
+		];
+		const trails = modelTrails(points.at(-1)?.models ?? [], points);
+		expect(trails).toHaveLength(6);
+		expect(trails.at(-1)?.id).toBe("__rest");
+		expect(trails.at(-1)?.label).toBe("everything else");
+		// Nothing is lost: the fold carries the tail's whole share.
+		const total = trails.reduce((a, t) => a + t.share, 0);
+		expect(total).toBeCloseTo(1, 6);
+	});
+});
+
+describe("the trail behind the headline", () => {
+	it("is one value per reading, in time order", () => {
+		const history = buildHistory();
+		const trail = tokenTrail(history.points);
+		expect(trail).toHaveLength(7);
+		expect(trail[0].at).toBeLessThan(trail[6].at);
+		expect(trail[0].value).toBe(history.points[0].tokens);
+	});
+
+	it("reports a fall as a fall — the window forgets its far end", () => {
+		const history = buildHistory({ readings: 5, claudeCodeOnly: true });
+		expect(tokenDelta(history.points)).toBe(4_427_010_000 - 4_604_390_000);
+	});
+
+	it("has no delta to report on a first reading", () => {
+		expect(tokenDelta(buildHistory({ readings: 1 }).points)).toBeNull();
+	});
+});

--- a/src/features/measured/__tests__/measured-section.test.tsx
+++ b/src/features/measured/__tests__/measured-section.test.tsx
@@ -1,23 +1,31 @@
 // @vitest-environment jsdom
 /**
- * Journey section 01 — "Actual Usage" (#46, building #40's variant B;
- * renamed and moved to the front by #58/#59).
+ * Journey section 01 — "Actual Usage", now living (#81, building #80's variant
+ * I over the #46 section).
  *
- * Four of these tests guard decisions rather than layout:
+ * The decisions these tests guard, rather than layout:
  *
- *   1. NO SNAPSHOT IS AN INVITATION, not a demerit. Every stack but one is in
- *      that state, so a page that scolded them would scold almost everybody.
- *   2. POSITIVE CLAIMS ONLY. #40 rejected variant C for labelling four models
- *      "listed, but not seen" when all four were genuinely in use, just not
- *      through Claude Code.
- *   3. A DOLLAR FIGURE NEVER APPEARS WITHOUT ITS PRICING TABLE.
- *   4. KEPT-PRIVATE COUNTS ARE COUNTS, never a percentage.
+ *   1. TOKENS LEAD, SPEND SITS UNDER THEM. Spend is optional by design
+ *      (`publishCost`), and a page whose headline can vanish is a page that
+ *      changes shape per stack.
+ *   2. NO SNAPSHOT IS AN INVITATION, not a demerit. Almost every stack is in
+ *      that state.
+ *   3. POSITIVE CLAIMS ONLY (#40): nothing here may say a listed thing went
+ *      unused.
+ *   4. A DOLLAR FIGURE NEVER APPEARS WITHOUT ITS PRICING TABLE.
+ *   5. KEPT-PRIVATE COUNTS ARE COUNTS, never a percentage.
+ *   6. THE PAGE RENDERS WHOLE WITHOUT ITS HISTORY. The series adds the trail,
+ *      the notch and the delta; it is never what makes the section readable.
  */
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { getFunctionName } from "convex/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MeasuredSection } from "@/features/measured/MeasuredSection";
+import { api } from "../../../../convex/_generated/api";
 import type { MeasuredSnapshot } from "../copy";
-import { buildSnapshot, DAY, withoutCost } from "./fixture";
+import type { MeasuredHistory } from "../history";
+import { DAY } from "./fixture";
+import { buildHistory, currentFromHistory } from "./history.fixture";
 
 const queryMock = vi.fn();
 
@@ -38,74 +46,152 @@ afterEach(() => {
 
 function setup(
 	snapshot: MeasuredSnapshot | null | undefined,
+	history: MeasuredHistory | null | undefined = null,
 	{ isOwner = false }: { isOwner?: boolean } = {},
 ) {
-	queryMock.mockReturnValue(snapshot);
+	const historyRef = getFunctionName(api.measured.getHistoryByStackSlug);
+	queryMock.mockImplementation((ref: Parameters<typeof getFunctionName>[0]) =>
+		getFunctionName(ref) === historyRef ? history : snapshot,
+	);
 	render(
 		<MeasuredSection index={1} slug="alps-stack-ab12" isOwner={isOwner} />,
 	);
 }
 
+/** The real seven readings, and the current reading that goes with them. */
+function live(options: Parameters<typeof buildHistory>[0] = {}) {
+	const history = buildHistory(options);
+	return { history, current: currentFromHistory(history) };
+}
+
 describe("the reading", () => {
-	it("leads with the dollar figure and dates it", () => {
-		setup(buildSnapshot());
-		expect(screen.getByText("≈$5,840")).toBeInTheDocument();
+	it("leads with tokens and puts spend underneath", () => {
+		const { current, history } = live({ claudeCodeOnly: true });
+		setup(current, history);
+		expect(screen.getByText("4.70B")).toBeInTheDocument();
+		expect(screen.getByText("tokens · last 30 days")).toBeInTheDocument();
+		expect(screen.getByText("≈$6,014")).toBeInTheDocument();
+		expect(screen.getByText("at api list prices")).toBeInTheDocument();
+	});
+
+	it("names the window as the thing that moves", () => {
+		const { current, history } = live();
+		setup(current, history);
 		expect(
-			screen.getByText("at API prices, over the last 30 days"),
+			screen.getByText(/rolling 30-day reading, not a running total/),
 		).toBeInTheDocument();
+		expect(screen.getByText("2026-07-05 → 2026-08-03")).toBeInTheDocument();
+	});
+
+	it("dates every dollar it prints", () => {
+		const { current, history } = live({ claudeCodeOnly: true });
+		setup(current, history);
 		expect(
 			screen.getByText(/prices: anthropic-list-2026-07-25/),
 		).toBeInTheDocument();
 	});
 
-	it("names the window as the thing that moves", () => {
-		setup(buildSnapshot());
-		expect(
-			screen.getByText(/rolling 30-day reading, not a running total/),
-		).toBeInTheDocument();
-		expect(screen.getByText("2026-06-27 → 2026-07-26")).toBeInTheDocument();
-	});
-
-	it("swaps the headline to tokens rather than blanking a money slot", () => {
-		setup(withoutCost());
-		expect(screen.getByText("4.27B")).toBeInTheDocument();
-		expect(
-			screen.getByText("tokens over the last 30 days"),
-		).toBeInTheDocument();
+	it("reads as complete on a stack that publishes no cost", () => {
+		const { current, history } = live({ withoutCost: true });
+		setup(current, history);
+		expect(screen.getByText("4.71B")).toBeInTheDocument();
+		expect(screen.getByText("cost not published")).toBeInTheDocument();
 		expect(document.body.textContent).not.toContain("$");
-	});
-
-	it("prints no dollars at all when the pricing table is missing", () => {
-		// The per-model column has to go too, not just the headline.
-		setup(buildSnapshot({ pricingTable: null }));
-		expect(document.body.textContent).not.toContain("$");
-		expect(screen.getByText("4.27B")).toBeInTheDocument();
 	});
 
 	it("shows the model split, raw vendor id and all", () => {
-		setup(buildSnapshot());
+		const { current, history } = live({ claudeCodeOnly: true });
+		setup(current, history);
 		expect(screen.getByText("claude-fable-5")).toBeInTheDocument();
-		expect(screen.getByText("35.1%")).toBeInTheDocument();
 		expect(screen.getByText("Claude Opus 5")).toBeInTheDocument();
+		expect(screen.getByText("40.1%")).toBeInTheDocument();
 	});
 
 	it("shows the activity stats", () => {
-		setup(buildSnapshot());
-		expect(screen.getByText("382")).toBeInTheDocument();
-		expect(screen.getByText("22 of 30")).toBeInTheDocument();
-		expect(screen.getByText("95%")).toBeInTheDocument();
-		expect(screen.getByText("33%")).toBeInTheDocument();
+		const { current, history } = live({ claudeCodeOnly: true });
+		setup(current, history);
+		expect(screen.getByText("554")).toBeInTheDocument();
+		expect(screen.getByText("23 of 30")).toBeInTheDocument();
 	});
 
 	it("says how long ago the machine was read, from the server clock", () => {
-		setup(buildSnapshot());
+		const { current, history } = live();
+		setup(current, history);
 		expect(screen.getByText("checked 2h ago")).toBeInTheDocument();
+	});
+
+	it("names each harness it read from", () => {
+		const { current, history } = live();
+		setup(current, history);
+		expect(screen.getByText(/read from Claude Code/)).toBeInTheDocument();
+		expect(screen.getByText(/read from Codex/)).toBeInTheDocument();
+	});
+});
+
+describe("the page moving", () => {
+	it("says how many readings there are, and since when", () => {
+		const { current, history } = live();
+		setup(current, history);
+		expect(screen.getByText("7 readings since Jul 30")).toBeInTheDocument();
+	});
+
+	it("reports a fall as a fall, in plain words", () => {
+		// The window forgets its far end, so a quiet week lowers the reading. That
+		// is not a fault and the page must not dress it as one.
+		const { current, history } = live({ readings: 5, claudeCodeOnly: true });
+		setup(current, history);
+		expect(
+			screen.getByText(/−177.4M since the last check/),
+		).toBeInTheDocument();
+	});
+
+	it("marks where each model's share started once there are two readings", () => {
+		const { current, history } = live({ claudeCodeOnly: true });
+		setup(current, history);
+		expect(
+			screen.getByText(/the hatched notch marks where each share stood on/),
+		).toBeInTheDocument();
+		expect(screen.getAllByTestId("share-notch").length).toBeGreaterThan(0);
+	});
+
+	it("draws no notch and no delta on a stack that has synced once", () => {
+		const { current, history } = live({ readings: 1, claudeCodeOnly: true });
+		setup(current, history);
+		expect(screen.queryByTestId("share-notch")).not.toBeInTheDocument();
+		expect(document.body.textContent).not.toContain("since the last check");
+		expect(screen.getByText("1 reading since Jul 30")).toBeInTheDocument();
+		// The reading itself is still the whole section.
+		expect(screen.getByText("4.69B")).toBeInTheDocument();
+	});
+
+	it("renders whole while the series is still out", () => {
+		const { current } = live();
+		setup(current, undefined);
+		expect(screen.getByText("4.71B")).toBeInTheDocument();
+		expect(screen.getByText("Claude Opus 5")).toBeInTheDocument();
+		expect(document.body.textContent).not.toContain("readings since");
+	});
+});
+
+describe("the fun-fact deck", () => {
+	it("offers another way to picture the number, without hiding the caption", () => {
+		const { current, history } = live();
+		setup(current, history);
+		const deal = screen.getByRole("button", {
+			name: /another way to picture/i,
+		});
+		expect(screen.getByText("tokens · last 30 days")).toBeInTheDocument();
+		// Clicking deals the next framing. The card itself is a hover surface, so
+		// what this asserts is that the control exists and stays quiet.
+		fireEvent.click(deal);
+		expect(screen.getByText("tokens · last 30 days")).toBeInTheDocument();
 	});
 });
 
 describe("what the reading admits", () => {
 	it("counts what was kept private, without scoring it", () => {
-		setup(buildSnapshot());
+		const { current, history } = live({ claudeCodeOnly: true });
+		setup(current, history);
 		expect(
 			screen.getByText(/kept private: 2 MCP servers, 10 skills/),
 		).toBeInTheDocument();
@@ -113,23 +199,27 @@ describe("what the reading admits", () => {
 	});
 
 	it("stays quiet about a clean scan", () => {
-		setup(buildSnapshot());
+		const { current, history } = live();
+		setup(current, history);
 		expect(document.body.textContent).not.toContain("Partial read");
 	});
 
 	it("calls a degraded scan a floor", () => {
+		const { current, history } = live({ claudeCodeOnly: true });
 		setup(
-			buildSnapshot(
-				{},
-				{
+			{
+				...current,
+				harnesses: current.harnesses.map((h) => ({
+					...h,
 					coverage: {
 						filesScanned: 3015,
 						filesUnreadable: 61,
 						linesParsed: 232058,
 						linesFailed: 4192,
 					},
-				},
-			),
+				})),
+			},
+			history,
 		);
 		expect(
 			screen.getByText(/The numbers below are a floor/),
@@ -137,11 +227,19 @@ describe("what the reading admits", () => {
 	});
 
 	it("admits when the reading is going stale", () => {
+		const { current, history } = live({ claudeCodeOnly: true });
 		setup(
-			buildSnapshot(
-				{ receivedAt: Date.now() - 19 * DAY, isFresh: false },
-				{ receivedAt: Date.now() - 19 * DAY, isFresh: false },
-			),
+			{
+				...current,
+				receivedAt: Date.now() - 19 * DAY,
+				isFresh: false,
+				harnesses: current.harnesses.map((h) => ({
+					...h,
+					receivedAt: Date.now() - 19 * DAY,
+					isFresh: false,
+				})),
+			},
+			history,
 		);
 		expect(screen.getByText(/this reading is going stale/)).toBeInTheDocument();
 	});
@@ -156,15 +254,11 @@ describe("a stack that has never synced, seen by a visitor", () => {
 		expect(
 			screen.getByText(/Stacks can publish what actually ran/),
 		).toBeInTheDocument();
-		// The section keeps its place in the journey either way — and since #58
-		// it leads the journey.
 		expect(screen.getByText("Actual Usage")).toBeInTheDocument();
 		expect(screen.getByText("01")).toBeInTheDocument();
 	});
 
 	it("hands the reader the command for their own stack, and the guide", () => {
-		// #58: the visitor line is addressed to the READER ("a stack of your
-		// own"), never to the author of this one.
 		setup(null);
 		expect(screen.getByText(/have a stack of your own/)).toBeInTheDocument();
 		expect(screen.getByText("npx @use-aistack/cli sync")).toBeInTheDocument();
@@ -174,9 +268,7 @@ describe("a stack that has never synced, seen by a visitor", () => {
 	});
 
 	it("says nothing at all while the query is still out", () => {
-		// Undefined is "not answered yet". Rendering the invitation here would
-		// claim a stack was never measured a beat before learning that it was.
-		setup(undefined);
+		setup(undefined, undefined);
 		expect(
 			screen.queryByText("This stack has not been measured yet."),
 		).not.toBeInTheDocument();
@@ -186,9 +278,7 @@ describe("a stack that has never synced, seen by a visitor", () => {
 
 describe("a stack that has never synced, seen by its owner", () => {
 	it("teaches the one command inline", () => {
-		// #74: `sync` starts the login flow inline on an unlinked machine, so
-		// honest teaching is one command.
-		setup(null, { isOwner: true });
+		setup(null, null, { isOwner: true });
 		expect(
 			screen.getByText("Your stack has not been measured yet."),
 		).toBeInTheDocument();
@@ -199,7 +289,7 @@ describe("a stack that has never synced, seen by its owner", () => {
 	});
 
 	it("states the privacy footnote and links the guide", () => {
-		setup(null, { isOwner: true });
+		setup(null, null, { isOwner: true });
 		expect(
 			screen.getByText(
 				"runs on your machine · you see everything before it sends · cancel sends nothing",
@@ -211,27 +301,20 @@ describe("a stack that has never synced, seen by its owner", () => {
 		);
 	});
 
-	it("offers a copy button for the command", () => {
-		setup(null, { isOwner: true });
-		expect(
-			screen.getByLabelText("Copy npx @use-aistack/cli sync"),
-		).toBeInTheDocument();
-	});
-
 	it("shows the reading, not the teaching box, once a snapshot exists", () => {
-		setup(buildSnapshot(), { isOwner: true });
+		const { current, history } = live();
+		setup(current, history, { isOwner: true });
 		expect(
 			screen.queryByText("Your stack has not been measured yet."),
 		).not.toBeInTheDocument();
-		expect(screen.getByText("≈$5,840")).toBeInTheDocument();
+		expect(screen.getByText("4.71B")).toBeInTheDocument();
 	});
 });
 
 describe("positive claims only", () => {
 	it("never says a listed thing went unused", () => {
-		// #40 rejected variant C on real data: the four models it labelled
-		// "listed, but not seen" were all in use, just not through Claude Code.
-		setup(buildSnapshot());
+		const { current, history } = live();
+		setup(current, history);
 		const text = (document.body.textContent ?? "").toLowerCase();
 		for (const banned of [
 			"not seen",

--- a/src/features/measured/__tests__/token-scale.test.ts
+++ b/src/features/measured/__tests__/token-scale.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Making a token count tangible (#80's deck, built by #81).
+ *
+ * The expected values here are the ones #80 published while the owner judged
+ * the cards — 4,709,720,000 real tokens reading as 39,000 novels, 72% of
+ * Wikipedia, 21.2 GB and 486 hours of video. They are the specification, not a
+ * recomputation of the code.
+ *
+ * Every framing rests on stated assumptions, and the one rule the audit added is
+ * that no card may change modality halfway: the video card converts tokens to
+ * visual tokens to frames to runtime and never borrows the words-per-token rule.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	fmtBytes,
+	fmtCount,
+	fmtDuration,
+	tokenScale,
+} from "../tokens/tokenScale";
+
+/** The owner's own window, to the token, as #80 measured it. */
+const REAL = 4_709_720_000;
+
+describe("tokenScale", () => {
+	it("reads the real window as 3.5 billion words", () => {
+		expect(fmtCount(tokenScale(REAL).words)).toBe("3.5 billion");
+	});
+
+	it("counts a shelf of 39,000 novels, and 3,300 runs of Harry Potter", () => {
+		const s = tokenScale(REAL);
+		expect(fmtCount(s.novels)).toBe("39,000");
+		expect(fmtCount(s.harryPotter)).toBe("3,300");
+	});
+
+	it("comes to 72% of every word in the English Wikipedia", () => {
+		expect(Math.round(tokenScale(REAL).wikipedia * 100)).toBe(72);
+	});
+
+	it("fills 21.2 GB as plain text", () => {
+		expect(fmtBytes(tokenScale(REAL).bytes)).toBe("21.2 GB");
+	});
+
+	it("buys 486 hours of full HD video, or 43 runs of the trilogy", () => {
+		// Vision math, not words: a frame costs ceil(w/28) x ceil(h/28) visual
+		// tokens, so 1920x1080 is 2,691 and video is sampled about once a second.
+		const s = tokenScale(REAL);
+		expect(Math.round(s.videoHours)).toBe(486);
+		expect(Math.round(s.lotrTrilogies)).toBe(43);
+	});
+
+	it("scales to nothing when a stack has nothing measured", () => {
+		const s = tokenScale(0);
+		expect(s.words).toBe(0);
+		expect(s.novels).toBe(0);
+		expect(s.videoHours).toBe(0);
+	});
+});
+
+describe("the formats a person can say out loud", () => {
+	it("rounds a count to the digits worth reading", () => {
+		expect(fmtCount(39_247)).toBe("39,000");
+		expect(fmtCount(3_258)).toBe("3,300");
+		expect(fmtCount(42.8)).toBe("43");
+		expect(fmtCount(0.42)).toBe("0.42");
+	});
+
+	it("drops to months, days and hours when years would round to zero", () => {
+		expect(fmtDuration(4.4)).toBe("4 years");
+		expect(fmtDuration(0.5)).toBe("6 months");
+		expect(fmtDuration(0.02)).toBe("7 days");
+		expect(fmtDuration(0.0001)).toBe("1 hour");
+	});
+});

--- a/src/features/measured/__tests__/token-tips.test.tsx
+++ b/src/features/measured/__tests__/token-tips.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+/**
+ * The fun-fact deck (#80's fifteen framings, built by #81).
+ *
+ * The deck exists to make a token count feel like something, and the whole
+ * reason it is allowed to be fun is that it never overstates:
+ *
+ *   1. EVERY CARD NAMES THE EXACT COUNT and says the dollar figure is not money
+ *      spent. A stack that keeps cost private still reads as complete.
+ *   2. EVERY CARD STATES ITS ASSUMPTION. Thirteen rest on words per token and
+ *      say so; electricity and video rest on something else and carry their own
+ *      note instead of borrowing that one.
+ *   3. NO CARD CLAIMS A THING WENT UNUSED (#40).
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { TIPS, TokenTip } from "../tokens/TokenTips";
+
+const REAL = 4_709_720_000;
+
+afterEach(cleanup);
+
+describe("every framing in the deck", () => {
+	it("names the exact token count and calls the money what it is not", () => {
+		for (const { key } of TIPS) {
+			cleanup();
+			render(<TokenTip tokens={REAL} usd={6026} tip={key} />);
+			expect(screen.getByText("4,709,720,000")).toBeInTheDocument();
+			expect(screen.getByText("Not money spent.")).toBeInTheDocument();
+			expect(
+				screen.getByText(/would cost at public list prices/),
+			).toBeInTheDocument();
+		}
+	});
+
+	it("states the assumption it rests on", () => {
+		const shared = "rough: about 0.75 words per token.";
+		for (const { key } of TIPS) {
+			cleanup();
+			render(<TokenTip tokens={REAL} usd={6026} tip={key} />);
+			if (key === "power") {
+				expect(
+					screen.getByText(/No vendor publishes a per-token figure/),
+				).toBeInTheDocument();
+			} else if (key === "video") {
+				expect(screen.getByText(/vision math, not words/)).toBeInTheDocument();
+			} else {
+				expect(screen.getByText(shared)).toBeInTheDocument();
+			}
+		}
+	});
+
+	it("reads as complete on a stack that publishes no cost", () => {
+		for (const { key } of TIPS) {
+			cleanup();
+			render(<TokenTip tokens={REAL} usd={null} tip={key} />);
+			expect(document.body.textContent).not.toContain("$");
+			expect(
+				screen.getByText(/This stack does not publish a cost/),
+			).toBeInTheDocument();
+		}
+	});
+
+	it("never says a listed thing went unused", () => {
+		for (const { key } of TIPS) {
+			cleanup();
+			render(<TokenTip tokens={REAL} usd={6026} tip={key} />);
+			const text = (document.body.textContent ?? "").toLowerCase();
+			for (const banned of ["not seen", "unused", "never used", "no longer"]) {
+				expect(text).not.toContain(banned);
+			}
+		}
+	});
+});
+
+describe("the cards the owner judged", () => {
+	it("counts the shelf of novels", () => {
+		render(<TokenTip tokens={REAL} usd={6026} tip="books" />);
+		expect(screen.getByText("39,000 novels")).toBeInTheDocument();
+		expect(screen.getByText(/3,300 times over/)).toBeInTheDocument();
+	});
+
+	it("reports video as runtime, never as scripts read", () => {
+		// The one defect the audit found: converting words into film scripts and
+		// then reporting those films' running time changes modality mid-sentence.
+		render(<TokenTip tokens={REAL} usd={6026} tip="video" />);
+		expect(screen.getByText("486 hours")).toBeInTheDocument();
+		expect(screen.getByText("2,691")).toBeInTheDocument();
+		expect(document.body.textContent).not.toMatch(/script/i);
+	});
+
+	it("holds its shape when a stack has just started measuring", () => {
+		for (const { key } of TIPS) {
+			cleanup();
+			render(<TokenTip tokens={1200} usd={0.04} tip={key} />);
+			expect(screen.getByText("1,200")).toBeInTheDocument();
+		}
+	});
+});

--- a/src/features/measured/copy.ts
+++ b/src/features/measured/copy.ts
@@ -66,6 +66,54 @@ export function fmtShare(share: number): string {
 }
 
 /**
+ * A move, signed. A rolling window is a LEVEL, so a minus sign here is ordinary
+ * — the window forgot a busy day at its far end — and the wording around it must
+ * never dress a fall as a fault.
+ */
+export function fmtDelta(n: number, fmt: (v: number) => string): string {
+	const sign = n > 0 ? "+" : n < 0 ? "−" : "±";
+	return `${sign}${fmt(Math.abs(n))}`;
+}
+
+/** "Jul 30" — a reading's day, always read as UTC. */
+export function fmtDay(at: number): string {
+	return new Date(at).toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+		timeZone: "UTC",
+	});
+}
+
+/** "7 readings since Jul 30" — how alive the page is, in one line. */
+export function readingsLine(count: number, firstAt: number): string {
+	return `${count} ${count === 1 ? "reading" : "readings"} since ${fmtDay(firstAt)}`;
+}
+
+/** The delta chip beside the headline. Null on a first reading. */
+export function lastCheckLine(
+	delta: number | null,
+	fmt: (v: number) => string,
+): string | null {
+	if (delta === null) return null;
+	return `${fmtDelta(delta, fmt)} since the last check`;
+}
+
+/** The kicker over the model rows, and the note that explains the notch. */
+export const MIX_KICKER = "where the tokens went";
+export function notchNote(firstAt: number): string {
+	return `the hatched notch marks where each share stood on ${fmtDay(firstAt)}`;
+}
+
+/** The captions under the two headline numbers. */
+export const TOKENS_CAPTION = (days: number) => `tokens · last ${days} days`;
+export const COST_CAPTION = "at api list prices";
+export const COST_PRIVATE = "kept private";
+export const COST_PRIVATE_CAPTION = "cost not published";
+/** The hover swap under the number, and the accessible name of the control. */
+export const DECK_HINT = "random fun fact";
+export const DECK_LABEL = "Show another way to picture these tokens";
+
+/**
  * The dollars the whole window cost at API prices, or null.
  *
  * Null in two cases, and the display must treat both the same way: the client

--- a/src/features/measured/history.ts
+++ b/src/features/measured/history.ts
@@ -1,0 +1,159 @@
+/**
+ * The living stack page's derivations — the series, read as the page reads it.
+ *
+ * Wayfinder ticket #81 (map #76), building the variant I design locked by #80.
+ * Three rules come from the data and not from taste:
+ *
+ *   1. A SNAPSHOT IS A ROLLING 30-DAY TOTAL, never a daily delta. Two readings
+ *      cannot be differenced into "what ran that day": the window slides, so the
+ *      difference is days added minus days dropped. Every figure here is a level
+ *      and it falls as often as it rises.
+ *   2. THE ROWS ARE THE NEWEST READING'S MODELS. A model an older reading
+ *      carried and the newest does not gets no row of its own — a 0% bar with a
+ *      downward arrow beside it says a listed thing went unused, and positive
+ *      claims only (#40) forbids that until the adapter seam covers every
+ *      harness the reader runs.
+ *   3. THE THIN CASE IS THE ONLY CASE. Two to five readings is what stacks have,
+ *      and everything here has to answer at one reading too.
+ *
+ * Colors come from the shared chart module (#91): the model rows are a
+ * categorical set, so they wear the validated palette in slot order and never
+ * the page accent.
+ */
+import type { FunctionReturnType } from "convex/server";
+import {
+	CHART_PAINTS,
+	CHART_SLOT_COUNT,
+	type ChartPointInput,
+} from "@/features/charts";
+import type { api } from "../../../convex/_generated/api";
+
+export type MeasuredHistory = NonNullable<
+	FunctionReturnType<typeof api.measured.getHistoryByStackSlug>
+>;
+export type MeasuredHistoryPoint = MeasuredHistory["points"][number];
+export type MeasuredHistoryModel = MeasuredHistoryPoint["models"][number];
+
+/** The id the folded tail carries. Never a model id. */
+const REST_ID = "__rest";
+const REST_LABEL = "everything else";
+
+/** Below this the bar and the notch would overlap, so the row says it held. */
+const MOVED_FLOOR = 0.005;
+
+export type ModelTrail = {
+	/** The published vendor id, or `__rest` for the folded tail. */
+	readonly id: string;
+	/** The catalog name, falling back to the raw vendor id (#33 decision 3). */
+	readonly label: string;
+	/** The validated palette slot this row wears. */
+	readonly paint: string;
+	/** Share of tokens at the newest reading. */
+	readonly share: number;
+	/** Share at the first reading in the window — where the notch sits. */
+	readonly first: number;
+	/** Share change across the window, in percentage points. */
+	readonly driftPoints: number;
+	/** True when there are two readings and the share actually moved. */
+	readonly moved: boolean;
+	/** The share at every reading, oldest first. */
+	readonly points: readonly ChartPointInput[];
+};
+
+/** The share this id held at one reading. Absent from the mix is zero. */
+function shareAt(
+	point: MeasuredHistoryPoint,
+	id: string,
+	kept: readonly string[],
+): number {
+	if (id === REST_ID) {
+		return point.models
+			.filter((m) => !kept.includes(m.id))
+			.reduce((a, m) => a + m.tokenShare, 0);
+	}
+	return point.models.find((m) => m.id === id)?.tokenShare ?? 0;
+}
+
+/** The fields a row needs from the reading it speaks for. */
+export type RankedModel = {
+	readonly id: string;
+	readonly catalogName: string | null;
+	readonly tokenShare: number;
+};
+
+/**
+ * One row per model of the current reading, each carrying its own trail.
+ *
+ * THE ROWS COME FROM `models`, NOT FROM THE SERIES. The page renders whole from
+ * the current reading and the series only adds history to it, so a page whose
+ * history has not arrived yet — or a stack that has synced once — still shows
+ * every row, with no notch and no drift.
+ *
+ * At most `max` rows: the palette has six validated slots and a seventh series
+ * would be a hue nobody checked, so the tail folds into one "everything else"
+ * row that keeps its share rather than dropping it.
+ */
+export function modelTrails(
+	models: readonly RankedModel[],
+	points: readonly MeasuredHistoryPoint[] = [],
+	max: number = CHART_SLOT_COUNT,
+): ModelTrail[] {
+	const ranked = [...models].sort((a, b) => b.tokenShare - a.tokenShare);
+	const folds = ranked.length > max;
+	const keptModels = folds ? ranked.slice(0, max - 1) : ranked;
+	const kept = keptModels.map((m) => m.id);
+	const restShare = ranked
+		.slice(keptModels.length)
+		.reduce((a, m) => a + m.tokenShare, 0);
+	const rows: Array<{ id: string; label: string; share: number }> = [
+		...keptModels.map((m) => ({
+			id: m.id,
+			label: m.catalogName ?? m.id,
+			share: m.tokenShare,
+		})),
+		...(folds ? [{ id: REST_ID, label: REST_LABEL, share: restShare }] : []),
+	];
+
+	const hasHistory = points.length > 0;
+	return rows.map((row, i) => {
+		const first = hasHistory ? shareAt(points[0], row.id, kept) : row.share;
+		const moved =
+			points.length > 1 && Math.abs(row.share - first) >= MOVED_FLOOR;
+		return {
+			id: row.id,
+			label: row.label,
+			paint: CHART_PAINTS[i % CHART_PAINTS.length],
+			share: row.share,
+			first,
+			driftPoints: points.length > 1 ? (row.share - first) * 100 : 0,
+			moved,
+			points: points.map((p) => ({
+				at: p.at,
+				value: shareAt(p, row.id, kept),
+			})),
+		};
+	});
+}
+
+/** The token reading at every sync — the trail behind the headline. */
+export function tokenTrail(
+	points: readonly MeasuredHistoryPoint[],
+): ChartPointInput[] {
+	return points.map((p) => ({ at: p.at, value: p.tokens }));
+}
+
+/**
+ * The move since the previous reading, or null on a first reading.
+ *
+ * Negative is ordinary: the window forgets its far end, so a quiet week lowers
+ * the reading without anything having gone wrong.
+ */
+export function tokenDelta(
+	points: readonly MeasuredHistoryPoint[],
+): number | null {
+	if (points.length < 2) return null;
+	const last = points.at(-1);
+	const prev = points.at(-2);
+	if (!last || !prev) return null;
+	return last.tokens - prev.tokens;
+}

--- a/src/features/measured/history.ts
+++ b/src/features/measured/history.ts
@@ -32,7 +32,6 @@ export type MeasuredHistory = NonNullable<
 	FunctionReturnType<typeof api.measured.getHistoryByStackSlug>
 >;
 export type MeasuredHistoryPoint = MeasuredHistory["points"][number];
-export type MeasuredHistoryModel = MeasuredHistoryPoint["models"][number];
 
 /** The id the folded tail carries. Never a model id. */
 const REST_ID = "__rest";

--- a/src/features/measured/tokens/TipIcons.tsx
+++ b/src/features/measured/tokens/TipIcons.tsx
@@ -1,0 +1,227 @@
+/**
+ * One recognizable mark per fun fact. Locked by #80, built by #81.
+ *
+ * The first pass was hand-drawn and read as generic wire shapes, so these are
+ * real assets instead: five icons from Material Design Icons (Pictogrammers),
+ * Apache-2.0, taken through the Iconify API on 2026-08-04.
+ *
+ * ONE FAMILY ON PURPOSE. Mixing icon sets is what makes a row of marks look
+ * assembled rather than designed, so every one of these is MDI: same 24x24 box,
+ * same solid-fill weight, same corner language. They are inlined as single
+ * paths filled with `currentColor`, so each one inherits its card's accent and
+ * nothing is fetched at runtime.
+ *
+ * On Harry Potter: the wizard hat is a nod, not a likeness. The card NAMES the
+ * books, which is ordinary nominative use, but a Potter-specific silhouette is
+ * Warner Bros. trade dress and does not belong on a commercial page.
+ */
+
+export type IconProps = { size?: number; className?: string };
+
+function Mdi({
+	size,
+	className,
+	label,
+	d,
+}: {
+	size?: number;
+	className?: string;
+	label: string;
+	d: string;
+}) {
+	return (
+		<svg
+			// A className wins: `w-full h-auto` cannot work against fixed attributes.
+			width={className ? undefined : size}
+			height={className ? undefined : size}
+			className={className}
+			viewBox="0 0 24 24"
+			// Decorative: every card already names its comparison in the title and
+			// the prose, so an accessible name here only repeats it.
+			aria-hidden="true"
+			data-mark={label}
+		>
+			<path fill="currentColor" d={d} />
+		</svg>
+	);
+}
+
+/** mdi:wizard-hat - the books card. */
+export function WizardHatIcon({ size = 48, className }: IconProps) {
+	return (
+		<Mdi
+			size={size}
+			className={className}
+			label="a wizard hat"
+			d="M21 22H3v-2h18zm-2-3H5l6.1-16.4q.3-.6.9-.6l6 3h-4.1zM10 7.5l1.04.47L11.5 9l.47-1.03L13 7.5l-1.03-.47L11.5 6l-.46 1.03zm3 7.5l-2.06-.93L10 12l-.93 2.07L7 15l2.07.93L10 18l.94-2.07zm.97-3.03L15 11.5l-1.03-.47L13.5 10l-.46 1.03l-1.04.47l1.04.47l.46 1.03zm2 4L17 15.5l-1.03-.47L15.5 14l-.46 1.03l-1.04.47l1.04.47l.46 1.03z"
+		/>
+	);
+}
+
+/** mdi:timer-sand - the time card. */
+export function HourglassIcon({ size = 48, className }: IconProps) {
+	return (
+		<Mdi
+			size={size}
+			className={className}
+			label="an hourglass"
+			d="M6 2h12v6l-4 4l4 4v6H6v-6l4-4l-4-4zm10 14.5l-4-4l-4 4V20h8zm-4-5l4-4V4H8v3.5zM10 6h4v.75l-2 2l-2-2z"
+		/>
+	);
+}
+
+/** mdi:wikipedia - the Wikipedia card. */
+export function WikipediaIcon({ size = 48, className }: IconProps) {
+	return (
+		<Mdi
+			size={size}
+			className={className}
+			label="the Wikipedia mark"
+			d="m14.97 18.95l-2.56-6.03c-1.02 1.99-2.14 4.08-3.1 6.03c-.01.01-.47 0-.47 0C7.37 15.5 5.85 12.1 4.37 8.68C4.03 7.84 2.83 6.5 2 6.5v-.45h5.06v.45c-.6 0-1.62.4-1.36 1.05c.72 1.54 3.24 7.51 3.93 9.03c.47-.94 1.8-3.42 2.37-4.47c-.45-.88-1.87-4.18-2.29-5c-.32-.54-1.13-.61-1.75-.61c0-.15.01-.25 0-.44l4.46.01v.4c-.61.03-1.18.24-.92.82c.6 1.24.95 2.13 1.5 3.28c.17-.34 1.07-2.19 1.5-3.16c.26-.65-.13-.91-1.21-.91c.01-.12.01-.33.01-.43c1.39-.01 3.48-.01 3.85-.02v.42c-.71.03-1.44.41-1.82.99L13.5 11.3c.18.51 1.96 4.46 2.15 4.9l3.85-8.83c-.3-.72-1.16-.87-1.5-.87v-.45l4 .03v.42c-.88 0-1.43.5-1.75 1.25c-.8 1.79-3.25 7.49-4.85 11.2z"
+		/>
+	);
+}
+
+/** mdi:eiffel-tower - the paper card. */
+export function EiffelTowerIcon({ size = 48, className }: IconProps) {
+	return (
+		<Mdi
+			size={size}
+			className={className}
+			label="the Eiffel Tower"
+			d="M8.21 17c.44-.85.85-1.84 1.23-3H9v-2h1c.61-2.6 1-5.87 1-10h2c0 4.13.4 7.4 1 10h1v2h-.44c.38 1.16.79 2.15 1.23 3H17v2l2 3h-2.42c-.77-1.76-2.53-3-4.58-3s-3.81 1.24-4.58 3H5l2-3l-.03-2zm4.38-3h-1.18a22 22 0 0 1-1.13 3h3.44c-.4-.87-.79-1.87-1.13-3"
+		/>
+	);
+}
+
+/** mdi:road-variant - the road card. */
+export function RoadIcon({ size = 48, className }: IconProps) {
+	return (
+		<Mdi
+			size={size}
+			className={className}
+			label="a road"
+			d="M18.1 4.8c-.1-.5-.5-.8-1-.8H13l.2 3h-2.4l.2-3H6.8c-.5 0-.9.4-1 .8l-2.7 14c-.1.6.4 1.2 1 1.2H10l.3-5h3.4l.3 5h5.8c.6 0 1.1-.6 1-1.2zM10.4 13l.2-4h2.6l.2 4z"
+		/>
+	);
+}
+
+/** mdi:keyboard */
+export function KeyboardIcon({ size = 48, className }: IconProps) {
+	return (
+		<Mdi
+			size={size}
+			className={className}
+			label="a keyboard"
+			d="M19 10h-2V8h2m0 5h-2v-2h2m-3-1h-2V8h2m0 5h-2v-2h2m0 6H8v-2h8m-9-5H5V8h2m0 5H5v-2h2m1 0h2v2H8m0-5h2v2H8m3 1h2v2h-2m0-5h2v2h-2m9-5H4c-1.11 0-2 .89-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2"
+		/>
+	);
+}
+
+/** mdi:floppy */
+export function FloppyIcon({ size = 48, className }: IconProps) {
+	return (
+		<Mdi
+			size={size}
+			className={className}
+			label="a floppy disk"
+			d="M5 3a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5.5L18.5 3H17v6a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V3zm7 1v5h3V4zm-5 8h10a1 1 0 0 1 1 1v6H6v-6a1 1 0 0 1 1-1"
+		/>
+	);
+}
+
+/** mdi:drama-masks */
+export function DramaMasksIcon({ size = 48, className }: IconProps) {
+	return (
+		<Mdi
+			size={size}
+			className={className}
+			label="theatre masks"
+			d="M8.11 19.45a6.95 6.95 0 0 1-4.4-5.1L2.05 6.54c-.24-1.08.45-2.14 1.53-2.37l9.77-2.07l.03-.01c1.07-.21 2.12.48 2.34 1.54l.35 1.67l4.35.93h.03c1.05.24 1.73 1.3 1.51 2.36l-1.66 7.82a6.993 6.993 0 0 1-8.3 5.38a6.9 6.9 0 0 1-3.89-2.34M20 8.18L10.23 6.1l-1.66 7.82v.03c-.57 2.68 1.16 5.32 3.85 5.89s5.35-1.15 5.92-3.84zm-4 8.32a2.96 2.96 0 0 1-3.17 1.39a2.97 2.97 0 0 1-2.33-2.55zM8.47 5.17L4 6.13l1.66 7.81l.01.03c.15.71.45 1.35.86 1.9c-.1-.77-.08-1.57.09-2.37l.43-2c-.45-.08-.84-.33-1.05-.69c.06-.61.56-1.15 1.25-1.31h.25l.78-3.81c.04-.19.1-.36.19-.52m6.56 7.06c.32-.53 1-.81 1.69-.66c.69.14 1.19.67 1.28 1.29c-.33.52-1 .8-1.7.64c-.69-.13-1.19-.66-1.27-1.27m-4.88-1.04c.32-.53.99-.81 1.68-.66c.67.14 1.2.68 1.28 1.29c-.33.52-1 .81-1.69.68c-.69-.17-1.19-.7-1.27-1.31m1.82-6.76l1.96.42l-.16-.8z"
+		/>
+	);
+}
+
+/** mdi:feather */
+export function FeatherIcon({ size = 48, className }: IconProps) {
+	return (
+		<Mdi
+			size={size}
+			className={className}
+			label="a quill"
+			d="M22 2s-7.64-.37-13.66 7.88C3.72 16.21 2 22 2 22l1.94-1c1.44-2.5 2.19-3.53 3.6-5c2.53.74 5.17.65 7.46-2c-2-.56-3.6-.43-5.96-.19C11.69 12 13.5 11.6 16 12l1-2c-1.8-.34-3-.37-4.78.04C14.19 8.65 15.56 7.87 18 8l1.21-1.93c-1.56-.11-2.5.06-4.29.5c1.61-1.46 3.08-2.12 5.22-2.25c0 0 1.05-1.89 1.86-2.32"
+		/>
+	);
+}
+
+/** mdi:message-text */
+export function MessageIcon({ size = 48, className }: IconProps) {
+	return (
+		<Mdi
+			size={size}
+			className={className}
+			label="a message bubble"
+			d="M20 2H4a2 2 0 0 0-2 2v18l4-4h14a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2M6 9h12v2H6m8 3H6v-2h8m4-4H6V6h12"
+		/>
+	);
+}
+
+/** mdi:pine-tree */
+export function PineTreeIcon({ size = 48, className }: IconProps) {
+	return (
+		<Mdi
+			size={size}
+			className={className}
+			label="a tree"
+			d="M10 21v-3H3l5-5H5l5-5H7l5-5l5 5h-3l5 5h-3l5 5h-7v3z"
+		/>
+	);
+}
+
+/** mdi:lightning-bolt */
+export function BoltIcon({ size = 48, className }: IconProps) {
+	return (
+		<Mdi
+			size={size}
+			className={className}
+			label="a lightning bolt"
+			d="M11 15H6l7-14v8h5l-7 14z"
+		/>
+	);
+}
+
+/** mdi:book-clock */
+export function BookClockIcon({ size = 48, className }: IconProps) {
+	return (
+		<Mdi
+			size={size}
+			className={className}
+			label="a book and a clock"
+			d="m16.5 17.25l2.86 1.69l-.75 1.22L15 18v-5h1.5zM23 17c0 3.87-3.13 7-7 7c-1.91 0-3.63-.76-4.89-2H6c-1.11 0-2-.89-2-2V4a2 2 0 0 1 2-2h1v7l2.5-1.5L12 9V2h6a2 2 0 0 1 2 2v7.26c1.81 1.27 3 3.36 3 5.74m-2 0c0-2.76-2.24-5-5-5s-5 2.24-5 5s2.24 5 5 5s5-2.24 5-5"
+		/>
+	);
+}
+
+/** mdi:earth */
+export function EarthIcon({ size = 48, className }: IconProps) {
+	return (
+		<Mdi
+			size={size}
+			className={className}
+			label="the Earth"
+			d="M17.9 17.39c-.26-.8-1.01-1.39-1.9-1.39h-1v-3a1 1 0 0 0-1-1H8v-2h2a1 1 0 0 0 1-1V7h2a2 2 0 0 0 2-2v-.41a7.984 7.984 0 0 1 2.9 12.8M11 19.93c-3.95-.49-7-3.85-7-7.93c0-.62.08-1.22.21-1.79L9 15v1a2 2 0 0 0 2 2m1-16A10 10 0 0 0 2 12a10 10 0 0 0 10 10a10 10 0 0 0 10-10A10 10 0 0 0 12 2"
+		/>
+	);
+}
+
+/** mdi:movie-open */
+export function MovieIcon({ size = 48, className }: IconProps) {
+	return (
+		<Mdi
+			size={size}
+			className={className}
+			label="a film reel"
+			d="m20.84 2.18l-3.93.78l2.74 3.54l1.97-.4zm-6.87 1.36L12 3.93l2.75 3.53l1.96-.39zm-4.9.96l-1.97.41l2.75 3.53l1.96-.39zm-4.91 1l-.98.19a2 2 0 0 0-1.57 2.35L2 10l4.9-.97zM2 10v10a2 2 0 0 0 2 2h16c1.11 0 2-.89 2-2V10z"
+		/>
+	);
+}

--- a/src/features/measured/tokens/TokenTips.tsx
+++ b/src/features/measured/tokens/TokenTips.tsx
@@ -1,0 +1,745 @@
+/**
+ * The headline popup — fifteen ways to feel a token count. Locked by #80, built
+ * by #81.
+ *
+ * "4.71B tokens" means nothing to a reader, so every card converts it into
+ * something they have held, read, said or walked past. One framing at a time,
+ * never a pile of them, and clicking the headline block deals the next one.
+ *
+ * THE SHELL CARRIES THE FACTS, THE BODY CARRIES THE FEELING. Every card closes
+ * with the exact count, the price caveat and the assumption it rests on. Two
+ * cards do not rest on words per token — electricity and video — and each says
+ * so in place of the shared rule.
+ *
+ * Every framing rests on the same soft assumption: roughly 0.75 English words
+ * per token. The fun is allowed. Pretending to precision is not.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { CHART_PAINTS } from "@/features/charts";
+import { cn } from "@/lib/utils";
+import { fmtUSD, MONO_LABEL } from "../copy";
+import {
+	BoltIcon,
+	BookClockIcon,
+	DramaMasksIcon,
+	EarthIcon,
+	EiffelTowerIcon,
+	FeatherIcon,
+	FloppyIcon,
+	HourglassIcon,
+	type IconProps,
+	KeyboardIcon,
+	MessageIcon,
+	MovieIcon,
+	PineTreeIcon,
+	RoadIcon,
+	WikipediaIcon,
+	WizardHatIcon,
+} from "./TipIcons";
+import {
+	EARTH_KM,
+	EIFFEL_M,
+	fmtBytes,
+	fmtCount,
+	fmtDuration,
+	fmtKm,
+	fmtMeters,
+	tokenScale,
+} from "./tokenScale";
+
+export type TipKey =
+	| "books"
+	| "time"
+	| "wiki"
+	| "paper"
+	| "road"
+	| "keys"
+	| "floppy"
+	| "bard"
+	| "scribe"
+	| "texts"
+	| "trees"
+	| "power"
+	| "lifetimes"
+	| "equator"
+	| "video";
+
+export const TIPS: { key: TipKey; label: string }[] = [
+	{ key: "books", label: "books: a shelf of novels" },
+	{ key: "time", label: "time: years of reading" },
+	{ key: "wiki", label: "wikipedia: share of every article" },
+	{ key: "paper", label: "paper: printed and stacked" },
+	{ key: "road", label: "road: pages laid end to end" },
+	{ key: "keys", label: "keys: keyboards worn out typing it" },
+	{ key: "floppy", label: "floppy: the stack of disks it fills" },
+	{ key: "bard", label: "bard: times over all of Shakespeare" },
+	{ key: "scribe", label: "scribe: centuries of copying by hand" },
+	{ key: "texts", label: "texts: messages at 160 characters" },
+	{ key: "trees", label: "trees: what printing it would fell" },
+	{ key: "power", label: "power: the electricity it took" },
+	{ key: "lifetimes", label: "lifetimes: whole reading lives" },
+	{ key: "equator", label: "equator: one line around the Earth" },
+	{ key: "video", label: "video: hours of full HD footage" },
+];
+
+const TIP_KEYS = TIPS.map((t) => t.key);
+
+// ---------------------------------------------------------------------------
+// The deck
+// ---------------------------------------------------------------------------
+
+function shuffled<T>(items: T[]): T[] {
+	const out = [...items];
+	for (let i = out.length - 1; i > 0; i--) {
+		const j = Math.floor(Math.random() * (i + 1));
+		[out[i], out[j]] = [out[j], out[i]];
+	}
+	return out;
+}
+
+/**
+ * One shuffled deck per page load, walked in order and looped.
+ *
+ * THE SHUFFLE RUNS IN AN EFFECT, never in render, so the server and the first
+ * client render agree and hydration stays quiet. The card itself never exists in
+ * the server HTML — the popup mounts on hover — so the reshuffle is invisible.
+ */
+export function useTipDeck() {
+	const [deck, setDeck] = useState<TipKey[]>(TIP_KEYS);
+	const [dealt, setDealt] = useState(0);
+
+	useEffect(() => {
+		setDeck(shuffled(TIP_KEYS));
+		setDealt(0);
+	}, []);
+
+	const next = useCallback(() => setDealt((n) => n + 1), []);
+
+	return { tip: deck[dealt % deck.length], next };
+}
+
+// ---------------------------------------------------------------------------
+// The card
+// ---------------------------------------------------------------------------
+
+export type TokenTipProps = {
+	/** The reading the card speaks for. */
+	readonly tokens: number;
+	/** The API-price equivalent, or null where the stack keeps cost private. */
+	readonly usd: number | null;
+	readonly tip: TipKey;
+};
+
+export function TokenTip({ tokens, usd, tip }: TokenTipProps) {
+	const body = BODIES[tip];
+	const Icon = body.Icon;
+	const exact = tokens.toLocaleString("en-US");
+
+	return (
+		<div className="relative overflow-hidden border-[3px] border-stroke-strong bg-bg-panel p-4 shadow-[6px_6px_0_var(--stroke-strong)]">
+			{/* The mark is a WATERMARK and nothing else. Every treatment that took
+			    layout space pushed the card's content around, and the content is the
+			    point. Pinned top right, bleeding past the padding, behind the text. */}
+			<span
+				aria-hidden="true"
+				className="pointer-events-none absolute -right-5 -top-5 text-accent-lime opacity-20"
+			>
+				<Icon size={150} />
+			</span>
+
+			<p className="relative mb-3 border-b-2 border-stroke-strong pb-2 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-accent-lime">
+				{body.title}
+			</p>
+
+			<div className="relative">{body.render(tokens)}</div>
+
+			{/* The exact count is not a header of its own. It reads better as the
+			    subject of the disclaimer, which is the one line that has to name it
+			    precisely anyway. */}
+			<div className="relative mt-7 space-y-1.5 border-t-2 border-dashed border-stroke-subtle pt-5">
+				{usd !== null ? (
+					<p className="text-xs leading-relaxed text-fg-secondary">
+						<span className="font-bold text-accent-lime">Not money spent.</span>{" "}
+						{fmtUSD(usd)} is what{" "}
+						<span className="font-mono font-bold text-fg-primary">{exact}</span>{" "}
+						tokens would cost at public list prices.
+					</p>
+				) : (
+					<p className="text-xs leading-relaxed text-fg-secondary">
+						<span className="font-mono font-bold text-fg-primary">{exact}</span>{" "}
+						tokens. This stack does not publish a cost.
+					</p>
+				)}
+				<p className="font-mono text-[10px] leading-relaxed text-fg-muted">
+					{body.note ?? WORDS_NOTE}
+				</p>
+			</div>
+		</div>
+	);
+}
+
+/** The assumption thirteen of the fifteen cards rest on. */
+const WORDS_NOTE = "rough: about 0.75 words per token.";
+
+function Headline({ children }: { children: React.ReactNode }) {
+	return (
+		<p className="font-mono text-3xl font-black leading-none text-fg-primary">
+			{children}
+		</p>
+	);
+}
+
+function Sub({ children }: { children: React.ReactNode }) {
+	return (
+		<p className="mt-2 text-sm leading-relaxed text-fg-secondary">{children}</p>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// The framings. One comparison each, never two — a card that offers a choice of
+// yardsticks makes the reader do the work the card was supposed to do.
+// ---------------------------------------------------------------------------
+
+type Body = {
+	title: string;
+	Icon: (props: IconProps) => React.ReactNode;
+	render: (tokens: number) => React.ReactNode;
+	/** Replaces the words-per-token caveat when a card rests on something else. */
+	note?: string;
+};
+
+const BODIES: Record<TipKey, Body> = {
+	books: {
+		title: "In books",
+		Icon: WizardHatIcon,
+		render: (tokens) => <BooksBody tokens={tokens} />,
+	},
+	time: {
+		title: "In human time",
+		Icon: HourglassIcon,
+		render: (tokens) => <TimeBody tokens={tokens} />,
+	},
+	wiki: {
+		title: "Against Wikipedia",
+		Icon: WikipediaIcon,
+		render: (tokens) => <WikiBody tokens={tokens} />,
+	},
+	paper: {
+		title: "On paper",
+		Icon: EiffelTowerIcon,
+		render: (tokens) => <PaperBody tokens={tokens} />,
+	},
+	road: {
+		title: "End to end",
+		Icon: RoadIcon,
+		render: (tokens) => <RoadBody tokens={tokens} />,
+	},
+	keys: {
+		title: "In keyboards",
+		Icon: KeyboardIcon,
+		render: (tokens) => <KeysBody tokens={tokens} />,
+	},
+	floppy: {
+		title: "On floppy disks",
+		Icon: FloppyIcon,
+		render: (tokens) => <FloppyBody tokens={tokens} />,
+	},
+	bard: {
+		title: "Against Shakespeare",
+		Icon: DramaMasksIcon,
+		render: (tokens) => <BardBody tokens={tokens} />,
+	},
+	scribe: {
+		title: "Copied by hand",
+		Icon: FeatherIcon,
+		render: (tokens) => <ScribeBody tokens={tokens} />,
+	},
+	texts: {
+		title: "In text messages",
+		Icon: MessageIcon,
+		render: (tokens) => <TextsBody tokens={tokens} />,
+	},
+	trees: {
+		title: "In trees",
+		Icon: PineTreeIcon,
+		render: (tokens) => <TreesBody tokens={tokens} />,
+	},
+	power: {
+		title: "In electricity",
+		Icon: BoltIcon,
+		render: (tokens) => <PowerBody tokens={tokens} />,
+		note: "very rough: about 0.3 Wh per 1,000 tokens. No vendor publishes a per-token figure, and the real one swings by an order of magnitude with the model and the hardware.",
+	},
+	lifetimes: {
+		title: "In reading lifetimes",
+		Icon: BookClockIcon,
+		render: (tokens) => <LifetimesBody tokens={tokens} />,
+	},
+	equator: {
+		title: "Around the Earth",
+		Icon: EarthIcon,
+		render: (tokens) => <EquatorBody tokens={tokens} />,
+	},
+	video: {
+		title: "As video",
+		Icon: MovieIcon,
+		render: (tokens) => <VideoBody tokens={tokens} />,
+		note: "vision math, not words: a frame costs ceil(w/28) x ceil(h/28) visual tokens, so 1920x1080 is 2,691. Video is read as still frames sampled about once a second.",
+	},
+};
+
+type BodyProps = { tokens: number };
+
+const SPINES = 26;
+
+/** The one phrase in a card's prose the reader is meant to leave with. */
+function Key({ children }: { children: React.ReactNode }) {
+	return <strong className="font-bold text-fg-primary">{children}</strong>;
+}
+
+/**
+ * A bar that survives values over 100%.
+ *
+ * The track is the LARGER of the value and its reference, so a stack at 1.3 laps
+ * of the Earth fills the whole bar and the hatched notch marks where one lap
+ * falls. A bar clamped at 100% said "1.3 laps" over a full bar, which is the
+ * same picture it draws for 74 laps.
+ */
+function RatioBar({
+	ratio,
+	leftLabel,
+	rightLabel,
+}: {
+	ratio: number;
+	leftLabel: string;
+	rightLabel: string;
+}) {
+	const scale = Math.max(1, ratio);
+	const fill = (ratio / scale) * 100;
+	const mark = (1 / scale) * 100;
+	const over = ratio > 1;
+
+	return (
+		<div className="mt-4">
+			<div className="relative h-4 w-full border border-stroke-strong bg-bg-canvas">
+				<div
+					className="absolute inset-y-0 left-0 bg-accent-lime"
+					style={{ width: `${fill}%` }}
+				/>
+				{over && (
+					<span
+						aria-hidden="true"
+						className="absolute -top-1 -bottom-1 w-[5px] -translate-x-1/2"
+						style={{
+							left: `${mark}%`,
+							backgroundImage:
+								"repeating-linear-gradient(135deg, var(--fg-primary) 0 2px, var(--bg-canvas) 2px 4px)",
+						}}
+					/>
+				)}
+			</div>
+			<p
+				className={cn(
+					MONO_LABEL,
+					"mt-2 flex justify-between text-[10px] text-fg-muted",
+				)}
+			>
+				<span>{leftLabel}</span>
+				<span>{over ? `notch = ${rightLabel}` : rightLabel}</span>
+			</p>
+		</div>
+	);
+}
+
+function BooksBody({ tokens }: BodyProps) {
+	const s = tokenScale(tokens);
+	return (
+		<>
+			<Headline>{fmtCount(s.novels)} novels</Headline>
+			<Sub>
+				{fmtCount(s.words)} words, at the length of an average novel. Read all
+				seven Harry Potter books back to back and you would have to do it{" "}
+				<Key>{fmtCount(s.harryPotter)} times over</Key>.
+			</Sub>
+
+			{/* A shelf. Deterministic heights, so the same count draws the same shelf. */}
+			<div className="mt-4 flex h-12 items-end gap-[3px] border-b-2 border-stroke-strong">
+				{Array.from({ length: SPINES }, (_, i) => {
+					const h = 60 + ((i * 37) % 41);
+					return (
+						<span
+							key={`spine-${i}-${h}`}
+							className="flex-1"
+							style={{
+								height: `${h}%`,
+								background: CHART_PAINTS[i % CHART_PAINTS.length],
+								opacity: 0.55 + ((i * 13) % 40) / 100,
+							}}
+						/>
+					);
+				})}
+			</div>
+			<p className={cn(MONO_LABEL, "mt-2 text-[10px] text-fg-muted")}>
+				each spine is about {fmtCount(s.novels / SPINES)} novels
+			</p>
+		</>
+	);
+}
+
+function TimeBody({ tokens }: BodyProps) {
+	const s = tokenScale(tokens);
+	return (
+		<>
+			<Headline>{fmtDuration(s.readYears)}</Headline>
+			<Sub>
+				of reading, at a good silent pace,{" "}
+				<Key>without ever stopping to sleep</Key>.
+			</Sub>
+
+			<dl className="mt-4 space-y-1.5">
+				<TimeRow label="read silently" value={fmtDuration(s.readYears)} />
+				<TimeRow label="read out loud" value={fmtDuration(s.speakYears)} />
+				<TimeRow label="typed by hand" value={fmtDuration(s.typeYears)} />
+			</dl>
+		</>
+	);
+}
+
+function TimeRow({ label, value }: { label: string; value: string }) {
+	return (
+		<div className="flex items-baseline justify-between gap-4 border-b border-stroke-subtle pb-1">
+			<dt className={cn(MONO_LABEL, "text-fg-muted")}>{label}</dt>
+			<dd className="font-mono text-sm font-bold text-fg-primary">{value}</dd>
+		</div>
+	);
+}
+
+function WikiBody({ tokens }: BodyProps) {
+	const s = tokenScale(tokens);
+	const over = s.wikipedia >= 1;
+	const pct = s.wikipedia * 100;
+	return (
+		<>
+			<Headline>
+				{over
+					? `${s.wikipedia.toFixed(1)}x`
+					: `${pct < 1 ? pct.toFixed(2) : pct.toFixed(0)}%`}
+			</Headline>
+			<Sub>
+				{over ? (
+					<>
+						more words than the whole English Wikipedia. Every article, every
+						edit war, every list of railway stations,{" "}
+						<Key>{s.wikipedia.toFixed(1)} times over</Key>.
+					</>
+				) : (
+					<>
+						of every word in the English Wikipedia. All 7 million articles come
+						to <Key>about 4.9 billion words</Key>.
+					</>
+				)}
+			</Sub>
+
+			<RatioBar
+				ratio={s.wikipedia}
+				leftLabel="this stack"
+				rightLabel="all of Wikipedia"
+			/>
+		</>
+	);
+}
+
+function PaperBody({ tokens }: BodyProps) {
+	const s = tokenScale(tokens);
+	const ratio = s.paperMeters / EIFFEL_M;
+	const maxH = 64;
+	const stackH = Math.max(2, Math.min(maxH, maxH * Math.min(1, ratio)));
+	const towerH = Math.max(2, Math.min(maxH, maxH / Math.max(1, ratio)));
+
+	return (
+		<>
+			<Headline>{fmtMeters(s.paperMeters)}</Headline>
+			<Sub>
+				printed double-sided, {fmtCount(s.pages)} pages make a stack that tall.{" "}
+				{ratio >= 1 ? (
+					<>
+						It <Key>clears the Eiffel Tower {ratio.toFixed(1)} times over</Key>.
+					</>
+				) : (
+					<>
+						The Eiffel Tower is 330 m, so it reaches{" "}
+						<Key>{(ratio * 100).toFixed(0)}% of the way up</Key>.
+					</>
+				)}
+			</Sub>
+
+			<div className="mt-4 flex h-16 items-end gap-6 border-b-2 border-stroke-strong px-2">
+				<span className="flex flex-1 justify-center">
+					<span
+						className="w-8 bg-accent-lime"
+						style={{ height: `${stackH}px` }}
+					/>
+				</span>
+				<span className="flex flex-1 justify-center">
+					<span
+						className="w-8"
+						style={{
+							height: `${towerH}px`,
+							backgroundImage:
+								"repeating-linear-gradient(135deg, var(--fg-muted) 0 2px, transparent 2px 5px)",
+						}}
+					/>
+				</span>
+			</div>
+			<p className={cn(MONO_LABEL, "mt-2 flex text-[10px] text-fg-muted")}>
+				<span className="flex-1 text-center">the stack</span>
+				<span className="flex-1 text-center">Eiffel Tower</span>
+			</p>
+		</>
+	);
+}
+
+function RoadBody({ tokens }: BodyProps) {
+	const s = tokenScale(tokens);
+	return (
+		<>
+			<Headline>
+				{s.marathons >= 1
+					? `${fmtCount(s.marathons)} marathons`
+					: "under one marathon"}
+			</Headline>
+			<Sub>
+				of paper, if you laid every printed page end to end along the ground.
+				That comes to <Key>{fmtKm(s.roadMeters / 1000)}</Key>, and a marathon is
+				42.2 km.
+			</Sub>
+
+			{/* A road. The dashes are the pages. */}
+			<div className="mt-4 h-8 border-y-2 border-stroke-strong bg-bg-canvas">
+				<div
+					className="h-full w-full"
+					style={{
+						backgroundImage:
+							"repeating-linear-gradient(90deg, var(--accent-lime) 0 10px, transparent 10px 22px)",
+						opacity: 0.8,
+					}}
+				/>
+			</div>
+			<p className={cn(MONO_LABEL, "mt-2 text-[10px] text-fg-muted")}>
+				every dash is a page
+			</p>
+		</>
+	);
+}
+
+function KeysBody({ tokens }: BodyProps) {
+	const s = tokenScale(tokens);
+	return (
+		<>
+			<Headline>
+				{s.keyboards >= 1
+					? `${fmtCount(s.keyboards)} keyboards`
+					: "one keyboard"}
+			</Headline>
+			<Sub>
+				worn out typing it. Every character by hand comes to{" "}
+				<Key>{fmtCount(s.keystrokes)} keystrokes</Key>, and a switch is rated
+				for about 50 million presses
+				{s.keyboards >= 1
+					? "."
+					: `, so this would use up ${Math.round(s.keyboards * 100)}% of one.`}
+			</Sub>
+		</>
+	);
+}
+
+function FloppyBody({ tokens }: BodyProps) {
+	const s = tokenScale(tokens);
+	return (
+		<>
+			<Headline>{fmtCount(s.floppies)} floppies</Headline>
+			<Sub>
+				As plain text the whole thing is <Key>{fmtBytes(s.bytes)}</Key>. The
+				last floppy disks were made in 2011, so you would be buying them second
+				hand.
+			</Sub>
+		</>
+	);
+}
+
+function BardBody({ tokens }: BodyProps) {
+	const s = tokenScale(tokens);
+	return (
+		<>
+			<Headline>{fmtCount(s.shakespeare)} times</Headline>
+			<Sub>
+				the complete works of Shakespeare. Every play and every sonnet he wrote
+				comes to about 885,000 words, and this is{" "}
+				<Key>{fmtCount(s.shakespeare)} of those</Key>.
+			</Sub>
+		</>
+	);
+}
+
+function ScribeBody({ tokens }: BodyProps) {
+	const s = tokenScale(tokens);
+	const startYear = Math.round(2026 - s.scribeYears);
+	return (
+		<>
+			<Headline>{fmtDuration(s.scribeYears)}</Headline>
+			<Sub>
+				of a medieval scribe copying 3,000 words a day, every working day.
+				{s.scribeYears >= 100 && (
+					<>
+						{" "}
+						To have finished by now, they would have had to{" "}
+						<Key>
+							start in{" "}
+							{startYear < 0
+								? `${Math.abs(startYear)} BC`
+								: `the year ${startYear}`}
+						</Key>
+						.
+					</>
+				)}
+			</Sub>
+		</>
+	);
+}
+
+function TextsBody({ tokens }: BodyProps) {
+	const s = tokenScale(tokens);
+	const yearsAtOnePerMinute = s.texts / (60 * 24 * 365);
+	return (
+		<>
+			<Headline>{fmtCount(s.texts)} texts</Headline>
+			<Sub>
+				at 160 characters each. Send one every minute, day and night, and you
+				would be at it for <Key>{fmtDuration(yearsAtOnePerMinute)}</Key>.
+			</Sub>
+		</>
+	);
+}
+
+function TreesBody({ tokens }: BodyProps) {
+	const s = tokenScale(tokens);
+	return (
+		<>
+			<Headline>
+				{s.trees >= 1 ? `${fmtCount(s.trees)} trees` : "under one tree"}
+			</Headline>
+			<Sub>
+				if every page were really printed, double-sided. One tree gives about
+				8,300 sheets of A4, and this needs{" "}
+				<Key>{fmtCount(s.pages / 2)} of them</Key>.
+			</Sub>
+		</>
+	);
+}
+
+function PowerBody({ tokens }: BodyProps) {
+	const s = tokenScale(tokens);
+	return (
+		<>
+			<Headline>{fmtCount(s.kwh)} kWh</Headline>
+			<Sub>
+				of electricity, give or take a lot. The same charge would drive an
+				electric car <Key>{fmtKm(s.evKm)}</Key>
+				{s.homeYears >= 1 / 24 ? (
+					<>
+						, or run a European home for <Key>{fmtDuration(s.homeYears)}</Key>.
+					</>
+				) : (
+					"."
+				)}
+			</Sub>
+		</>
+	);
+}
+
+function LifetimesBody({ tokens }: BodyProps) {
+	const s = tokenScale(tokens);
+	return (
+		<>
+			<Headline>
+				{s.readingLifetimes >= 1
+					? `${fmtCount(s.readingLifetimes)} lifetimes`
+					: `${Math.round(s.readingLifetimes * 100)}% of a lifetime`}
+			</Headline>
+			<Sub>
+				of reading. Somebody who finishes a book a month for sixty years gets
+				through about <Key>720 books</Key>, and this is {fmtCount(s.novels)}{" "}
+				novels.
+			</Sub>
+		</>
+	);
+}
+
+function EquatorBody({ tokens }: BodyProps) {
+	const s = tokenScale(tokens);
+	const pct = s.earthLaps * 100;
+	return (
+		<>
+			<Headline>
+				{s.earthLaps >= 1
+					? `${s.earthLaps.toFixed(1)} laps`
+					: `${pct < 1 ? pct.toFixed(2) : pct.toFixed(0)}% of a lap`}
+			</Headline>
+			<Sub>
+				of the Earth. Set every character in one unbroken line of monospace and
+				it runs <Key>{fmtKm(s.lineKm)}</Key>. The equator is{" "}
+				{EARTH_KM.toLocaleString("en-US")} km.
+			</Sub>
+
+			<RatioBar
+				ratio={s.earthLaps}
+				leftLabel="this stack"
+				rightLabel="once around"
+			/>
+		</>
+	);
+}
+
+/**
+ * The one card that does not run on words per token.
+ *
+ * The first version converted words into film SCRIPTS and then reported the
+ * running time of those films, which is a modality jump: reading a screenplay is
+ * not watching the film. This one stays in one modality. A model reads video as
+ * sampled still frames, each frame costs real visual tokens, so "how much video
+ * would this many tokens buy" is a question the same number can answer.
+ */
+function VideoBody({ tokens }: BodyProps) {
+	const s = tokenScale(tokens);
+	// Hours, not the shared duration formatter: video is the one card where the
+	// natural unit is smaller than a day.
+	const runtime =
+		s.videoHours >= 2
+			? `${fmtCount(s.videoHours)} hours`
+			: `${Math.round(s.videoHours * 60)} minutes`;
+	return (
+		<>
+			<Headline>{runtime}</Headline>
+			<Sub>
+				of full HD video, or{" "}
+				<Key>
+					{s.lotrTrilogies >= 1
+						? `${fmtCount(s.lotrTrilogies)} runs through the extended Lord of the Rings trilogy`
+						: `${Math.round(s.lotrTrilogies * 100)}% of the extended Lord of the Rings trilogy`}
+				</Key>
+				.
+			</Sub>
+
+			<dl className="mt-4 space-y-1.5">
+				<TimeRow label="frames read" value={fmtCount(s.videoFrames)} />
+				<TimeRow label="tokens per frame" value="2,691" />
+				{s.videoHours >= 24 && (
+					<TimeRow
+						label="watched non-stop"
+						value={fmtDuration(s.videoHours / 24 / 365)}
+					/>
+				)}
+			</dl>
+		</>
+	);
+}

--- a/src/features/measured/tokens/tokenScale.ts
+++ b/src/features/measured/tokens/tokenScale.ts
@@ -1,0 +1,229 @@
+/**
+ * Making a token count tangible. Locked by #80, built by #81.
+ *
+ * "4.71B tokens" is a number nobody has a feel for. Everything here converts it
+ * into something a reader has held, read or walked past.
+ *
+ * ONE assumption drives all of it: about 0.75 English words per token. That is
+ * the usual working figure for English prose, and it is wrong for code, for
+ * other languages and for the cache-heavy traffic an agent actually generates.
+ * So every surface built on this file has to say "roughly" and show the rule.
+ * The site's whole claim is that its numbers are honest, and a fun fact that
+ * quietly pretends to be precise would spend that credit.
+ *
+ * EVERY CONSTANT CARRIES ITS SOURCE, in a comment beside it. Two of them do not
+ * rest on words per token at all — electricity and vision — and the cards that
+ * use those carry their own caveat instead of the shared one.
+ */
+
+export const WORDS_PER_TOKEN = 0.75;
+
+/** Reference lengths, in words. */
+const NOVEL = 90_000;
+const WAR_AND_PEACE = 587_287;
+const LOTR = 481_103;
+const HARRY_POTTER_ALL = 1_084_170;
+/** Every article in the English Wikipedia, prose only. */
+const WIKIPEDIA = 4_900_000_000;
+
+const READ_WPM = 238;
+const SPEAK_WPM = 130;
+const TYPE_WPM = 40;
+
+const WORDS_PER_PAGE = 500;
+/** Sheet thickness of ordinary 80gsm paper. */
+const SHEET_MM = 0.1;
+/** The long side of an A4 sheet, for pages laid end to end. */
+const A4_HEIGHT_M = 0.297;
+
+export const EIFFEL_M = 330;
+export const MARATHON_M = 42_195;
+
+// --- the second wave of framings ------------------------------------------
+
+/** Characters per English word, counting the space after it. */
+const CHARS_PER_WORD = 5.7;
+/** Keypresses a switch is typically rated for. */
+const KEYBOARD_RATING = 50_000_000;
+/** Bytes per word as UTF-8 plain text, counting the space. */
+const BYTES_PER_WORD = 6;
+/** A 3.5 inch high-density floppy disk. */
+const FLOPPY_BYTES = 1_474_560;
+/** The complete works of Shakespeare, plays and poems. */
+const SHAKESPEARE = 884_647;
+/** What a medieval scribe could copy in a working day. */
+const SCRIBE_WORDS_PER_DAY = 3_000;
+/** Words in a 160-character text message. */
+const SMS_WORDS = 28;
+/** Sheets of A4 from one tree, the usual working figure. */
+const SHEETS_PER_TREE = 8_333;
+/**
+ * Energy per 1,000 tokens, in watt-hours. The softest number in this file by a
+ * wide margin: it swings by an order of magnitude across models, hardware and
+ * batch size, and no vendor publishes a per-token figure. The card that uses it
+ * carries its own caveat instead of the words-per-token one.
+ */
+const WH_PER_1K_TOKENS = 0.3;
+/** A European household, per year. */
+const HOME_KWH_PER_YEAR = 3_500;
+/** An electric car, per kilometer. */
+const EV_KWH_PER_KM = 0.18;
+/** Books an avid reader finishes in a year, over a reading life of 60 years. */
+const READING_LIFETIME_BOOKS = 12 * 60;
+/** Width of one character set in 12pt monospace. */
+const CHAR_WIDTH_MM = 2.5;
+export const EARTH_KM = 40_075;
+/**
+ * VISION, not text. A model reads an image in 28x28 pixel patches, so a frame
+ * costs ceil(w/28) * ceil(h/28) visual tokens: 1920x1080 comes to 2,691 on the
+ * high-resolution tier (Claude 4.7 and later), which does not downscale it.
+ *
+ * There is no video input. Video is read as sampled still frames, and one frame
+ * a second is the usual sampling rate. So this is the one conversion in the
+ * file that does NOT go through words per token, and the card that uses it says
+ * so instead of borrowing the shared caveat.
+ */
+const HD_FRAME_TOKENS = 2_691;
+const VIDEO_FPS = 1;
+/** The Lord of the Rings, extended editions, all three, in hours. */
+const LOTR_TRILOGY_HOURS = 11.37;
+
+export type TokenScale = {
+	tokens: number;
+	words: number;
+	novels: number;
+	warAndPeace: number;
+	lotr: number;
+	harryPotter: number;
+	/** Share of the whole English Wikipedia, as a fraction. */
+	wikipedia: number;
+	readYears: number;
+	speakYears: number;
+	typeYears: number;
+	pages: number;
+	/** Height of the printed stack, double-sided, in meters. */
+	paperMeters: number;
+	/** The same pages laid end to end, in meters. */
+	roadMeters: number;
+	/** That length, counted in marathons. */
+	marathons: number;
+
+	/** Keystrokes to type it all, and keyboards worn out doing so. */
+	keystrokes: number;
+	keyboards: number;
+	/** Size as UTF-8 plain text, in bytes, and in 1.44 MB floppy disks. */
+	bytes: number;
+	floppies: number;
+	/** Times over the complete works of Shakespeare. */
+	shakespeare: number;
+	/** Years a medieval scribe would need, copying by hand. */
+	scribeYears: number;
+	/** Text messages at 160 characters each. */
+	texts: number;
+	/** Trees felled if every page were actually printed. */
+	trees: number;
+	/** Energy at a rough per-token rate, in kWh, and what it would otherwise do. */
+	kwh: number;
+	homeYears: number;
+	evKm: number;
+	/** Reading lifetimes of someone who finishes a book a month for 60 years. */
+	readingLifetimes: number;
+	/** Every character set in one line: its length in km, and laps of the Earth. */
+	lineKm: number;
+	earthLaps: number;
+	/** Full HD video the same token count would buy, sampled at one frame a second. */
+	videoFrames: number;
+	videoHours: number;
+	/** Those hours, counted in extended Lord of the Rings trilogies. */
+	lotrTrilogies: number;
+};
+
+export function tokenScale(tokens: number): TokenScale {
+	const words = tokens * WORDS_PER_TOKEN;
+	const pages = words / WORDS_PER_PAGE;
+	const chars = words * CHARS_PER_WORD;
+	const kwh = (tokens / 1000) * (WH_PER_1K_TOKENS / 1000);
+	const minutesToYears = (m: number) => m / 60 / 24 / 365;
+	return {
+		tokens,
+		words,
+		novels: words / NOVEL,
+		warAndPeace: words / WAR_AND_PEACE,
+		lotr: words / LOTR,
+		harryPotter: words / HARRY_POTTER_ALL,
+		wikipedia: words / WIKIPEDIA,
+		readYears: minutesToYears(words / READ_WPM),
+		speakYears: minutesToYears(words / SPEAK_WPM),
+		typeYears: minutesToYears(words / TYPE_WPM),
+		pages,
+		paperMeters: (pages / 2) * SHEET_MM * 0.001,
+		roadMeters: (pages / 2) * A4_HEIGHT_M,
+		marathons: ((pages / 2) * A4_HEIGHT_M) / MARATHON_M,
+
+		keystrokes: chars,
+		keyboards: chars / KEYBOARD_RATING,
+		bytes: words * BYTES_PER_WORD,
+		floppies: (words * BYTES_PER_WORD) / FLOPPY_BYTES,
+		shakespeare: words / SHAKESPEARE,
+		scribeYears: words / SCRIBE_WORDS_PER_DAY / 365,
+		texts: words / SMS_WORDS,
+		trees: pages / 2 / SHEETS_PER_TREE,
+		kwh,
+		homeYears: kwh / HOME_KWH_PER_YEAR,
+		evKm: kwh / EV_KWH_PER_KM,
+		readingLifetimes: words / NOVEL / READING_LIFETIME_BOOKS,
+		lineKm: (chars * CHAR_WIDTH_MM) / 1_000_000,
+		earthLaps: (chars * CHAR_WIDTH_MM) / 1_000_000 / EARTH_KM,
+		videoFrames: tokens / HD_FRAME_TOKENS,
+		videoHours: tokens / HD_FRAME_TOKENS / VIDEO_FPS / 3600,
+		lotrTrilogies:
+			tokens / HD_FRAME_TOKENS / VIDEO_FPS / 3600 / LOTR_TRILOGY_HOURS,
+	};
+}
+
+// --- formatting -------------------------------------------------------------
+
+/** A count a person can say out loud: 39,000 rather than 39,244. */
+export function fmtCount(n: number): string {
+	if (n >= 1e12) return `${(n / 1e12).toFixed(1)} trillion`;
+	if (n >= 1e9) return `${(n / 1e9).toFixed(1)} billion`;
+	if (n >= 1e6) return `${(n / 1e6).toFixed(1)} million`;
+	if (n >= 10_000) return `${Math.round(n / 1000).toLocaleString("en-US")},000`;
+	if (n >= 1000) return (Math.round(n / 100) * 100).toLocaleString("en-US");
+	if (n >= 10) return Math.round(n).toLocaleString("en-US");
+	if (n >= 1) return n.toFixed(1);
+	return n.toFixed(2);
+}
+
+/** Years, or months when there are not enough years to round to one. */
+export function fmtDuration(years: number): string {
+	if (years >= 2) return `${Math.round(years).toLocaleString("en-US")} years`;
+	const months = years * 12;
+	if (months >= 2) return `${Math.round(months)} months`;
+	const days = years * 365;
+	if (days >= 2) return `${Math.round(days)} days`;
+	const hours = Math.round(days * 24);
+	return `${hours} ${hours === 1 ? "hour" : "hours"}`;
+}
+
+/** Bytes as a size a person recognises. */
+export function fmtBytes(n: number): string {
+	if (n >= 1e12) return `${(n / 1e12).toFixed(1)} TB`;
+	if (n >= 1e9) return `${(n / 1e9).toFixed(1)} GB`;
+	if (n >= 1e6) return `${(n / 1e6).toFixed(0)} MB`;
+	return `${Math.round(n / 1000).toLocaleString("en-US")} KB`;
+}
+
+export function fmtKm(km: number): string {
+	if (km >= 100) return `${Math.round(km).toLocaleString("en-US")} km`;
+	if (km >= 1) return `${km.toFixed(1)} km`;
+	return `${Math.round(km * 1000)} m`;
+}
+
+export function fmtMeters(m: number): string {
+	const km = m / 1000;
+	if (km >= 100) return `${Math.round(km).toLocaleString("en-US")} km`;
+	if (km >= 1) return `${km.toFixed(1)} km`;
+	if (m >= 1) return `${Math.round(m).toLocaleString("en-US")} m`;
+	return `${Math.round(m * 100)} cm`;
+}


### PR DESCRIPTION
Ticket: alp82/aistack#81 — [Task: build live stack-page stats](https://github.com/alp82/aistack/issues/81)

Builds the living stack page (#81, map #76) as #80 locked it.

**The series query.** `getHistoryByStackSlug({ slug, days?, harness? })` reads `by_stack_capturedAt` / `by_stack_harness_capturedAt` and returns one point per sync. A point is the same merge the headline uses, over the newest reading of every harness as of that moment, so the big number is the end of its own trail by construction. Rows captured in the same minute are one reading (the real 60-second pair on 08-01). A harness that did not sync carries forward, seeded from before the window, so a point never drops a harness the headline counts. Read-time catalog resolution and read-time repricing apply to every reading. `harness` narrows the series to one machine, unmerged.

`mergeHarnesses` is split out of `getCurrentByStackSlug`, which now uses it. The models catalog is read once per query instead of once per model id.

**The page.** Variant I: tokens lead, spend under them, history as a watermark behind the numbers, model rows as solid full-color bars with a hatched "was here" notch and a hover card carrying that model's trail, and the fifteen-card fun-fact deck with its audited copy and its stated assumptions. Two queries, and the series is optional — one reading, or a series that has not answered yet, still renders the whole section.

**Charts.** `Sparkline` gains `paint`, `area` and `fluid`, so a row already wearing a palette slot keeps that slot and a trail can sit behind a headline. Model rows wear the validated palette in slot order, never the accent. The shared hover card now opens on focus, because the headline block is a real button.

Tests: 10 Convex tests on the series (including "the newest point states exactly what the headline states"), 10 on the derivations, 8 on the token scale, 7 on the deck, 25 on the section, 1 on the hover card. The fixtures are the real production readings.

---

Dispatched by the curia daemon — session `curia-81`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `e27d5f3` fix(measured): take the watermark chart out of the button (#81)
- `936eb79` feat(hover-card): open the card on focus, so a keyboard reader reaches it (#81)
- `b0e39fc` feat(measured): the living stack page — a windowed series and variant I (#81)