### PR TITLE
Task: window-based harness detection — no stale harness scans, asks, or hooks (alp82/aistack#101)

### DIFF
--- a/packages/cli/src/autosync/codexHook.ts
+++ b/packages/cli/src/autosync/codexHook.ts
@@ -29,14 +29,10 @@ export function codexHooksFile(): string {
 	return join(codexHome(), "hooks.json");
 }
 
-/**
- * Is Codex on this machine at all? Keyed on $CODEX_HOME existing, not on
- * session logs: a hook belongs wherever Codex will RUN, including a fresh
- * install that has no sessions yet.
- */
-export function codexPresent(): boolean {
-	return existsSync(codexHome());
-}
+// `codexPresent()` lived here and keyed on $CODEX_HOME existing. #101 replaced
+// it with `codexAdapter.detect()`: a directory proves an install, and an
+// install is not a user. A fresh Codex with no sessions yet gets its hook from
+// the interactive sync that reconciles hooks (#103), one session later.
 
 export function codexConfigFile(): string {
 	return join(codexHome(), "config.toml");

--- a/packages/cli/src/autosync/optin.test.ts
+++ b/packages/cli/src/autosync/optin.test.ts
@@ -3,29 +3,54 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { getSettings, saveSettings } from "../config.js";
-import { disableAutoSync, type EnableDeps, enableAutoSync } from "./optin.js";
+import { claudeAdapter, codexAdapter } from "../harness/index.js";
+import {
+	disableAutoSync,
+	type EnableDeps,
+	enableAutoSync,
+	NOTHING_TO_TRIGGER,
+	offerAutoSyncOptIn,
+} from "./optin.js";
 
 /**
  * Enable/disable the standing opt-in — wayfinder #62 (map #60), Codex half
- * added by #67.
+ * added by #67, narrowed to ACTIVE harnesses by #101.
  *
- * The invariants: enable is flag+hooks or neither, disable flips the flag even
- * when a hook file resists (the flag is the publish gate, the hooks are just
- * the triggers). Every dep is injected — a test that touches the REAL
- * ~/.claude/settings.json or ~/.codex/hooks.json is a bug.
+ * The invariants: enable is flag+hooks or neither, a hook goes only to a
+ * harness that ran inside the window, disable removes every hook it can reach,
+ * and the flag flips even when a hook file resists (the flag is the publish
+ * gate, the hooks are just the triggers). Every dep is injected — a test that
+ * touches the REAL ~/.claude/settings.json or ~/.codex/hooks.json is a bug.
  */
+
+const selectMock = vi.hoisted(() => vi.fn());
+vi.mock("@clack/prompts", () => ({
+	select: selectMock,
+	isCancel: (v: unknown) => typeof v === "symbol",
+	log: { success: vi.fn(), error: vi.fn(), message: vi.fn() },
+}));
 
 let dir: string;
 let settingsFile: string;
 
-/** No Codex on the imaginary test machine unless a test says otherwise. */
-const noCodex: Pick<EnableDeps, "codexPresentImpl"> = {
-	codexPresentImpl: () => false,
+/** Only Claude Code ran on the imaginary test machine unless a test says otherwise. */
+const claudeOnly: Pick<EnableDeps, "detectedImpl"> = {
+	detectedImpl: async () => [claudeAdapter],
+};
+const codexOnly: Pick<EnableDeps, "detectedImpl"> = {
+	detectedImpl: async () => [codexAdapter],
+};
+const bothHarnesses: Pick<EnableDeps, "detectedImpl"> = {
+	detectedImpl: async () => [claudeAdapter, codexAdapter],
+};
+const nothingActive: Pick<EnableDeps, "detectedImpl"> = {
+	detectedImpl: async () => [],
 };
 
 beforeEach(() => {
 	dir = mkdtempSync(join(tmpdir(), "aistack-optin-"));
 	settingsFile = join(dir, "settings.json");
+	selectMock.mockReset();
 });
 
 afterEach(() => {
@@ -33,9 +58,13 @@ afterEach(() => {
 });
 
 describe("enableAutoSync", () => {
-	test("writes the hook, then persists the flag and the answer", () => {
+	test("writes the hook, then persists the flag and the answer", async () => {
 		const installHook = vi.fn(() => ({ ok: true, message: "written" }));
-		const res = enableAutoSync(24, { settingsFile, installHook, ...noCodex });
+		const res = await enableAutoSync(24, {
+			settingsFile,
+			installHook,
+			...claudeOnly,
+		});
 		expect(res.ok).toBe(true);
 		expect(installHook).toHaveBeenCalledOnce();
 		const s = getSettings(settingsFile);
@@ -43,34 +72,38 @@ describe("enableAutoSync", () => {
 		expect(s.autoSyncAnswered).toBe(true);
 	});
 
-	test("a failed hook write persists nothing", () => {
+	test("a failed hook write persists nothing", async () => {
 		const installHook = vi.fn(() => ({ ok: false, message: "bad json" }));
-		const res = enableAutoSync(24, { settingsFile, installHook, ...noCodex });
+		const res = await enableAutoSync(24, {
+			settingsFile,
+			installHook,
+			...claudeOnly,
+		});
 		expect(res.ok).toBe(false);
 		expect(getSettings(settingsFile).autoSync).toBeUndefined();
 		expect(getSettings(settingsFile).autoSyncAnswered).toBeUndefined();
 	});
 
-	test("a custom frequency persists", () => {
-		enableAutoSync(6, {
+	test("a custom frequency persists", async () => {
+		await enableAutoSync(6, {
 			settingsFile,
 			installHook: () => ({ ok: true, message: "" }),
-			...noCodex,
+			...claudeOnly,
 		});
 		expect(getSettings(settingsFile).autoSync?.frequencyHours).toBe(6);
 	});
 
-	test("with Codex present, the Codex hook is written and the trust step named", () => {
+	test("with Codex active, the Codex hook is written and the trust step named", async () => {
 		const installCodexHook = vi.fn(() => ({
 			ok: true,
 			message:
 				"Codex hook written — open Codex and run /hooks once to trust it, or it will not run.",
 		}));
-		const res = enableAutoSync(24, {
+		const res = await enableAutoSync(24, {
 			settingsFile,
 			installHook: () => ({ ok: true, message: "" }),
 			installCodexHook,
-			codexPresentImpl: () => true,
+			...bothHarnesses,
 		});
 		expect(res.ok).toBe(true);
 		expect(installCodexHook).toHaveBeenCalledOnce();
@@ -78,14 +111,77 @@ describe("enableAutoSync", () => {
 		expect(getSettings(settingsFile).autoSync?.enabled).toBe(true);
 	});
 
-	test("a failed Codex hook write persists nothing", () => {
-		const res = enableAutoSync(24, {
+	test("a failed Codex hook write persists nothing", async () => {
+		const res = await enableAutoSync(24, {
 			settingsFile,
 			installHook: () => ({ ok: true, message: "" }),
 			installCodexHook: () => ({ ok: false, message: "bad json" }),
-			codexPresentImpl: () => true,
+			...bothHarnesses,
 		});
 		expect(res.ok).toBe(false);
+		expect(getSettings(settingsFile).autoSync).toBeUndefined();
+	});
+
+	// #101: the stale-harness machine. Claude Code is installed and its logs are
+	// on disk, but nothing has run inside the window, so it gets no hook.
+	test("a stale Claude Code gets no hook when only Codex is active", async () => {
+		const installHook = vi.fn(() => ({ ok: true, message: "" }));
+		const installCodexHook = vi.fn(() => ({ ok: true, message: "" }));
+		const res = await enableAutoSync(24, {
+			settingsFile,
+			installHook,
+			installCodexHook,
+			...codexOnly,
+		});
+		expect(res.ok).toBe(true);
+		expect(installHook).not.toHaveBeenCalled();
+		expect(installCodexHook).toHaveBeenCalledOnce();
+	});
+
+	test("a stale Codex gets no hook when only Claude Code is active", async () => {
+		const installCodexHook = vi.fn(() => ({ ok: true, message: "" }));
+		await enableAutoSync(24, {
+			settingsFile,
+			installHook: () => ({ ok: true, message: "" }),
+			installCodexHook,
+			...claudeOnly,
+		});
+		expect(installCodexHook).not.toHaveBeenCalled();
+	});
+
+	test("the confirmation names the active harnesses, not Claude Code by default", async () => {
+		const codex = await enableAutoSync(24, {
+			settingsFile,
+			installCodexHook: () => ({ ok: true, message: "" }),
+			...codexOnly,
+		});
+		expect(codex.message).toContain("when a Codex session starts");
+		expect(codex.message).not.toContain("Claude Code");
+
+		const both = await enableAutoSync(24, {
+			settingsFile,
+			installHook: () => ({ ok: true, message: "" }),
+			installCodexHook: () => ({ ok: true, message: "" }),
+			...bothHarnesses,
+		});
+		expect(both.message).toContain(
+			"when a Claude Code or Codex session starts",
+		);
+	});
+
+	test("with no active harness it writes nothing and persists nothing", async () => {
+		const installHook = vi.fn(() => ({ ok: true, message: "" }));
+		const installCodexHook = vi.fn(() => ({ ok: true, message: "" }));
+		const res = await enableAutoSync(24, {
+			settingsFile,
+			installHook,
+			installCodexHook,
+			...nothingActive,
+		});
+		expect(res.ok).toBe(false);
+		expect(res.message).toBe(NOTHING_TO_TRIGGER);
+		expect(installHook).not.toHaveBeenCalled();
+		expect(installCodexHook).not.toHaveBeenCalled();
 		expect(getSettings(settingsFile).autoSync).toBeUndefined();
 	});
 });
@@ -98,18 +194,27 @@ describe("disableAutoSync", () => {
 		);
 		const removeHook = vi.fn(() => ({ ok: true, message: "removed" }));
 		const removeCodexHook = vi.fn(() => ({ ok: true, message: "removed" }));
-		const res = disableAutoSync({
-			settingsFile,
-			removeHook,
-			removeCodexHook,
-			codexPresentImpl: () => true,
-		});
+		const res = disableAutoSync({ settingsFile, removeHook, removeCodexHook });
 		expect(res.ok).toBe(true);
 		expect(removeHook).toHaveBeenCalledOnce();
 		expect(removeCodexHook).toHaveBeenCalledOnce();
 		const s = getSettings(settingsFile);
 		expect(s.autoSync?.enabled).toBe(false);
 		expect(s.autoSync?.frequencyHours).toBe(6);
+	});
+
+	// #101: a revoke must reach a hook whose harness has since gone quiet.
+	test("removes both hooks even when neither harness is active", () => {
+		const removeHook = vi.fn(() => ({ ok: true, message: "removed" }));
+		const removeCodexHook = vi.fn(() => ({ ok: true, message: "removed" }));
+		disableAutoSync({
+			settingsFile,
+			removeHook,
+			removeCodexHook,
+			...nothingActive,
+		});
+		expect(removeHook).toHaveBeenCalledOnce();
+		expect(removeCodexHook).toHaveBeenCalledOnce();
 	});
 
 	test("flips the flag even when a hook cannot be removed", () => {
@@ -120,10 +225,67 @@ describe("disableAutoSync", () => {
 		const res = disableAutoSync({
 			settingsFile,
 			removeHook: () => ({ ok: false, message: "bad json" }),
-			...noCodex,
+			removeCodexHook: () => ({ ok: true, message: "" }),
 		});
 		expect(res.ok).toBe(false);
 		expect(getSettings(settingsFile).autoSync?.enabled).toBe(false);
 		expect(res.message).toContain("nothing will publish");
+	});
+});
+
+/** The hint the ask renders — #101's fifth bullet. */
+function hintOfEnableOption(): string {
+	const arg = selectMock.mock.calls[0]?.[0] as {
+		options: Array<{ value: string; hint?: string }>;
+	};
+	return arg.options.find((o) => o.value === "enable")?.hint ?? "";
+}
+
+describe("offerAutoSyncOptIn", () => {
+	test("a Codex-only machine is asked about Codex sessions", async () => {
+		selectMock.mockResolvedValue("later");
+		const asked = await offerAutoSyncOptIn({ settingsFile, ...codexOnly });
+		expect(asked).toBe(true);
+		expect(hintOfEnableOption()).toBe(
+			"a silent daily sync when a Codex session starts",
+		);
+	});
+
+	test("a two-harness machine is asked about both", async () => {
+		selectMock.mockResolvedValue("later");
+		await offerAutoSyncOptIn({ settingsFile, ...bothHarnesses });
+		expect(hintOfEnableOption()).toBe(
+			"a silent daily sync when a Claude Code or Codex session starts",
+		);
+	});
+
+	test("an answered machine is not asked again", async () => {
+		saveSettings({ autoSyncAnswered: true }, settingsFile);
+		expect(await offerAutoSyncOptIn({ settingsFile, ...claudeOnly })).toBe(
+			false,
+		);
+		expect(selectMock).not.toHaveBeenCalled();
+	});
+
+	test("with no active harness there is nothing to ask", async () => {
+		expect(await offerAutoSyncOptIn({ settingsFile, ...nothingActive })).toBe(
+			false,
+		);
+		expect(selectMock).not.toHaveBeenCalled();
+	});
+
+	test("enabling reuses the harnesses the hint named", async () => {
+		selectMock.mockResolvedValue("enable");
+		const installHook = vi.fn(() => ({ ok: true, message: "" }));
+		const installCodexHook = vi.fn(() => ({ ok: true, message: "" }));
+		await offerAutoSyncOptIn({
+			settingsFile,
+			installHook,
+			installCodexHook,
+			...codexOnly,
+		});
+		expect(installHook).not.toHaveBeenCalled();
+		expect(installCodexHook).toHaveBeenCalledOnce();
+		expect(getSettings(settingsFile).autoSync?.enabled).toBe(true);
 	});
 });

--- a/packages/cli/src/autosync/optin.ts
+++ b/packages/cli/src/autosync/optin.ts
@@ -1,4 +1,4 @@
-// The auto-sync opt-in (#62, map #60).
+// The auto-sync opt-in (#62, map #60), narrowed to active harnesses by #101.
 //
 // This ask is the PRIMARY post-sync ask: it runs first, and the connect-claude
 // upsell yields to a later sync (at most one ask per sync, each asked once,
@@ -12,9 +12,16 @@ import {
 	getSettings,
 	saveSettings,
 } from "../config.js";
+import { CLAUDE_HARNESS_NAME } from "../harness/claude/adapter.js";
+import { CODEX_HARNESS_NAME } from "../harness/codex/adapter.js";
+import {
+	DEFAULT_WINDOW_DAYS,
+	detectedAdapters,
+	harnessListLabel,
+} from "../harness/index.js";
+import type { HarnessAdapter } from "../harness/types.js";
 import { dim, limeBold } from "../theme.js";
 import {
-	codexPresent,
 	installCodexAutoSyncHook,
 	removeCodexAutoSyncHook,
 } from "./codexHook.js";
@@ -30,28 +37,39 @@ export interface EnableDeps {
 	removeHook?: () => HookResult;
 	installCodexHook?: () => HookResult;
 	removeCodexHook?: () => HookResult;
-	codexPresentImpl?: () => boolean;
+	/** Override the detected harness set. Tests only. */
+	detectedImpl?: () => Promise<HarnessAdapter[]>;
 }
+
+/** The message when the machine has no active harness to trigger anything. */
+export const NOTHING_TO_TRIGGER = `No Claude Code or Codex session on this machine in the last ${DEFAULT_WINDOW_DAYS} days, so nothing would trigger an auto-sync. Nothing was changed.`;
 
 /**
  * Turn the standing opt-in on: persist the flag, write the SessionStart hooks
- * — Claude Code always, Codex when it is on this machine (#66 decision 4; one
- * `sync --auto` covers all detected harnesses, so both hooks run the same
- * command). When a hook write fails, the flag is NOT persisted — a
- * half-enabled state (flag on, no hook) would claim a freshness the machine
- * cannot deliver.
+ * — one per DETECTED harness (#101). A hook for a harness whose last session
+ * predates the window is a trigger that will never fire, and its install is the
+ * step that made a dead Claude Code install look alive.
+ *
+ * When a hook write fails, the flag is NOT persisted — a half-enabled state
+ * (flag on, no hook) would claim a freshness the machine cannot deliver.
  */
-export function enableAutoSync(
+export async function enableAutoSync(
 	frequencyHours: number = DEFAULT_FREQUENCY_HOURS,
 	deps: EnableDeps = {},
-): HookResult {
-	const install = deps.installHook ?? installAutoSyncHook;
-	const result = install();
-	if (!result.ok) return result;
+): Promise<HookResult> {
+	const detected = await (deps.detectedImpl ?? detectedAdapters)();
+	if (detected.length === 0) {
+		return { ok: false, message: NOTHING_TO_TRIGGER };
+	}
+	const names = new Set(detected.map((a) => a.name));
 
-	const hasCodex = (deps.codexPresentImpl ?? codexPresent)();
+	if (names.has(CLAUDE_HARNESS_NAME)) {
+		const result = (deps.installHook ?? installAutoSyncHook)();
+		if (!result.ok) return result;
+	}
+
 	let trustLine: string | null = null;
-	if (hasCodex) {
+	if (names.has(CODEX_HARNESS_NAME)) {
 		const codexResult = (deps.installCodexHook ?? installCodexAutoSyncHook)();
 		if (!codexResult.ok) return codexResult;
 		// The one-time /hooks trust step (#65 §6) — repeated by the next
@@ -66,23 +84,24 @@ export function enableAutoSync(
 		},
 		deps.settingsFile,
 	);
-	const sessionWord = hasCodex ? "Claude Code or Codex" : "Claude Code";
 	return {
 		ok: true,
 		message: [
-			`Auto-sync is on — about every ${frequencyHours}h when a ${sessionWord} session starts. Turn it off any time: npx @use-aistack/cli sync --auto off`,
+			`Auto-sync is on — about every ${frequencyHours}h when a ${harnessListLabel(detected)} session starts. Turn it off any time: npx @use-aistack/cli sync --auto off`,
 			...(trustLine ? [trustLine] : []),
 		].join("\n"),
 	};
 }
 
 /**
- * Revoke: remove the hook AND flip the flag. The flag flips even when the
- * hook file cannot be edited, because `sync --auto` gates on the flag — a
- * stale hook without the flag publishes nothing.
+ * Revoke: remove the hooks AND flip the flag. The flag flips even when a hook
+ * file cannot be edited, because `sync --auto` gates on the flag — a stale hook
+ * without the flag publishes nothing.
+ *
+ * Removal is unconditional, unlike install: a revoke must reach the hook of a
+ * harness that has since gone quiet, and removing an absent hook is success.
  */
 export function disableAutoSync(deps: EnableDeps = {}): HookResult {
-	const remove = deps.removeHook ?? removeAutoSyncHook;
 	const settings = getSettings(deps.settingsFile);
 	saveSettings(
 		{
@@ -95,10 +114,8 @@ export function disableAutoSync(deps: EnableDeps = {}): HookResult {
 		},
 		deps.settingsFile,
 	);
-	const result = remove();
-	const codexResult = (deps.codexPresentImpl ?? codexPresent)()
-		? (deps.removeCodexHook ?? removeCodexAutoSyncHook)()
-		: { ok: true, message: "" };
+	const result = (deps.removeHook ?? removeAutoSyncHook)();
+	const codexResult = (deps.removeCodexHook ?? removeCodexAutoSyncHook)();
 	const failures = [result, codexResult]
 		.filter((r) => !r.ok)
 		.map((r) => r.message);
@@ -114,9 +131,18 @@ export function disableAutoSync(deps: EnableDeps = {}): HookResult {
 /**
  * The post-sync ask. Returns true when it asked (so the caller skips the
  * connect upsell this sync), false when it had nothing to ask.
+ *
+ * The hint names the harnesses this machine actually runs (#101): a Codex-only
+ * user is told "when a Codex session starts", not a Claude Code sentence that
+ * describes nothing they do.
  */
-export async function offerAutoSyncOptIn(): Promise<boolean> {
-	if (getSettings().autoSyncAnswered === true) return false;
+export async function offerAutoSyncOptIn(
+	deps: EnableDeps = {},
+): Promise<boolean> {
+	if (getSettings(deps.settingsFile).autoSyncAnswered === true) return false;
+
+	const detected = await (deps.detectedImpl ?? detectedAdapters)();
+	if (detected.length === 0) return false;
 
 	const answer = await p.select({
 		message: "Keep this stack fresh automatically?",
@@ -129,7 +155,7 @@ export async function offerAutoSyncOptIn(): Promise<boolean> {
 			{
 				value: "enable",
 				label: "Enable",
-				hint: "a silent daily sync when a Claude Code session starts",
+				hint: `a silent daily sync when a ${harnessListLabel(detected)} session starts`,
 			},
 		],
 		initialValue: "later",
@@ -138,7 +164,11 @@ export async function offerAutoSyncOptIn(): Promise<boolean> {
 	if (p.isCancel(answer)) return true;
 
 	if (answer === "enable") {
-		const result = enableAutoSync();
+		// The set is reused, not re-detected: the user answered the hint they saw.
+		const result = await enableAutoSync(DEFAULT_FREQUENCY_HOURS, {
+			...deps,
+			detectedImpl: async () => detected,
+		});
 		if (result.ok) {
 			p.log.success(result.message);
 		} else {
@@ -147,7 +177,7 @@ export async function offerAutoSyncOptIn(): Promise<boolean> {
 		return true;
 	}
 
-	saveSettings({ autoSyncAnswered: true });
+	saveSettings({ autoSyncAnswered: true }, deps.settingsFile);
 	p.log.message(
 		`If you change your mind: ${limeBold("npx @use-aistack/cli sync --auto on")} ${dim(
 			"(and --auto off to revoke)",

--- a/packages/cli/src/commands/connect.test.ts
+++ b/packages/cli/src/commands/connect.test.ts
@@ -1,12 +1,23 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { saveSettings } from "../config.js";
 import {
 	claudeOnPath,
 	findSkillSource,
 	installClaudeConnect,
+	offerConnectUpsell,
 	type Runner,
 	type RunResult,
 } from "./connect.js";
+
+const selectMock = vi.hoisted(() => vi.fn());
+vi.mock("@clack/prompts", () => ({
+	select: selectMock,
+	isCancel: (v: unknown) => typeof v === "symbol",
+	log: { success: vi.fn(), error: vi.fn(), message: vi.fn(), warn: vi.fn() },
+}));
 
 const ok = (output = ""): RunResult => ({ notFound: false, status: 0, output });
 const fail = (output: string): RunResult => ({
@@ -27,6 +38,67 @@ function recordingRunner(results: RunResult[]): {
 	};
 	return { run, calls };
 }
+
+/**
+ * The upsell gate — wayfinder #101 (map #76). A Codex-only user with a
+ * months-old Claude Code install got this ask, which is what opened #100. The
+ * gate is now Claude activity inside the window, THEN the binary on PATH.
+ */
+describe("offerConnectUpsell", () => {
+	let dir: string;
+	let settingsFile: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "aistack-upsell-"));
+		settingsFile = join(dir, "settings.json");
+		selectMock.mockReset();
+		selectMock.mockResolvedValue("later");
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("does not ask when Claude Code has not run inside the window", async () => {
+		const claudeOnPathImpl = vi.fn(() => true);
+		await offerConnectUpsell({
+			settingsFile,
+			claudeActiveImpl: async () => false,
+			claudeOnPathImpl,
+		});
+		expect(selectMock).not.toHaveBeenCalled();
+		// The stale check comes first, so the subprocess never even runs.
+		expect(claudeOnPathImpl).not.toHaveBeenCalled();
+	});
+
+	it("does not ask when claude is not on PATH, however recent the logs", async () => {
+		await offerConnectUpsell({
+			settingsFile,
+			claudeActiveImpl: async () => true,
+			claudeOnPathImpl: () => false,
+		});
+		expect(selectMock).not.toHaveBeenCalled();
+	});
+
+	it("asks when Claude Code is both active and installed", async () => {
+		await offerConnectUpsell({
+			settingsFile,
+			claudeActiveImpl: async () => true,
+			claudeOnPathImpl: () => true,
+		});
+		expect(selectMock).toHaveBeenCalledOnce();
+	});
+
+	it("does not ask twice", async () => {
+		saveSettings({ connectClaudeAnswered: true }, settingsFile);
+		await offerConnectUpsell({
+			settingsFile,
+			claudeActiveImpl: async () => true,
+			claudeOnPathImpl: () => true,
+		});
+		expect(selectMock).not.toHaveBeenCalled();
+	});
+});
 
 describe("findSkillSource", () => {
 	it("finds the bundled Skill from the source tree (dev layout)", () => {

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -12,6 +12,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import * as p from "@clack/prompts";
 import { getSettings, saveSettings } from "../config.js";
+import { claudeAdapter, detectionSinceMs } from "../harness/index.js";
 import {
 	dim,
 	intro,
@@ -174,15 +175,34 @@ export async function connectCommand(harness: string): Promise<void> {
 	outro("done");
 }
 
+export interface UpsellDeps {
+	/** Override the Claude activity check. Tests only. */
+	claudeActiveImpl?: () => Promise<boolean>;
+	/** Override the PATH check. Tests only. */
+	claudeOnPathImpl?: () => boolean;
+	/** Override the settings file. Tests only. */
+	settingsFile?: string;
+}
+
+/** Has Claude Code written a transcript inside the sync window? */
+export function claudeRecentlyActive(): Promise<boolean> {
+	return claudeAdapter.detect({ sinceMs: detectionSinceMs() });
+}
+
 /**
  * The post-sync upsell (#56 decision 2), asked once per machine. Any explicit
  * answer persists to ~/.config/aistack/settings.json; ctrl-C is not an answer
- * and the question returns on the next sync. Skipped silently when claude is
- * not on PATH — the offer would be noise on a machine that cannot take it.
+ * and the question returns on the next sync.
+ *
+ * Two gates, both silent. The offer needs a Claude Code the user actually runs
+ * (#101) — a months-old install asked a Codex-only user to connect a harness
+ * they had left behind, which is what opened #100. It also needs `claude` on
+ * PATH, because that binary is what installs the MCP server.
  */
-export async function offerConnectUpsell(): Promise<void> {
-	if (getSettings().connectClaudeAnswered === true) return;
-	if (!claudeOnPath()) return;
+export async function offerConnectUpsell(deps: UpsellDeps = {}): Promise<void> {
+	if (getSettings(deps.settingsFile).connectClaudeAnswered === true) return;
+	if (!(await (deps.claudeActiveImpl ?? claudeRecentlyActive)())) return;
+	if (!(deps.claudeOnPathImpl ?? claudeOnPath)()) return;
 
 	const answer = await p.select({
 		message: "Sync from inside Claude Code too?",
@@ -202,7 +222,7 @@ export async function offerConnectUpsell(): Promise<void> {
 	});
 
 	if (p.isCancel(answer)) return;
-	saveSettings({ connectClaudeAnswered: true });
+	saveSettings({ connectClaudeAnswered: true }, deps.settingsFile);
 
 	if (answer === "install") {
 		const result = installClaudeConnect();

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -48,7 +48,7 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
 		intro("sync");
 		const result =
 			options.auto === "on"
-				? enableAutoSync(
+				? await enableAutoSync(
 						options.every
 							? Number.parseInt(options.every, 10) || DEFAULT_FREQUENCY_HOURS
 							: DEFAULT_FREQUENCY_HOURS,

--- a/packages/cli/src/harness/claude/adapter.ts
+++ b/packages/cli/src/harness/claude/adapter.ts
@@ -2,38 +2,31 @@
 // analyzer.ts/scan.ts, unchanged from the single-harness era; this file only
 // gives it the adapter shape.
 
-import { stat } from "node:fs/promises";
 import { BUILTIN_TOOLS } from "../shared/allowlist.js";
 import { PRICING_TABLE_VERSION } from "../shared/pricing.js";
+import { hasRecentFile } from "../shared/recency.js";
 import type {
 	HarnessAdapter,
+	HarnessDetectOptions,
 	HarnessScan,
 	HarnessScanOptions,
 } from "../types.js";
 import { createAggregate } from "./analyzer.js";
-import { scan, transcriptRoots } from "./scan.js";
+import { isTranscriptFile, scan, transcriptRoots } from "./scan.js";
 
 export const CLAUDE_HARNESS_NAME = "claude-code";
-
-async function exists(p: string): Promise<boolean> {
-	try {
-		await stat(p);
-		return true;
-	} catch {
-		return false;
-	}
-}
 
 export const claudeAdapter: HarnessAdapter = {
 	name: CLAUDE_HARNESS_NAME,
 	builtinTools: BUILTIN_TOOLS,
 	pricingTableVersion: PRICING_TABLE_VERSION,
 
-	async detect(): Promise<boolean> {
-		for (const root of transcriptRoots()) {
-			if (await exists(root)) return true;
-		}
-		return false;
+	async detect(opts: HarnessDetectOptions): Promise<boolean> {
+		return hasRecentFile(
+			opts.roots ?? transcriptRoots(),
+			isTranscriptFile,
+			opts.sinceMs,
+		);
 	},
 
 	async scan(opts: HarnessScanOptions): Promise<HarnessScan> {

--- a/packages/cli/src/harness/claude/scan.ts
+++ b/packages/cli/src/harness/claude/scan.ts
@@ -40,6 +40,11 @@ export function transcriptRoots(): string[] {
 	return roots;
 }
 
+/** What counts as a Claude Code transcript. Shared with `detect` (#101). */
+export function isTranscriptFile(basename: string): boolean {
+	return basename.endsWith(".jsonl");
+}
+
 /** Recursive *.jsonl walk — the nested `<sessionId>/subagents/` layout is real. */
 async function* walkJsonl(dir: string): AsyncGenerator<string> {
 	let entries: Dirent[];
@@ -51,7 +56,7 @@ async function* walkJsonl(dir: string): AsyncGenerator<string> {
 	for (const e of entries) {
 		const full = path.join(dir, e.name);
 		if (e.isDirectory()) yield* walkJsonl(full);
-		else if (e.isFile() && e.name.endsWith(".jsonl")) yield full;
+		else if (e.isFile() && isTranscriptFile(e.name)) yield full;
 	}
 }
 

--- a/packages/cli/src/harness/codex/adapter.ts
+++ b/packages/cli/src/harness/codex/adapter.ts
@@ -1,15 +1,15 @@
 // The Codex CLI harness behind the seam (#66 decision 6, built in #67).
 
-import { stat } from "node:fs/promises";
-
 import { OPENAI_PRICING_TABLE_VERSION } from "../shared/pricing.js";
+import { hasRecentFile } from "../shared/recency.js";
 import type {
 	HarnessAdapter,
+	HarnessDetectOptions,
 	HarnessScan,
 	HarnessScanOptions,
 } from "../types.js";
 import { createAggregate } from "./analyzer.js";
-import { rolloutRoots, scan } from "./scan.js";
+import { isRolloutFile, rolloutRoots, scan } from "./scan.js";
 
 export const CODEX_HARNESS_NAME = "codex";
 
@@ -44,25 +44,17 @@ export const CODEX_BUILTIN_TOOLS: ReadonlySet<string> = new Set([
 	"tool_search",
 ]);
 
-async function exists(p: string): Promise<boolean> {
-	try {
-		await stat(p);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
 export const codexAdapter: HarnessAdapter = {
 	name: CODEX_HARNESS_NAME,
 	builtinTools: CODEX_BUILTIN_TOOLS,
 	pricingTableVersion: OPENAI_PRICING_TABLE_VERSION,
 
-	async detect(): Promise<boolean> {
-		for (const root of rolloutRoots()) {
-			if (await exists(root)) return true;
-		}
-		return false;
+	async detect(opts: HarnessDetectOptions): Promise<boolean> {
+		return hasRecentFile(
+			opts.roots ?? rolloutRoots(),
+			isRolloutFile,
+			opts.sinceMs,
+		);
 	},
 
 	async scan(opts: HarnessScanOptions): Promise<HarnessScan> {

--- a/packages/cli/src/harness/codex/scan.ts
+++ b/packages/cli/src/harness/codex/scan.ts
@@ -43,6 +43,11 @@ export function rolloutRoots(): string[] {
 
 const ROLLOUT_RE = /^rollout-.*\.jsonl(\.zst)?$/;
 
+/** What counts as a Codex rollout. Shared with `detect` (#101). */
+export function isRolloutFile(basename: string): boolean {
+	return ROLLOUT_RE.test(basename);
+}
+
 /** Recursive rollout walk — the YYYY/MM/DD nesting is real. */
 async function* walkRollouts(dir: string): AsyncGenerator<string> {
 	let entries: Dirent[];
@@ -54,7 +59,7 @@ async function* walkRollouts(dir: string): AsyncGenerator<string> {
 	for (const e of entries) {
 		const full = path.join(dir, e.name);
 		if (e.isDirectory()) yield* walkRollouts(full);
-		else if (e.isFile() && ROLLOUT_RE.test(e.name)) yield full;
+		else if (e.isFile() && isRolloutFile(e.name)) yield full;
 	}
 }
 

--- a/packages/cli/src/harness/detect.test.ts
+++ b/packages/cli/src/harness/detect.test.ts
@@ -1,0 +1,200 @@
+// Window-based harness detection — wayfinder #101 (map #76), decided in #100.
+//
+// "Detected" means active in the sync window, not "the log directory is still
+// on disk". The machine this exists for: a Codex-only user whose months-old
+// Claude Code install made the scan publish a dead snapshot, made the connect
+// upsell appear, and made the opt-in write a Claude hook.
+
+import {
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { enableAutoSync } from "../autosync/optin.js";
+import { claudeRecentlyActive } from "../commands/connect.js";
+import { claudeAdapter } from "./claude/adapter.js";
+import { codexAdapter } from "./codex/adapter.js";
+import { detectedAdapters, detectionSinceMs } from "./index.js";
+
+const NOW = Date.UTC(2026, 7, 5, 12, 0, 0);
+const DAY = 86_400_000;
+const SINCE = detectionSinceMs(NOW);
+
+let dir: string;
+const savedEnv = {
+	CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+	CODEX_HOME: process.env.CODEX_HOME,
+};
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "aistack-detect-"));
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+	for (const [key, value] of Object.entries(savedEnv)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+});
+
+/** Write a transcript under `dir` and stamp the mtime detection reads. */
+function write(relPath: string, mtimeMs: number): void {
+	const full = join(dir, relPath);
+	mkdirSync(join(full, ".."), { recursive: true });
+	writeFileSync(full, "{}\n");
+	utimesSync(full, mtimeMs / 1000, mtimeMs / 1000);
+}
+
+const claudeRoot = () => join(dir, "claude");
+const codexRoot = () => join(dir, "codex");
+
+describe("detectionSinceMs", () => {
+	it("opens the same 30-day window the scan uses", () => {
+		expect(new Date(detectionSinceMs(NOW)).toISOString()).toBe(
+			"2026-07-07T00:00:00.000Z",
+		);
+	});
+});
+
+describe("claudeAdapter.detect", () => {
+	it("an existing root with only stale transcripts is not detected", async () => {
+		write("claude/proj-a/sess-1.jsonl", NOW - 90 * DAY);
+		expect(
+			await claudeAdapter.detect({ sinceMs: SINCE, roots: [claudeRoot()] }),
+		).toBe(false);
+	});
+
+	it("one in-window transcript detects the harness", async () => {
+		write("claude/proj-a/sess-1.jsonl", NOW - 90 * DAY);
+		write("claude/proj-b/sess-2.jsonl", NOW - DAY);
+		expect(
+			await claudeAdapter.detect({ sinceMs: SINCE, roots: [claudeRoot()] }),
+		).toBe(true);
+	});
+
+	it("a missing root is not detected", async () => {
+		expect(
+			await claudeAdapter.detect({ sinceMs: SINCE, roots: [claudeRoot()] }),
+		).toBe(false);
+	});
+
+	it("a recent non-transcript file does not detect the harness", async () => {
+		write("claude/proj-a/notes.md", NOW);
+		expect(
+			await claudeAdapter.detect({ sinceMs: SINCE, roots: [claudeRoot()] }),
+		).toBe(false);
+	});
+});
+
+describe("codexAdapter.detect", () => {
+	it("an existing root with only stale rollouts is not detected", async () => {
+		write("codex/2026/01/02/rollout-old.jsonl", NOW - 200 * DAY);
+		expect(
+			await codexAdapter.detect({ sinceMs: SINCE, roots: [codexRoot()] }),
+		).toBe(false);
+	});
+
+	it("one in-window rollout detects the harness", async () => {
+		write("codex/2026/08/04/rollout-new.jsonl", NOW - DAY);
+		expect(
+			await codexAdapter.detect({ sinceMs: SINCE, roots: [codexRoot()] }),
+		).toBe(true);
+	});
+
+	it("a compressed rollout counts", async () => {
+		write("codex/2026/08/04/rollout-new.jsonl.zst", NOW - DAY);
+		expect(
+			await codexAdapter.detect({ sinceMs: SINCE, roots: [codexRoot()] }),
+		).toBe(true);
+	});
+
+	it("a recent file that is not a rollout does not detect the harness", async () => {
+		write("codex/history.jsonl", NOW);
+		expect(
+			await codexAdapter.detect({ sinceMs: SINCE, roots: [codexRoot()] }),
+		).toBe(false);
+	});
+});
+
+describe("detectedAdapters", () => {
+	it("skips the stale harness and keeps the live one", async () => {
+		process.env.CLAUDE_CONFIG_DIR = join(dir, "claude-home");
+		process.env.CODEX_HOME = join(dir, "codex-home");
+		write("claude-home/projects/proj-a/sess-1.jsonl", NOW - 90 * DAY);
+		write("codex-home/sessions/2026/08/04/rollout-new.jsonl", NOW - DAY);
+
+		const names = (await detectedAdapters(SINCE)).map((a) => a.name);
+		expect(names).toEqual(["codex"]);
+	});
+
+	it("returns both when both are active, Claude Code first", async () => {
+		process.env.CLAUDE_CONFIG_DIR = join(dir, "claude-home");
+		process.env.CODEX_HOME = join(dir, "codex-home");
+		write("claude-home/projects/proj-a/sess-1.jsonl", NOW - DAY);
+		write("codex-home/sessions/2026/08/04/rollout-new.jsonl", NOW - DAY);
+
+		const names = (await detectedAdapters(SINCE)).map((a) => a.name);
+		expect(names).toEqual(["claude-code", "codex"]);
+	});
+
+	it("returns nothing when every harness is stale", async () => {
+		process.env.CLAUDE_CONFIG_DIR = join(dir, "claude-home");
+		process.env.CODEX_HOME = join(dir, "codex-home");
+		write("claude-home/projects/proj-a/sess-1.jsonl", NOW - 90 * DAY);
+		write("codex-home/sessions/2026/01/02/rollout-old.jsonl", NOW - 200 * DAY);
+
+		expect(await detectedAdapters(SINCE)).toEqual([]);
+	});
+});
+
+/**
+ * The ticket's done-bar (#101), on a real filesystem and the real wall clock:
+ * a machine with only stale Claude Code logs gets no Claude scan, no Claude
+ * upsell, and no Claude hook. This is the machine from #100 — a Codex-only user
+ * whose months-old Claude Code install drove all three.
+ */
+describe("a machine with only stale Claude logs", () => {
+	const REAL_NOW = Date.now();
+	let settingsFile: string;
+
+	beforeEach(() => {
+		settingsFile = join(dir, "settings.json");
+		process.env.CLAUDE_CONFIG_DIR = join(dir, "claude-home");
+		process.env.CODEX_HOME = join(dir, "codex-home");
+		write("claude-home/projects/proj-a/sess-1.jsonl", REAL_NOW - 200 * DAY);
+		write(
+			"codex-home/sessions/2026/08/04/rollout-live.jsonl",
+			REAL_NOW - 2 * 3_600_000,
+		);
+	});
+
+	it("does not scan Claude Code", async () => {
+		const scanned: string[] = [];
+		for (const adapter of await detectedAdapters()) scanned.push(adapter.name);
+		expect(scanned).toEqual(["codex"]);
+	});
+
+	it("does not offer the Claude connect upsell", async () => {
+		expect(await claudeRecentlyActive()).toBe(false);
+	});
+
+	it("does not write the Claude hook", async () => {
+		const installHook = vi.fn(() => ({ ok: true, message: "" }));
+		const installCodexHook = vi.fn(() => ({ ok: true, message: "" }));
+		const result = await enableAutoSync(24, {
+			settingsFile,
+			installHook,
+			installCodexHook,
+		});
+		expect(result.ok).toBe(true);
+		expect(installHook).not.toHaveBeenCalled();
+		expect(installCodexHook).toHaveBeenCalledOnce();
+		expect(result.message).toContain("when a Codex session starts");
+	});
+});

--- a/packages/cli/src/harness/index.ts
+++ b/packages/cli/src/harness/index.ts
@@ -8,11 +8,10 @@
 // Typical use:
 //
 //   const now = Date.now();
+//   const sinceMs = windowStartMs(now, DEFAULT_WINDOW_DAYS);
 //   const { config } = await loadSyncConfig({ baseUrl });
-//   for (const adapter of await detectedAdapters()) {
-//     const { aggregate, stats } = await adapter.scan({
-//       sinceMs: windowStartMs(now, DEFAULT_WINDOW_DAYS),
-//     });
+//   for (const adapter of await detectedAdapters(sinceMs)) {
+//     const { aggregate, stats } = await adapter.scan({ sinceMs });
 //     const built = buildPayload({
 //       aggregate, stats, syncConfig: config, now,
 //       windowDays: DEFAULT_WINDOW_DAYS,
@@ -22,8 +21,9 @@
 //     });
 //   }
 
-import { claudeAdapter } from "./claude/adapter.js";
-import { codexAdapter } from "./codex/adapter.js";
+import { CLAUDE_HARNESS_NAME, claudeAdapter } from "./claude/adapter.js";
+import { CODEX_HARNESS_NAME, codexAdapter } from "./codex/adapter.js";
+import { DEFAULT_WINDOW_DAYS, windowStartMs } from "./shared/window.js";
 import type { HarnessAdapter } from "./types.js";
 
 export { CLAUDE_HARNESS_NAME, claudeAdapter } from "./claude/adapter.js";
@@ -94,6 +94,7 @@ export {
 	SONNET_5_INTRO_ENDS_MS,
 	type TokenCounts,
 } from "./shared/pricing.js";
+export { hasRecentFile } from "./shared/recency.js";
 export {
 	DEFAULT_WINDOW_DAYS,
 	type ScanStats,
@@ -101,6 +102,7 @@ export {
 } from "./shared/window.js";
 export type {
 	HarnessAdapter,
+	HarnessDetectOptions,
 	HarnessScan,
 	HarnessScanOptions,
 } from "./types.js";
@@ -115,11 +117,37 @@ export const HARNESS_ADAPTERS: readonly HarnessAdapter[] = [
 	codexAdapter,
 ];
 
-/** The adapters whose log roots exist on this machine. */
-export async function detectedAdapters(): Promise<HarnessAdapter[]> {
+/** Display name for a harness discriminator. One name per harness, defined here. */
+export function harnessLabel(name: string): string {
+	if (name === CLAUDE_HARNESS_NAME) return "Claude Code";
+	if (name === CODEX_HARNESS_NAME) return "Codex";
+	return name;
+}
+
+/** The detected harnesses as one phrase: "Claude Code or Codex". */
+export function harnessListLabel(adapters: readonly HarnessAdapter[]): string {
+	return adapters.map((a) => harnessLabel(a.name)).join(" or ");
+}
+
+/**
+ * The window every detection uses when the caller has no scan in hand. The
+ * scan passes its own window start instead, which is the same number.
+ */
+export function detectionSinceMs(now: number = Date.now()): number {
+	return windowStartMs(now, DEFAULT_WINDOW_DAYS);
+}
+
+/**
+ * The adapters that wrote a transcript inside the window — the machine's LIVE
+ * harnesses (#101). A stale one is skipped everywhere this is read: it does not
+ * scan, it does not publish, it earns no upsell and it gets no hook.
+ */
+export async function detectedAdapters(
+	sinceMs: number = detectionSinceMs(),
+): Promise<HarnessAdapter[]> {
 	const out: HarnessAdapter[] = [];
 	for (const adapter of HARNESS_ADAPTERS) {
-		if (await adapter.detect()) out.push(adapter);
+		if (await adapter.detect({ sinceMs })) out.push(adapter);
 	}
 	return out;
 }

--- a/packages/cli/src/harness/shared/recency.test.ts
+++ b/packages/cli/src/harness/shared/recency.test.ts
@@ -1,0 +1,105 @@
+// The detection primitive — wayfinder #101 (map #76), decided in #100.
+//
+// The property under test: recency, not existence. A root full of old files is
+// the exact machine that used to scan, publish, ask and hook for a harness its
+// owner had abandoned.
+
+import {
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { hasRecentFile } from "./recency.js";
+
+const NOW = Date.UTC(2026, 7, 5, 12, 0, 0);
+const DAY = 86_400_000;
+const WINDOW_START = NOW - 29 * DAY;
+
+const isJsonl = (name: string) => name.endsWith(".jsonl");
+
+let root: string;
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "aistack-recency-"));
+});
+
+afterEach(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+function writeFile(relPath: string, mtimeMs: number): void {
+	const full = join(root, relPath);
+	mkdirSync(join(full, ".."), { recursive: true });
+	writeFileSync(full, "{}\n");
+	utimesSync(full, mtimeMs / 1000, mtimeMs / 1000);
+}
+
+describe("hasRecentFile", () => {
+	it("a root that exists but holds only old files is not recent", async () => {
+		writeFile("proj-a/sess-1.jsonl", NOW - 200 * DAY);
+		writeFile("proj-b/sess-2.jsonl", NOW - 31 * DAY);
+		expect(await hasRecentFile([root], isJsonl, WINDOW_START)).toBe(false);
+	});
+
+	it("one in-window file makes the whole root recent", async () => {
+		writeFile("proj-a/sess-1.jsonl", NOW - 200 * DAY);
+		writeFile("proj-b/sess-2.jsonl", NOW - DAY);
+		expect(await hasRecentFile([root], isJsonl, WINDOW_START)).toBe(true);
+	});
+
+	it("a file exactly on the window edge counts", async () => {
+		writeFile("proj-a/sess-1.jsonl", WINDOW_START);
+		expect(await hasRecentFile([root], isJsonl, WINDOW_START)).toBe(true);
+	});
+
+	it("finds a recent file nested below the top level", async () => {
+		writeFile("proj-a/sess-1/subagents/sub-1.jsonl", NOW - DAY);
+		expect(await hasRecentFile([root], isJsonl, WINDOW_START)).toBe(true);
+	});
+
+	it("ignores recent files the matcher rejects", async () => {
+		writeFile("proj-a/notes.md", NOW);
+		expect(await hasRecentFile([root], isJsonl, WINDOW_START)).toBe(false);
+	});
+
+	it("a missing root is not recent, and does not throw", async () => {
+		expect(
+			await hasRecentFile([join(root, "nope")], isJsonl, WINDOW_START),
+		).toBe(false);
+	});
+
+	it("an empty root list is not recent", async () => {
+		expect(await hasRecentFile([], isJsonl, WINDOW_START)).toBe(false);
+	});
+
+	it("any one of several roots can carry the recent file", async () => {
+		writeFile("a/old.jsonl", NOW - 200 * DAY);
+		writeFile("b/new.jsonl", NOW - DAY);
+		expect(
+			await hasRecentFile(
+				[join(root, "a"), join(root, "b")],
+				isJsonl,
+				WINDOW_START,
+			),
+		).toBe(true);
+	});
+
+	it("stops statting once it has its answer", async () => {
+		for (let i = 0; i < 20; i++) writeFile(`proj/sess-${i}.jsonl`, NOW - DAY);
+		let stats = 0;
+		const found = await hasRecentFile([root], isJsonl, WINDOW_START, {
+			statImpl: async (file) => {
+				stats++;
+				const { stat } = await import("node:fs/promises");
+				return stat(file);
+			},
+		});
+		expect(found).toBe(true);
+		expect(stats).toBe(1);
+	});
+});

--- a/packages/cli/src/harness/shared/recency.ts
+++ b/packages/cli/src/harness/shared/recency.ts
@@ -1,0 +1,77 @@
+// "Is this harness alive?" — the detection primitive behind every adapter's
+// `detect()` (#101, decided in #100).
+//
+// A directory that merely exists proves nothing: a Claude Code install from
+// months ago leaves its transcript root behind forever, and detection keyed on
+// that root scanned it, published a dead snapshot next to a live one, and asked
+// its owner to connect a harness they had stopped using.
+//
+// So detection asks the same question the scan asks: did this harness write
+// anything inside the rolling window? It answers with `stat` calls only —
+// nothing is opened, nothing is parsed. A live harness answers on the first
+// recent file it meets, which is usually the first file it meets. A dead
+// harness pays a full walk of stats to say no, which is the cost the old
+// `exists()` check saved and the reason the answer was wrong.
+//
+// Directory mtimes cannot prune this walk. `claude/scan.ts` verified why:
+// appending to a file does not move its parent directory's mtime, so a resumed
+// session writes in-window records into a directory that looks untouched.
+
+import type { Dirent, Stats } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
+import path from "node:path";
+
+export type RecencyOptions = {
+	/** Override the directory reader. Tests only. */
+	readdirImpl?: (dir: string) => Promise<Dirent[]>;
+	/** Override the stat call. Tests only. */
+	statImpl?: (file: string) => Promise<Stats>;
+};
+
+/**
+ * True when any file under `roots` whose basename passes `matches` was modified
+ * at or after `sinceMs`. Unreadable directories and files are silence, not an
+ * error — the same fail-quiet rule the scanners hold, and for the same reason:
+ * the error object carries the absolute path.
+ */
+export async function hasRecentFile(
+	roots: readonly string[],
+	matches: (basename: string) => boolean,
+	sinceMs: number,
+	opts: RecencyOptions = {},
+): Promise<boolean> {
+	const readDir =
+		opts.readdirImpl ??
+		((dir: string) => readdir(dir, { withFileTypes: true }));
+	const statFile = opts.statImpl ?? stat;
+
+	const seen = new Set<string>();
+	const pending: string[] = [...roots];
+	while (pending.length > 0) {
+		const dir = pending.pop() as string;
+		if (seen.has(dir)) continue;
+		seen.add(dir);
+
+		let entries: Dirent[];
+		try {
+			entries = await readDir(dir);
+		} catch {
+			continue;
+		}
+		for (const e of entries) {
+			const full = path.join(dir, e.name);
+			if (e.isDirectory()) {
+				pending.push(full);
+				continue;
+			}
+			if (!e.isFile() || !matches(e.name)) continue;
+			try {
+				const st = await statFile(full);
+				if (st.mtimeMs >= sinceMs) return true;
+			} catch {
+				/* unreadable file — it proves nothing either way */
+			}
+		}
+	}
+	return false;
+}

--- a/packages/cli/src/harness/types.ts
+++ b/packages/cli/src/harness/types.ts
@@ -21,6 +21,17 @@ export type HarnessScanOptions = {
 	onProgress?: (files: number) => void;
 };
 
+export type HarnessDetectOptions = {
+	/**
+	 * The harness counts as present only when it wrote a transcript at or after
+	 * this epoch ms. Callers pass the window start the scan uses, so "detected"
+	 * and "in window" are the same number by construction (#101).
+	 */
+	sinceMs: number;
+	/** Override the discovered roots. Tests only. */
+	roots?: string[];
+};
+
 export interface HarnessAdapter {
 	/** The payload discriminator: `"claude-code"` | `"codex"`. */
 	readonly name: string;
@@ -34,7 +45,11 @@ export interface HarnessAdapter {
 	 * harness because the vendors publish their lists separately.
 	 */
 	readonly pricingTableVersion: string;
-	/** True when this harness's log roots exist on this machine. */
-	detect(): Promise<boolean>;
+	/**
+	 * True when this harness wrote a transcript inside the sync window. A log
+	 * root that merely exists is NOT detection (#101): a months-old install
+	 * leaves one behind forever, and it used to scan, publish, ask and hook.
+	 */
+	detect(opts: HarnessDetectOptions): Promise<boolean>;
 	scan(opts: HarnessScanOptions): Promise<HarnessScan>;
 }

--- a/packages/cli/src/sync/stage.test.ts
+++ b/packages/cli/src/sync/stage.test.ts
@@ -16,6 +16,10 @@ import {
 } from "../harness/shared/allowlist.js";
 import { PRICING_TABLE_VERSION } from "../harness/shared/pricing.js";
 import type { ScanStats } from "../harness/shared/window.js";
+import {
+	DEFAULT_WINDOW_DAYS,
+	windowStartMs,
+} from "../harness/shared/window.js";
 import type { HarnessAdapter } from "../harness/types.js";
 import { type StageDeps, stageId, stageSync } from "./stage.js";
 
@@ -121,5 +125,36 @@ describe("stageSync", () => {
 			}),
 		);
 		expect(staged.blockedReason).toContain("/stacks/new");
+	});
+
+	// #101: detection and the scan read ONE window start, so a harness that
+	// counts as detected is exactly a harness with something in the window.
+	test("detection gets the same window start the scan gets", async () => {
+		let detectSince: number | null = null;
+		let scanSince: number | null = null;
+		await stageSync(
+			deps({
+				adaptersImpl: async (sinceMs) => {
+					detectSince = sinceMs;
+					return [
+						{
+							...FAKE_CLAUDE_ADAPTER,
+							scan: async (opts) => {
+								scanSince = opts.sinceMs;
+								return FAKE_CLAUDE_ADAPTER.scan(opts);
+							},
+						},
+					];
+				},
+			}),
+		);
+		expect(detectSince).toBe(windowStartMs(NOW, DEFAULT_WINDOW_DAYS));
+		expect(scanSince).toBe(detectSince);
+	});
+
+	test("no active harness blocks, and the reason names the window", async () => {
+		const staged = await stageSync(deps({ adaptersImpl: async () => [] }));
+		expect(staged.blockedReason).toContain("No active harness");
+		expect(staged.blockedReason).toContain("last 30 days");
 	});
 });

--- a/packages/cli/src/sync/stage.ts
+++ b/packages/cli/src/sync/stage.ts
@@ -1,5 +1,7 @@
-// Stage one send: scan every detected harness → build → derive the gate's
-// text from the exact bytes.
+// Stage one send: scan every ACTIVE harness → build → derive the gate's text
+// from the exact bytes. Active, not installed: a harness with nothing in the
+// window is not scanned and does not publish, so a dead Claude Code install no
+// longer lands a stale snapshot next to a live Codex one (#101).
 //
 // Wayfinder ticket #41 (map #29), widened to the adapter seam by #67 (map
 // #60). The staged `bodyJson` string IS what a publish transmits — the summary
@@ -66,7 +68,7 @@ export type StageDeps = {
 		token?: string;
 	}) => Promise<LoadedSyncConfig>;
 	/** Override the adapter set. Tests only. */
-	adaptersImpl?: () => Promise<HarnessAdapter[]>;
+	adaptersImpl?: (sinceMs: number) => Promise<HarnessAdapter[]>;
 	getSettingsImpl?: () => Settings;
 	windowDays?: number;
 };
@@ -89,8 +91,10 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 
 	const built: BuiltPayload[] = [];
 	const scanStats: Record<string, ScanStats> = {};
+	// One window start for detection AND for the scan (#101), so a harness that
+	// counts as detected is exactly a harness with something in the window.
 	const sinceMs = windowStartMs(now, windowDays);
-	for (const adapter of await adapters()) {
+	for (const adapter of await adapters(sinceMs)) {
 		const { aggregate, stats } = await adapter.scan({ sinceMs });
 		scanStats[adapter.name] = stats;
 		built.push(
@@ -126,8 +130,7 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 
 	let blockedReason: string | null = null;
 	if (built.length === 0) {
-		blockedReason =
-			"No supported harness was found on this machine — no Claude Code and no Codex logs to read.";
+		blockedReason = `No active harness on this machine — no Claude Code and no Codex transcript from the last ${windowDays} days to read.`;
 	} else if (token === null) {
 		blockedReason =
 			"This machine is not linked. Run `npx @use-aistack/cli login` first.";

--- a/packages/cli/src/sync/summary.ts
+++ b/packages/cli/src/sync/summary.ts
@@ -10,6 +10,7 @@
 // Nothing in this file is accepted as a caller-supplied argument beside the
 // payload — the spike promoted that from a caution to a demonstrated property.
 
+import { harnessLabel } from "../harness/index.js";
 import type {
 	KeptPrivateAtom,
 	NameCategory,
@@ -152,12 +153,10 @@ export function keptPrivateRows(
 
 const KEPT_PRIVATE_ROWS_SHOWN = 6;
 
-/** Display name for a harness discriminator the gate prints. */
-export function harnessLabel(name: string): string {
-	if (name === "claude-code") return "Claude Code";
-	if (name === "codex") return "Codex";
-	return name;
-}
+// The harness display names live with the harness names themselves (#101), so
+// one harness has one label everywhere. Re-exported: this module is where the
+// gate's renderers reach for it.
+export { harnessLabel };
 
 /** How many unreadable files get named before the list truncates. */
 const UNREADABLE_FILES_SHOWN = 5;


### PR DESCRIPTION
Ticket: alp82/aistack#101 — [Task: window-based harness detection — no stale harness scans, asks, or hooks](https://github.com/alp82/aistack/issues/101)

Resolves alp82/aistack#101 (map #76). Decided in #100.

## What changed

A harness counts as detected only when its newest transcript sits inside the rolling 30-day sync window. A log directory that merely exists proves an install, not a user. A months-old Claude Code left one behind, and it scanned, published a dead snapshot, asked for the connect upsell, and took a SessionStart hook. That is the machine that opened #100.

- **`harness/shared/recency.ts`** — `hasRecentFile` answers detection with `stat` calls only, and exits on the first in-window file. Nothing is opened and nothing is parsed. Directory mtimes cannot prune the walk, for the reason `claude/scan.ts` already verified: appending to a file does not move its parent directory's mtime.
- **`claudeAdapter.detect()` / `codexAdapter.detect()`** take the window start. Each reuses its own scanner's file matcher, so the walk and the detection agree on what a transcript is.
- **`stageSync`** passes the SAME window start to detection and to the scan, so "detected" and "in window" cannot drift apart. A stale harness is skipped, so a dead claude-code snapshot no longer publishes next to a live Codex one. The blocked message now names the window.
- **The connect upsell** gates on recent Claude activity first, then on `claude` being on PATH. The stale check runs first, so the subprocess does not even start on a machine that would fail it.
- **`enableAutoSync`** installs a hook per detected harness, and refuses when no harness is active (nothing persists). **`disableAutoSync`** removes both hooks unconditionally, so a revoke reaches a harness that has since gone quiet.
- **The ask hint and the confirmation** name the detected harnesses: "when a Codex session starts", "when a Claude Code or Codex session starts".
- `codexPresent()` is gone — it keyed on `$CODEX_HOME` existing. A fresh Codex with no sessions gets its hook from the interactive reconcile in #103, one session later.
- `harnessLabel` moved next to the harness names, so one harness has one label.

Not in scope: removing stale snapshots on the server. They stay and age visibly.

## Verification

The ticket's done-bar runs as a test on a real filesystem and the real clock (`harness/detect.test.ts`): a machine with 200-day-old Claude logs beside a two-hour-old Codex rollout gets no Claude scan, no Claude upsell, and no Claude hook.

Full repo suite green: 1469 passed, 6 skipped. `tsc --noEmit` clean, biome clean, the CLI builds.

No schema change. No release: the wire is untouched, and #102/#103/#104 add to the same CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Dispatched by the curia daemon — session `curia-101`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `235e1d6` feat(cli): window-based harness detection (#101)