### PR TITLE
Prototype: refine the view-analytics page and its entry points (alp82/aistack#98)

### DIFF
--- a/docs/prototypes/view-analytics-98.md
+++ b/docs/prototypes/view-analytics-98.md
@@ -1,0 +1,111 @@
+# View analytics: the page and its entry points
+
+Decided in [alp82/aistack#98](https://github.com/alp82/aistack/issues/98), a prototype
+ticket on [map #76](https://github.com/alp82/aistack/issues/76). The owner picked every
+shape below from a live prototype. This file is what the follow-up build ticket
+implements.
+
+The prototype routes are `/prototype/views`, `/prototype/views-entry` and
+`/prototype/views-stack` on branch `curia/98`. They run on fixtures, they are
+throwaway, and the build deletes them.
+
+## What was decided
+
+### 1. The profile gets an owner-only Views panel
+
+Shape **E4** in the prototype: the headline total from E2, plus one inline box per
+page from E3.
+
+The panel renders in the owner region of `ProfilePage`, where the "View analytics
+(owner-only)" seam sits today. It carries, in this order:
+
+1. The headline total, in the accent, with `deduped daily visitors · <range>` under it.
+2. One box per target — the profile and every stack, drafts included — with the
+   page name, its note, its sparkline and its own total.
+3. The short honest-labeling paragraph.
+4. A link to `/settings/analytics`, labeled for what that page adds: the day-by-day
+   reading and the referrer split.
+
+The draft box stays in the list. A draft that reads zero is the number an owner most
+needs explained, and dropping it makes the list lie by omission.
+
+The whole panel sits inside a private fence: a dashed border, a lock icon, and the
+words "only you can see this". That is the same treatment the draft-stack cards
+already use, so "private" is a shape the owner knows on this page and not a sentence
+they have to find.
+
+`ProfilePage` already carries the prop the build needs. `ownerViewsSlot` is optional,
+gated on `isOwner`, and falls back to today's seam.
+
+### 2. `/settings/analytics` keeps design B
+
+Design **B** in the prototype, which is what ships today, tightened. In order: the
+headline total, one `TimeSeriesChart` line per page, the `BarsChart` of where the
+visits came from, then a row per page.
+
+This is the decision that unblocks [#95](https://github.com/alp82/aistack/issues/95).
+The multi-series chart survives, so #95 still has a real multi-series chart to check
+the palette on, on the page it planned to check.
+
+Designs A (rows only, referrers as a sentence) and C (a card per page, no site-wide
+total) were rejected. They live on branch `curia/98` if the question reopens.
+
+### 3. Three ways in, not one
+
+- **The account menu keeps Views.** It stays pointed at `/settings/analytics`.
+- **The profile gets the panel above.**
+- **A stack page gets a private line for its owner.**
+
+`/stacks/{slug}/changes` gets nothing. It is already owner-only, so it adds a fourth
+door without adding a reader.
+
+### 4. The stack-page line is shape S1
+
+A one-line strip under the hero, above the first numbered section. Lock icon, the
+words "only you can see this", this stack's total in the accent, then
+`deduped daily visitors · <range> · not page loads`, then a link to
+`/settings/analytics` on the right.
+
+S2, the fenced box with a trail, was rejected as too loud for a page whose own
+subject is the stack and not its audience.
+
+## What may not change
+
+- **Strictly private means owner-gated.** The profile and a stack page are both public
+  routes. A visitor's render of either must contain no line, no number and no lock.
+  The prototype was checked this way: the server HTML for a visitor carries none of
+  the private markup, on every variant.
+- **The guard stays in the query.** `viewAnalytics.mine` takes no target argument.
+  A per-stack number on a stack page must not become a query that accepts a target.
+  See "What the build has to solve" below.
+- **The honest labeling.** Deduped daily visitors, one visitor per page per UTC day,
+  a browser on a network and not a person, owner views excluded while signed in, not
+  page loads. Re-word it freely. Never let a number appear without it.
+- House style: no border-radius, mono for labels and technical accents, charts only
+  from `src/features/charts`.
+
+## What the build has to solve
+
+**The stack-page line needs a number for one stack, and `mine` answers for all of
+them.** Two ways out, and the build picks one:
+
+1. Call `mine` on the stack page and select the entry whose `targetId` matches. No
+   query change, one extra read of every counter the owner has, on a page that does
+   not need them.
+2. Add a second owner-scoped query that takes a slug and verifies ownership server
+   side before it answers. It must derive the caller the same way `mine` does, and it
+   must return null rather than zero for a stack the caller does not own.
+
+Option 1 is the smaller change and is right at this size. Option 2 is right once a
+creator has enough stacks that reading all of them per stack page stops being free.
+
+**The thin-data cases are the normal case, not the edge.** Prod holds 14 counter rows.
+A target with one reading draws no sparkline — `Sparkline` returns null below two
+points — so every surface needs a shape for that. The existing empty states on
+`/settings/analytics` are decisions and they keep working.
+
+## What was NOT decided
+
+- Nothing changed on the query side. There is still no per-page referrer split, no
+  per-referrer time series, and no window other than 30 days.
+- The `aggregate`/`global` counter stays excluded. It has no owner.

--- a/src/components/PrototypeSwitcher.tsx
+++ b/src/components/PrototypeSwitcher.tsx
@@ -1,0 +1,80 @@
+/**
+ * PROTOTYPE (#98) — the floating bar that flips between variants.
+ *
+ * Throwaway. It is deliberately loud, so nobody mistakes it for the design it
+ * is showing. Hidden in a production build, so a stray merge cannot ship it.
+ */
+
+import { useEffect } from "react";
+
+type Axis = {
+	readonly name: string;
+	readonly keys: readonly string[];
+	readonly labels: Record<string, string>;
+	readonly current: string;
+	readonly onPick: (key: string) => void;
+	/** Left and right arrow keys cycle this axis. Only one axis may claim them. */
+	readonly arrowKeys?: boolean;
+};
+
+function PrototypeSwitcher({ axes }: { readonly axes: readonly Axis[] }) {
+	const keyed = axes.find((a) => a.arrowKeys);
+
+	useEffect(() => {
+		if (!keyed) return;
+		function onKey(e: KeyboardEvent) {
+			if (!keyed) return;
+			const el = document.activeElement;
+			const tag = el?.tagName;
+			if (
+				tag === "INPUT" ||
+				tag === "TEXTAREA" ||
+				(el as HTMLElement | null)?.isContentEditable
+			)
+				return;
+			if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+			const i = keyed.keys.indexOf(keyed.current);
+			const next =
+				e.key === "ArrowRight"
+					? (i + 1) % keyed.keys.length
+					: (i - 1 + keyed.keys.length) % keyed.keys.length;
+			keyed.onPick(keyed.keys[next]);
+		}
+		window.addEventListener("keydown", onKey);
+		return () => window.removeEventListener("keydown", onKey);
+	}, [keyed]);
+
+	if (import.meta.env.PROD) return null;
+
+	return (
+		<div className="fixed inset-x-0 bottom-0 z-50 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 border-t-2 border-accent-lime bg-bg-canvas/95 px-3 py-2 shadow-[0_-6px_0_rgba(0,0,0,0.25)] backdrop-blur">
+			<span className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-accent-lime">
+				Prototype #98
+			</span>
+			{axes.map((axis) => (
+				<div key={axis.name} className="flex items-center gap-1.5">
+					<span className="font-mono text-[10px] uppercase tracking-[0.14em] text-fg-muted">
+						{axis.name}
+					</span>
+					{axis.keys.map((k) => (
+						<button
+							key={k}
+							type="button"
+							onClick={() => axis.onPick(k)}
+							className={
+								k === axis.current
+									? "border border-accent-lime bg-accent-lime px-2 py-1 font-mono text-[11px] font-bold uppercase tracking-[0.1em] text-accent-lime-contrast"
+									: "border border-stroke-strong px-2 py-1 font-mono text-[11px] uppercase tracking-[0.1em] text-fg-secondary hover:border-accent-lime hover:text-accent-lime"
+							}
+						>
+							{axis.labels[k] ?? k}
+						</button>
+					))}
+				</div>
+			))}
+		</div>
+	);
+}
+
+export { PrototypeSwitcher };
+export type { Axis as PrototypeAxis };

--- a/src/features/profile/ProfilePage.tsx
+++ b/src/features/profile/ProfilePage.tsx
@@ -31,6 +31,14 @@ type ProfilePageProps = {
 	stacks: ProfileStackCard[];
 	/** Owner-only companion data (null for visitors/guests). */
 	ownProfile: OwnProfileData | null;
+	/**
+	 * PROTOTYPE (#98) — what the owner-only view-analytics region renders.
+	 *
+	 * Rendered only when `ownProfile` says the reader owns this profile, so a
+	 * visitor never receives it. Falls back to today's planned-seam when nothing
+	 * is passed. The prototype route feeds this; #98 decides what ships here.
+	 */
+	ownerViewsSlot?: React.ReactNode;
 };
 
 function formatUpdatedAt(updatedAt: number): string {
@@ -87,7 +95,12 @@ function Seam({ label, note }: { label: string; note: string }) {
  * full-width callout. Owner affordances (New stack, Edit profile, draft
  * cards) are gated on `ownProfile`.
  */
-function ProfilePage({ profile, stacks, ownProfile }: ProfilePageProps) {
+function ProfilePage({
+	profile,
+	stacks,
+	ownProfile,
+	ownerViewsSlot,
+}: ProfilePageProps) {
 	const isOwner = ownProfile?.isOwner === true;
 	const draftStacks = ownProfile?.draftStacks ?? [];
 	const stackCount = stacks.length + draftStacks.length;
@@ -164,12 +177,13 @@ function ProfilePage({ profile, stacks, ownProfile }: ProfilePageProps) {
 							label="Live stats"
 							note="Measured usage per stack — lands with auto-sync."
 						/>
-						{isOwner && (
-							<Seam
-								label="View analytics (owner-only)"
-								note="Private per-profile dashboard — planned."
-							/>
-						)}
+						{isOwner &&
+							(ownerViewsSlot ?? (
+								<Seam
+									label="View analytics (owner-only)"
+									note="Private per-profile dashboard — planned."
+								/>
+							))}
 					</div>
 				</main>
 			</div>

--- a/src/features/profile/prototype/EntryVariants.tsx
+++ b/src/features/profile/prototype/EntryVariants.tsx
@@ -19,10 +19,11 @@ import { formatExact, Sparkline } from "@/features/charts";
 import { REFERRER_LABELS, rangeLabel } from "@/features/settings/AnalyticsPage";
 import type { AnalyticsData } from "@/features/settings/prototype/fixtures";
 
-export const ENTRIES = ["E1", "E2", "E3"] as const;
+export const ENTRIES = ["E4", "E1", "E2", "E3"] as const;
 export type EntryKey = (typeof ENTRIES)[number];
 
 export const ENTRY_LABELS: Record<EntryKey, string> = {
+	E4: "E4 · Picked",
 	E1: "E1 · Link",
 	E2: "E2 · Summary",
 	E3: "E3 · Inline",
@@ -225,6 +226,96 @@ export function EntryE3({ data }: { readonly data: AnalyticsData }) {
 				phone and a laptop counts twice. Visits you make while signed in are
 				left out. These are not page loads.
 			</p>
+		</PrivateFence>
+	);
+}
+
+/* -------------------------------------------------------------------- E4 */
+
+/**
+ * E4 — the picked shape: E2 with the inline boxes from E3.
+ *
+ * The owner gets the headline total AND every page as its own box, on the
+ * profile, inside the private fence. `/settings/analytics` stays, because the
+ * day-by-day reading and the referrer split do not fit here and do not belong
+ * on a public page even behind a gate.
+ *
+ * The draft box stays in the list. A draft that reads zero is the one number an
+ * owner most needs explained, and dropping it makes the list lie by omission.
+ */
+export function EntryE4({ data }: { readonly data: AnalyticsData }) {
+	const range = rangeLabel(
+		data.firstCountedDayMs,
+		data.windowStartMs,
+		data.windowDays,
+	);
+
+	return (
+		<PrivateFence title="Views">
+			{data.total === 0 ? (
+				<p className="mt-3 text-sm leading-relaxed text-fg-secondary">
+					Nobody has opened your pages yet. Counting starts the first time
+					somebody who is not you opens one. Your own visits never count while
+					you are signed in.
+				</p>
+			) : (
+				<>
+					<p className="mt-3 font-mono text-3xl font-black text-accent">
+						{formatExact(data.total)}
+					</p>
+					<p className="mt-1 font-mono text-[10px] uppercase tracking-[0.2em] text-fg-muted">
+						deduped daily visitors · {range}
+					</p>
+				</>
+			)}
+
+			<ul className="mt-4 space-y-2">
+				{data.targets.map((t) => (
+					<li
+						key={t.targetId}
+						className="flex items-center justify-between gap-3 border border-stroke-subtle bg-bg-panel px-3 py-2"
+					>
+						<span className="min-w-0">
+							<span className="block truncate font-mono text-xs font-bold text-fg-primary">
+								{t.label}
+							</span>
+							<span className="mt-0.5 block font-mono text-[10px] text-fg-muted">
+								{!t.openable
+									? "Draft — nobody can open it yet"
+									: t.total === 0
+										? "Nobody has opened it yet"
+										: "deduped daily visitors"}
+							</span>
+						</span>
+						<span className="flex shrink-0 items-center gap-3">
+							<Sparkline
+								points={t.days}
+								ariaLabel={`Daily visitors for ${t.label}`}
+								width={72}
+								height={20}
+								area
+							/>
+							<span className="font-mono text-sm font-black text-fg-primary">
+								{formatExact(t.total)}
+							</span>
+						</span>
+					</li>
+				))}
+			</ul>
+
+			<p className="mt-3 max-w-prose text-xs leading-relaxed text-fg-muted">
+				One page counts one visitor once per day. A visitor is a browser on a
+				network, not a person. Visits you make while signed in are left out.
+				These are not page loads.
+			</p>
+
+			<Link
+				to="/settings/analytics"
+				className="mt-4 inline-flex items-center gap-1.5 font-mono text-xs font-semibold uppercase tracking-[0.12em] text-fg-secondary hover:text-accent-lime"
+			>
+				Day by day, and where they came from
+				<ArrowRight aria-hidden="true" className="size-3" />
+			</Link>
 		</PrivateFence>
 	);
 }

--- a/src/features/profile/prototype/EntryVariants.tsx
+++ b/src/features/profile/prototype/EntryVariants.tsx
@@ -1,0 +1,230 @@
+/**
+ * PROTOTYPE (#98) — where an owner enters the view numbers from.
+ *
+ * Throwaway. All three render inside the owner-only region of the real profile
+ * page, which is the surface the risk lives on: the profile is PUBLIC, the
+ * number is STRICTLY PRIVATE. Every variant has to read as private to the
+ * owner, and a screenshot of a visitor's view of the same page must contain
+ * none of it.
+ *
+ * E1 — Link only. A door, no number. Nothing private is ever painted here.
+ * E2 — Summary. The total and the top pages, fenced and labeled private, with
+ *      the full page one click away.
+ * E3 — Inline. The whole thing lives here and `/settings/analytics` goes away.
+ */
+
+import { Link } from "@tanstack/react-router";
+import { ArrowRight, Lock } from "lucide-react";
+import { formatExact, Sparkline } from "@/features/charts";
+import { REFERRER_LABELS, rangeLabel } from "@/features/settings/AnalyticsPage";
+import type { AnalyticsData } from "@/features/settings/prototype/fixtures";
+
+export const ENTRIES = ["E1", "E2", "E3"] as const;
+export type EntryKey = (typeof ENTRIES)[number];
+
+export const ENTRY_LABELS: Record<EntryKey, string> = {
+	E1: "E1 · Link",
+	E2: "E2 · Summary",
+	E3: "E3 · Inline",
+};
+
+/**
+ * The fence every variant that paints a number sits inside.
+ *
+ * A dashed edge and a lock, in the same treatment the draft-stack cards already
+ * use for owner-only content, so "only you see this" is a shape the owner
+ * already knows on this page and not a sentence they have to find.
+ */
+function PrivateFence({
+	children,
+	title,
+}: {
+	readonly children: React.ReactNode;
+	readonly title: string;
+}) {
+	return (
+		<section className="border border-dashed border-stroke-strong bg-bg-panel-muted p-5">
+			<div className="flex items-center gap-1.5">
+				<Lock aria-hidden="true" className="size-3 text-fg-muted" />
+				<h2 className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-fg-muted">
+					{title} — only you can see this
+				</h2>
+			</div>
+			{children}
+		</section>
+	);
+}
+
+/* -------------------------------------------------------------------- E1 */
+
+export function EntryE1() {
+	return (
+		<Link
+			to="/settings/analytics"
+			className="group flex items-center justify-between gap-4 border border-dashed border-stroke-strong px-4 py-3 transition-colors hover:border-accent-lime"
+		>
+			<span className="flex items-center gap-1.5">
+				<Lock aria-hidden="true" className="size-3 text-fg-muted" />
+				<span className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-fg-muted group-hover:text-accent-lime">
+					Views — only you can see them
+				</span>
+			</span>
+			<span className="flex items-center gap-1.5 font-mono text-xs text-fg-secondary group-hover:text-accent-lime">
+				Open
+				<ArrowRight aria-hidden="true" className="size-3" />
+			</span>
+		</Link>
+	);
+}
+
+/* -------------------------------------------------------------------- E2 */
+
+export function EntryE2({ data }: { readonly data: AnalyticsData }) {
+	const range = rangeLabel(
+		data.firstCountedDayMs,
+		data.windowStartMs,
+		data.windowDays,
+	);
+	const top = data.targets.filter((t) => t.openable).slice(0, 3);
+
+	return (
+		<PrivateFence title="Views">
+			{data.total === 0 ? (
+				<p className="mt-3 text-sm leading-relaxed text-fg-secondary">
+					Nobody has opened your pages yet. Counting starts the first time
+					somebody who is not you opens one. Your own visits never count while
+					you are signed in.
+				</p>
+			) : (
+				<>
+					<p className="mt-3 font-mono text-3xl font-black text-accent">
+						{formatExact(data.total)}
+					</p>
+					<p className="mt-1 font-mono text-[10px] uppercase tracking-[0.2em] text-fg-muted">
+						deduped daily visitors · {range}
+					</p>
+					<ul className="mt-4 space-y-2 border-t border-stroke-subtle pt-3">
+						{top.map((t) => (
+							<li
+								key={t.targetId}
+								className="flex items-center justify-between gap-3"
+							>
+								<span className="truncate font-mono text-xs text-fg-secondary">
+									{t.label}
+								</span>
+								<span className="flex shrink-0 items-center gap-3">
+									<Sparkline
+										points={t.days}
+										ariaLabel={`Daily visitors for ${t.label}`}
+										width={64}
+										height={18}
+									/>
+									<span className="font-mono text-sm font-bold text-fg-primary">
+										{formatExact(t.total)}
+									</span>
+								</span>
+							</li>
+						))}
+					</ul>
+					<p className="mt-3 text-xs leading-relaxed text-fg-muted">
+						One page counts one visitor once per day. A visitor is a browser on
+						a network, not a person. Not page loads.
+					</p>
+				</>
+			)}
+			<Link
+				to="/settings/analytics"
+				className="mt-4 inline-flex items-center gap-1.5 font-mono text-xs font-semibold uppercase tracking-[0.12em] text-fg-secondary hover:text-accent-lime"
+			>
+				All pages, day by day
+				<ArrowRight aria-hidden="true" className="size-3" />
+			</Link>
+		</PrivateFence>
+	);
+}
+
+/* -------------------------------------------------------------------- E3 */
+
+/**
+ * E3 — the whole surface inline, and no separate page.
+ *
+ * Every page, every number, the referrer split and the full labeling live in
+ * the owner-only region. `/settings/analytics` is deleted and the account-menu
+ * entry points at the profile instead.
+ */
+export function EntryE3({ data }: { readonly data: AnalyticsData }) {
+	const range = rangeLabel(
+		data.firstCountedDayMs,
+		data.windowStartMs,
+		data.windowDays,
+	);
+	const sentence =
+		data.referrers.length > 0
+			? `Most visits came from ${REFERRER_LABELS[
+					data.referrers[0].bucket
+				].toLowerCase()} (${data.referrers[0].count}).`
+			: null;
+
+	return (
+		<PrivateFence title="Views">
+			{data.total === 0 ? (
+				<p className="mt-3 text-sm leading-relaxed text-fg-secondary">
+					Nobody has opened your pages yet. Counting starts the first time
+					somebody who is not you opens one.
+				</p>
+			) : (
+				<p className="mt-3 font-mono text-xs uppercase tracking-[0.2em] text-fg-muted">
+					<span className="text-accent">{formatExact(data.total)}</span> deduped
+					daily visitors · {range}
+				</p>
+			)}
+
+			<ul className="mt-4 space-y-2">
+				{data.targets.map((t) => (
+					<li
+						key={t.targetId}
+						className="flex items-center justify-between gap-3 border border-stroke-subtle bg-bg-panel px-3 py-2"
+					>
+						<span className="min-w-0">
+							<span className="block truncate font-mono text-xs font-bold text-fg-primary">
+								{t.label}
+							</span>
+							<span className="mt-0.5 block font-mono text-[10px] text-fg-muted">
+								{!t.openable
+									? "Draft — nobody can open it yet"
+									: t.total === 0
+										? "Nobody has opened it yet"
+										: "deduped daily visitors"}
+							</span>
+						</span>
+						<span className="flex shrink-0 items-center gap-3">
+							<Sparkline
+								points={t.days}
+								ariaLabel={`Daily visitors for ${t.label}`}
+								width={72}
+								height={20}
+								area
+							/>
+							<span className="font-mono text-sm font-black text-fg-primary">
+								{formatExact(t.total)}
+							</span>
+						</span>
+					</li>
+				))}
+			</ul>
+
+			{sentence && (
+				<p className="mt-3 text-xs leading-relaxed text-fg-secondary">
+					{sentence} A visitor who then clicks around your pages counts as a
+					link on this site.
+				</p>
+			)}
+			<p className="mt-3 max-w-prose text-xs leading-relaxed text-fg-muted">
+				One page counts one visitor once per day. A visitor is a browser on a
+				network, not a person — an office shares one number and one person on a
+				phone and a laptop counts twice. Visits you make while signed in are
+				left out. These are not page loads.
+			</p>
+		</PrivateFence>
+	);
+}

--- a/src/features/settings/prototype/PageVariants.tsx
+++ b/src/features/settings/prototype/PageVariants.tsx
@@ -1,0 +1,399 @@
+/**
+ * PROTOTYPE (#98) — three designs for the owner-private view numbers.
+ *
+ * Throwaway. Each variant renders the whole page, so any of them is free to
+ * throw out the layout. What none of them is free to throw out is the honest
+ * labeling: deduped daily visitors, one visitor per page per UTC day, a browser
+ * on a network and not a person, owner views excluded, not page loads.
+ *
+ * A — Rows only. A total, a sentence about referrers, one row per page with a
+ *     sparkline. No chart section at all.
+ * B — Chart led. What ships today, tightened: a total, one line per page, the
+ *     referrer bars, then a plain table of pages.
+ * C — Per page. No site-wide headline. One card per page carrying its own
+ *     number, its own trail and its own start date. Referrers demoted to a
+ *     footnote, because six buckets over eleven visits says nothing.
+ */
+
+import { Link } from "@tanstack/react-router";
+import {
+	BarsChart,
+	type ChartBar,
+	type ChartSeries,
+	formatDayFull,
+	formatExact,
+	Sparkline,
+	TimeSeriesChart,
+} from "@/features/charts";
+import { REFERRER_LABELS, rangeLabel } from "@/features/settings/AnalyticsPage";
+import type { AnalyticsData, AnalyticsTarget } from "./fixtures";
+
+export const VARIANTS = ["A", "B", "C"] as const;
+export type VariantKey = (typeof VARIANTS)[number];
+
+export const VARIANT_LABELS: Record<VariantKey, string> = {
+	A: "A · Rows",
+	B: "B · Chart",
+	C: "C · Cards",
+};
+
+/* ------------------------------------------------------------------ shared */
+
+/** The sentence every state of every variant carries. */
+function HonestLabel({ className = "" }: { readonly className?: string }) {
+	return (
+		<p
+			className={`max-w-prose text-sm leading-relaxed text-fg-muted ${className}`}
+		>
+			One page counts one visitor once per day. A visitor is a browser on a
+			network, not a person — an office shares one number and one person on a
+			phone and a laptop counts twice. Visits you make while signed in are left
+			out. These are not page loads.
+		</p>
+	);
+}
+
+function PrivateLead({ className = "" }: { readonly className?: string }) {
+	return (
+		<p
+			className={`max-w-prose text-sm leading-relaxed text-fg-secondary ${className}`}
+		>
+			How often your profile and your stacks were opened. Only you can see these
+			numbers, and no view count appears anywhere else on the site.
+		</p>
+	);
+}
+
+function NothingCounted() {
+	return (
+		<div className="mt-8 border-2 border-stroke-strong bg-bg-panel p-6">
+			<p className="font-mono text-sm text-fg-primary">
+				No visits counted yet.
+			</p>
+			<p className="mt-2 text-sm text-fg-secondary">
+				Counting starts the first time somebody who is not you opens one of your
+				pages. Your own visits never count while you are signed in, so reloading
+				your stack will not move this number.
+			</p>
+		</div>
+	);
+}
+
+function targetNote(t: AnalyticsTarget): string {
+	if (!t.openable) return "Draft — nobody can open it yet";
+	if (t.total === 0) return "Nobody has opened it yet";
+	return "deduped daily visitors";
+}
+
+function toSeries(data: AnalyticsData): ChartSeries[] {
+	return data.targets
+		.filter((t) => t.days.length > 0)
+		.map((t) => ({ key: t.targetId, label: t.label, points: t.days }));
+}
+
+/**
+ * The referrer split as one sentence.
+ *
+ * At eleven visits a six-bar chart draws a shape that a reader will over-read.
+ * The sentence carries the same four numbers and claims nothing about a
+ * ranking that one extra visit would flip.
+ */
+function referrerSentence(data: AnalyticsData): string | null {
+	if (data.referrers.length === 0) return null;
+	const parts = data.referrers.map(
+		(r) => `${REFERRER_LABELS[r.bucket].toLowerCase()} (${r.count})`,
+	);
+	const [first, ...rest] = parts;
+	if (rest.length === 0) return `Every visit came from ${first}.`;
+	return `Most visits came from ${first}. Then ${rest.join(", ")}.`;
+}
+
+function TargetLink({ t }: { readonly t: AnalyticsTarget }) {
+	if (!t.openable) return <>{t.label}</>;
+	return (
+		<Link to={t.href} className="hover:text-accent">
+			{t.label}
+		</Link>
+	);
+}
+
+/* --------------------------------------------------------------- variant A */
+
+/** A — a total, a sentence, and one row per page. No chart section. */
+export function VariantA({ data }: { readonly data: AnalyticsData }) {
+	const range = rangeLabel(
+		data.firstCountedDayMs,
+		data.windowStartMs,
+		data.windowDays,
+	);
+	const sentence = referrerSentence(data);
+
+	return (
+		<div className="mx-auto max-w-3xl px-6 py-12">
+			<h1 className="font-mono text-xs font-bold uppercase tracking-[0.2em] text-fg-muted">
+				Views
+			</h1>
+			<PrivateLead className="mt-3" />
+
+			{data.total > 0 ? (
+				<div className="mt-8 border-2 border-stroke-strong bg-bg-panel p-6">
+					<p className="font-mono text-4xl font-black text-accent">
+						{formatExact(data.total)}
+					</p>
+					<p className="mt-1 font-mono text-xs uppercase tracking-[0.2em] text-fg-muted">
+						deduped daily visitors · {range}
+					</p>
+					{sentence && (
+						<p className="mt-4 max-w-prose border-t border-stroke-subtle pt-4 text-sm leading-relaxed text-fg-secondary">
+							{sentence} A visitor who then clicks around your pages counts as a
+							link on this site.
+						</p>
+					)}
+				</div>
+			) : (
+				<NothingCounted />
+			)}
+
+			<section className="mt-8">
+				<h2 className="font-mono text-xs font-bold uppercase tracking-[0.2em] text-fg-muted">
+					Each page
+				</h2>
+				<ul aria-label="Views per page" className="mt-3 space-y-3">
+					{data.targets.map((t) => (
+						<li
+							key={t.targetId}
+							className="flex items-center justify-between gap-4 border-2 border-stroke-strong bg-bg-panel p-4"
+						>
+							<div className="min-w-0">
+								<p className="truncate font-mono text-sm font-bold text-fg-primary">
+									<TargetLink t={t} />
+								</p>
+								<p className="mt-1 font-mono text-xs text-fg-muted">
+									{targetNote(t)}
+								</p>
+							</div>
+							<div className="flex shrink-0 items-center gap-4">
+								<Sparkline
+									points={t.days}
+									ariaLabel={`Daily visitors for ${t.label}`}
+									area
+								/>
+								<p className="font-mono text-lg font-black text-fg-primary">
+									{formatExact(t.total)}
+								</p>
+							</div>
+						</li>
+					))}
+				</ul>
+			</section>
+
+			<HonestLabel className="mt-8 border-t border-stroke-subtle pt-6" />
+		</div>
+	);
+}
+
+/* --------------------------------------------------------------- variant B */
+
+/** B — what ships today: total, one line per page, referrer bars, table. */
+export function VariantB({ data }: { readonly data: AnalyticsData }) {
+	const range = rangeLabel(
+		data.firstCountedDayMs,
+		data.windowStartMs,
+		data.windowDays,
+	);
+	const series = toSeries(data);
+	const bars: ChartBar[] = data.referrers.map((r) => ({
+		key: r.bucket,
+		label: REFERRER_LABELS[r.bucket],
+		value: r.count,
+	}));
+
+	return (
+		<div className="mx-auto max-w-3xl px-6 py-12">
+			<h1 className="font-mono text-xs font-bold uppercase tracking-[0.2em] text-fg-muted">
+				Views
+			</h1>
+			<PrivateLead className="mt-3" />
+			<HonestLabel className="mt-3" />
+
+			{data.total > 0 && (
+				<div className="mt-8 border-2 border-stroke-strong bg-bg-panel p-6">
+					<p className="font-mono text-4xl font-black text-accent">
+						{formatExact(data.total)}
+					</p>
+					<p className="mt-1 font-mono text-xs uppercase tracking-[0.2em] text-fg-muted">
+						deduped daily visitors · {range}
+					</p>
+				</div>
+			)}
+
+			{data.total === 0 ? (
+				<NothingCounted />
+			) : (
+				<>
+					{series.length > 0 && (
+						<section className="mt-8">
+							<h2 className="font-mono text-xs font-bold uppercase tracking-[0.2em] text-fg-muted">
+								Visitors per day
+							</h2>
+							<TimeSeriesChart
+								className="mt-3"
+								series={series}
+								ariaLabel="Deduped daily visitors per page"
+								ariaDescription={`One line per page, ${range}.`}
+								valueLabel="Visitors"
+								caption={`deduped daily visitors · ${range}`}
+							/>
+						</section>
+					)}
+
+					{bars.length > 0 && (
+						<section className="mt-8">
+							<h2 className="font-mono text-xs font-bold uppercase tracking-[0.2em] text-fg-muted">
+								Where they came from
+							</h2>
+							<p className="mt-2 max-w-prose text-sm leading-relaxed text-fg-secondary">
+								Decided once per visit, from the page the visitor came off. A
+								visitor who then clicks around your pages counts as a link on
+								this site.
+							</p>
+							<BarsChart
+								className="mt-3"
+								bars={bars}
+								ariaLabel="Deduped daily visitors by where the visit came from"
+								valueLabel="Visitors"
+							/>
+						</section>
+					)}
+				</>
+			)}
+
+			<section className="mt-8">
+				<h2 className="font-mono text-xs font-bold uppercase tracking-[0.2em] text-fg-muted">
+					Each page
+				</h2>
+				<ul aria-label="Views per page" className="mt-3 space-y-3">
+					{data.targets.map((t) => (
+						<li
+							key={t.targetId}
+							className="flex items-baseline justify-between gap-4 border-2 border-stroke-strong bg-bg-panel p-4"
+						>
+							<div className="min-w-0">
+								<p className="truncate font-mono text-sm font-bold text-fg-primary">
+									<TargetLink t={t} />
+								</p>
+								<p className="mt-1 font-mono text-xs text-fg-muted">
+									{targetNote(t)}
+								</p>
+							</div>
+							<p className="shrink-0 font-mono text-lg font-black text-fg-primary">
+								{formatExact(t.total)}
+							</p>
+						</li>
+					))}
+				</ul>
+			</section>
+		</div>
+	);
+}
+
+/* --------------------------------------------------------------- variant C */
+
+/**
+ * C — one card per page and no site-wide headline.
+ *
+ * The site-wide total answers a question nobody asked: an owner wants to know
+ * which page is being opened, and adding a draft's zero to a stack's seven
+ * makes a number that means nothing. It survives as a footnote.
+ */
+export function VariantC({ data }: { readonly data: AnalyticsData }) {
+	const range = rangeLabel(
+		data.firstCountedDayMs,
+		data.windowStartMs,
+		data.windowDays,
+	);
+	const sentence = referrerSentence(data);
+	const live = data.targets.filter((t) => t.openable);
+	const drafts = data.targets.filter((t) => !t.openable);
+
+	return (
+		<div className="mx-auto max-w-4xl px-6 py-12">
+			<h1 className="font-mono text-xs font-bold uppercase tracking-[0.2em] text-fg-muted">
+				Views
+			</h1>
+			<PrivateLead className="mt-3" />
+			<p className="mt-4 font-mono text-xs uppercase tracking-[0.2em] text-accent">
+				{live.length} live {live.length === 1 ? "page" : "pages"} · deduped
+				daily visitors · {range}
+			</p>
+
+			{data.total === 0 && <NothingCounted />}
+
+			<div className="mt-6 grid gap-4 sm:grid-cols-2">
+				{live.map((t) => (
+					<article
+						key={t.targetId}
+						className="border-2 border-stroke-strong bg-bg-panel p-5"
+					>
+						<p className="truncate font-mono text-sm font-bold text-fg-primary">
+							<TargetLink t={t} />
+						</p>
+						<p className="mt-3 font-mono text-3xl font-black text-accent">
+							{formatExact(t.total)}
+						</p>
+						<p className="mt-1 font-mono text-[10px] uppercase tracking-[0.2em] text-fg-muted">
+							{t.total === 0
+								? "nobody has opened it yet"
+								: "deduped daily visitors"}
+						</p>
+						{t.days.length > 1 && (
+							<Sparkline
+								className="mt-4"
+								points={t.days}
+								ariaLabel={`Daily visitors for ${t.label}`}
+								area
+								fluid
+								width={320}
+								height={44}
+							/>
+						)}
+						{t.days.length === 1 && (
+							<p className="mt-4 font-mono text-xs text-fg-muted">
+								One day counted so far — {formatDayFull(new Date(t.days[0].at))}
+								. A trail needs a second day.
+							</p>
+						)}
+					</article>
+				))}
+			</div>
+
+			{drafts.length > 0 && (
+				<section className="mt-6">
+					<h2 className="font-mono text-xs font-bold uppercase tracking-[0.2em] text-fg-muted">
+						Not open to anyone
+					</h2>
+					<ul className="mt-3 space-y-2">
+						{drafts.map((t) => (
+							<li
+								key={t.targetId}
+								className="border border-dashed border-stroke-strong px-4 py-3 font-mono text-xs text-fg-muted"
+							>
+								{t.label} — draft, nobody can open it yet
+							</li>
+						))}
+					</ul>
+				</section>
+			)}
+
+			<footer className="mt-10 space-y-3 border-t border-stroke-subtle pt-6">
+				{data.total > 0 && (
+					<p className="max-w-prose text-sm leading-relaxed text-fg-secondary">
+						{formatExact(data.total)} deduped daily visitors across every page,{" "}
+						{range}.{sentence ? ` ${sentence}` : ""}
+					</p>
+				)}
+				<HonestLabel />
+			</footer>
+		</div>
+	);
+}

--- a/src/features/settings/prototype/fixtures.ts
+++ b/src/features/settings/prototype/fixtures.ts
@@ -1,0 +1,240 @@
+/**
+ * PROTOTYPE (#98) — throwaway fixture data for the view-analytics variants.
+ *
+ * The shape matches what `viewAnalytics.mine` returns, so a variant that wins
+ * can be rebuilt against the real query without reshaping anything. Nothing
+ * here talks to Convex: the question is what the page should look like, and a
+ * signed-out reader on a phone must be able to flip through it.
+ *
+ * Three data states, because thin data is the normal case and not the edge.
+ * Prod holds 14 counter rows across 14 targets.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type ReferrerBucket =
+	| "direct"
+	| "search"
+	| "ai"
+	| "social"
+	| "internal"
+	| "other";
+
+export type AnalyticsTarget = {
+	kind: "profile" | "stack";
+	targetId: string;
+	label: string;
+	href: string;
+	openable: boolean;
+	total: number;
+	days: { at: number; value: number }[];
+};
+
+export type AnalyticsData = {
+	windowDays: number;
+	windowStartMs: number;
+	endDayMs: number;
+	firstCountedDayMs: number | null;
+	total: number;
+	targets: AnalyticsTarget[];
+	referrers: { bucket: ReferrerBucket; count: number }[];
+};
+
+export type DataState = "none" | "thin" | "year";
+
+export const DATA_STATES: readonly DataState[] = ["none", "thin", "year"];
+
+export const DATA_STATE_LABELS: Record<DataState, string> = {
+	none: "Nothing counted",
+	thin: "Prod today",
+	year: "Open a year",
+};
+
+function utcDayStart(ms: number): number {
+	return Math.floor(ms / DAY_MS) * DAY_MS;
+}
+
+/** Turn a list of counts, oldest last, into filled day points ending today. */
+function daysEndingToday(endDayMs: number, counts: number[]) {
+	return counts.map((value, i) => ({
+		at: endDayMs - (counts.length - 1 - i) * DAY_MS,
+		value,
+	}));
+}
+
+const WINDOW_DAYS = 30;
+
+/** A creator whose pages exist but whom nobody has opened yet. */
+function noneFixture(endDayMs: number): AnalyticsData {
+	return {
+		windowDays: WINDOW_DAYS,
+		windowStartMs: endDayMs - (WINDOW_DAYS - 1) * DAY_MS,
+		endDayMs,
+		firstCountedDayMs: null,
+		total: 0,
+		targets: [
+			{
+				kind: "profile",
+				targetId: "p",
+				label: "Your profile",
+				href: "/@jules",
+				openable: true,
+				total: 0,
+				days: [],
+			},
+			{
+				kind: "stack",
+				targetId: "s1",
+				label: "Terminal-first daily driver",
+				href: "/stacks/terminal-first-daily-driver",
+				openable: true,
+				total: 0,
+				days: [],
+			},
+			{
+				kind: "stack",
+				targetId: "s2",
+				label: "Docs-heavy writing setup",
+				href: "/stacks/docs-heavy-writing-setup",
+				openable: false,
+				total: 0,
+				days: [],
+			},
+		],
+		referrers: [],
+	};
+}
+
+/**
+ * What prod actually holds: a handful of readings across a few pages, one of
+ * them a single day, one of them a draft nobody can open.
+ */
+function thinFixture(endDayMs: number): AnalyticsData {
+	const targets: AnalyticsTarget[] = [
+		{
+			kind: "profile",
+			targetId: "p",
+			label: "Your profile",
+			href: "/@jules",
+			openable: true,
+			total: 3,
+			days: daysEndingToday(endDayMs, [1, 0, 2]),
+		},
+		{
+			kind: "stack",
+			targetId: "s1",
+			label: "Terminal-first daily driver",
+			href: "/stacks/terminal-first-daily-driver",
+			openable: true,
+			total: 7,
+			days: daysEndingToday(endDayMs, [2, 1, 0, 0, 3, 1]),
+		},
+		{
+			kind: "stack",
+			targetId: "s2",
+			label: "Cheap research rig",
+			href: "/stacks/cheap-research-rig",
+			openable: true,
+			total: 1,
+			days: daysEndingToday(endDayMs, [1]),
+		},
+		{
+			kind: "stack",
+			targetId: "s3",
+			label: "Docs-heavy writing setup",
+			href: "/stacks/docs-heavy-writing-setup",
+			openable: false,
+			total: 0,
+			days: [],
+		},
+	];
+	return {
+		windowDays: WINDOW_DAYS,
+		windowStartMs: endDayMs - (WINDOW_DAYS - 1) * DAY_MS,
+		endDayMs,
+		// Six days back: the oldest reading on the busiest stack.
+		firstCountedDayMs: endDayMs - 5 * DAY_MS,
+		total: 11,
+		targets,
+		referrers: [
+			{ bucket: "internal", count: 5 },
+			{ bucket: "search", count: 3 },
+			{ bucket: "direct", count: 2 },
+			{ bucket: "ai", count: 1 },
+		],
+	};
+}
+
+/** A deterministic wobble, so the server and the browser draw the same shape. */
+function wobble(seed: number, i: number, base: number): number {
+	const n = Math.sin(seed * 12.9898 + i * 78.233) * 43758.5453;
+	return Math.max(
+		0,
+		Math.round(base + (n - Math.floor(n)) * base * 1.6 - base * 0.6),
+	);
+}
+
+/** A page open long enough that the 30-day window is full on every target. */
+function yearFixture(endDayMs: number): AnalyticsData {
+	const specs: [string, string, string, number, boolean][] = [
+		["p", "Your profile", "/@jules", 6, true],
+		[
+			"s1",
+			"Terminal-first daily driver",
+			"/stacks/terminal-first-daily-driver",
+			14,
+			true,
+		],
+		["s2", "Cheap research rig", "/stacks/cheap-research-rig", 5, true],
+		[
+			"s3",
+			"Docs-heavy writing setup",
+			"/stacks/docs-heavy-writing-setup",
+			9,
+			true,
+		],
+		["s4", "Weekend robotics bench", "/stacks/weekend-robotics-bench", 2, true],
+	];
+	const targets: AnalyticsTarget[] = specs.map(
+		([id, label, href, base, openable], si) => {
+			const days = Array.from({ length: WINDOW_DAYS }, (_, i) => ({
+				at: endDayMs - (WINDOW_DAYS - 1 - i) * DAY_MS,
+				value: wobble(si + 1, i, base),
+			}));
+			return {
+				kind: id === "p" ? ("profile" as const) : ("stack" as const),
+				targetId: id,
+				label,
+				href,
+				openable,
+				total: days.reduce((a, d) => a + d.value, 0),
+				days,
+			};
+		},
+	);
+	const total = targets.reduce((a, t) => a + t.total, 0);
+	return {
+		windowDays: WINDOW_DAYS,
+		windowStartMs: endDayMs - (WINDOW_DAYS - 1) * DAY_MS,
+		endDayMs,
+		// Older than the window, so the page says "last 30 days".
+		firstCountedDayMs: endDayMs - 300 * DAY_MS,
+		total,
+		targets,
+		referrers: [
+			{ bucket: "search", count: Math.round(total * 0.38) },
+			{ bucket: "internal", count: Math.round(total * 0.24) },
+			{ bucket: "direct", count: Math.round(total * 0.17) },
+			{ bucket: "ai", count: Math.round(total * 0.11) },
+			{ bucket: "social", count: Math.round(total * 0.07) },
+			{ bucket: "other", count: Math.round(total * 0.03) },
+		],
+	};
+}
+
+export function fixture(state: DataState, nowMs: number): AnalyticsData {
+	const endDayMs = utcDayStart(nowMs);
+	if (state === "none") return noneFixture(endDayMs);
+	if (state === "year") return yearFixture(endDayMs);
+	return thinFixture(endDayMs);
+}

--- a/src/features/stack-view/prototype/StackViewsLine.tsx
+++ b/src/features/stack-view/prototype/StackViewsLine.tsx
@@ -1,0 +1,111 @@
+/**
+ * PROTOTYPE (#98) — the owner-only view line on a PUBLIC stack page.
+ *
+ * Throwaway. This is the riskiest surface in the ticket. The profile panel sits
+ * on a page whose owner region already exists. A stack page has no such region,
+ * it is the page a creator screenshots and posts, and the number on it is
+ * strictly private. So both shapes below are fenced and labeled, and both
+ * render nothing at all for a visitor.
+ *
+ * S1 — one line. Lock, one number, the range, a link. Reads as a status bar.
+ * S2 — a fenced box, the same shape the profile panel uses, carrying the trail.
+ */
+
+import { Link } from "@tanstack/react-router";
+import { ArrowRight, Lock } from "lucide-react";
+import { formatExact, Sparkline } from "@/features/charts";
+import { rangeLabel } from "@/features/settings/AnalyticsPage";
+import type { AnalyticsData } from "@/features/settings/prototype/fixtures";
+
+export const STACK_SHAPES = ["S1", "S2"] as const;
+export type StackShapeKey = (typeof STACK_SHAPES)[number];
+
+export const STACK_SHAPE_LABELS: Record<StackShapeKey, string> = {
+	S1: "S1 · One line",
+	S2: "S2 · Fenced box",
+};
+
+/** The stack this prototype speaks for: the busiest one in the fixture. */
+function thisStack(data: AnalyticsData) {
+	return data.targets.find((t) => t.targetId === "s1") ?? data.targets[0];
+}
+
+export function StackViewsS1({ data }: { readonly data: AnalyticsData }) {
+	const t = thisStack(data);
+	const range = rangeLabel(
+		data.firstCountedDayMs,
+		data.windowStartMs,
+		data.windowDays,
+	);
+
+	return (
+		<div className="flex flex-wrap items-center gap-x-3 gap-y-1 border border-dashed border-stroke-strong px-4 py-2">
+			<Lock aria-hidden="true" className="size-3 shrink-0 text-fg-muted" />
+			<span className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-fg-muted">
+				Only you can see this
+			</span>
+			<span className="font-mono text-sm font-black text-accent">
+				{formatExact(t.total)}
+			</span>
+			<span className="font-mono text-[10px] uppercase tracking-[0.14em] text-fg-muted">
+				deduped daily visitors · {range} · not page loads
+			</span>
+			<Link
+				to="/settings/analytics"
+				className="ml-auto flex items-center gap-1.5 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-fg-secondary hover:text-accent-lime"
+			>
+				All pages
+				<ArrowRight aria-hidden="true" className="size-3" />
+			</Link>
+		</div>
+	);
+}
+
+export function StackViewsS2({ data }: { readonly data: AnalyticsData }) {
+	const t = thisStack(data);
+	const range = rangeLabel(
+		data.firstCountedDayMs,
+		data.windowStartMs,
+		data.windowDays,
+	);
+
+	return (
+		<section className="border border-dashed border-stroke-strong bg-bg-panel-muted p-5">
+			<div className="flex items-center gap-1.5">
+				<Lock aria-hidden="true" className="size-3 text-fg-muted" />
+				<h2 className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-fg-muted">
+					Views — only you can see this
+				</h2>
+			</div>
+			<div className="mt-3 flex flex-wrap items-end justify-between gap-4">
+				<div>
+					<p className="font-mono text-3xl font-black text-accent">
+						{formatExact(t.total)}
+					</p>
+					<p className="mt-1 font-mono text-[10px] uppercase tracking-[0.2em] text-fg-muted">
+						deduped daily visitors · {range}
+					</p>
+				</div>
+				<Sparkline
+					points={t.days}
+					ariaLabel={`Daily visitors for ${t.label}`}
+					width={140}
+					height={36}
+					area
+				/>
+			</div>
+			<p className="mt-3 max-w-prose text-xs leading-relaxed text-fg-muted">
+				One page counts one visitor once per day. A visitor is a browser on a
+				network, not a person. Visits you make while signed in are left out.
+				These are not page loads.
+			</p>
+			<Link
+				to="/settings/analytics"
+				className="mt-4 inline-flex items-center gap-1.5 font-mono text-xs font-semibold uppercase tracking-[0.12em] text-fg-secondary hover:text-accent-lime"
+			>
+				Every page, day by day
+				<ArrowRight aria-hidden="true" className="size-3" />
+			</Link>
+		</section>
+	);
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as StacksNewRouteImport } from './routes/stacks.new'
 import { Route as StacksSlugRouteImport } from './routes/stacks.$slug'
 import { Route as SettingsMachinesRouteImport } from './routes/settings.machines'
 import { Route as SettingsAnalyticsRouteImport } from './routes/settings.analytics'
+import { Route as PrototypeViewsStackRouteImport } from './routes/prototype.views-stack'
 import { Route as PrototypeViewsEntryRouteImport } from './routes/prototype.views-entry'
 import { Route as PrototypeViewsRouteImport } from './routes/prototype.views'
 import { Route as CliAuthRouteImport } from './routes/cli.auth'
@@ -146,6 +147,11 @@ const SettingsAnalyticsRoute = SettingsAnalyticsRouteImport.update({
   path: '/settings/analytics',
   getParentRoute: () => rootRouteImport,
 } as any)
+const PrototypeViewsStackRoute = PrototypeViewsStackRouteImport.update({
+  id: '/prototype/views-stack',
+  path: '/prototype/views-stack',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const PrototypeViewsEntryRoute = PrototypeViewsEntryRouteImport.update({
   id: '/prototype/views-entry',
   path: '/prototype/views-entry',
@@ -246,6 +252,7 @@ export interface FileRoutesByFullPath {
   '/cli/auth': typeof CliAuthRoute
   '/prototype/views': typeof PrototypeViewsRoute
   '/prototype/views-entry': typeof PrototypeViewsEntryRoute
+  '/prototype/views-stack': typeof PrototypeViewsStackRoute
   '/settings/analytics': typeof SettingsAnalyticsRoute
   '/settings/machines': typeof SettingsMachinesRoute
   '/stacks/$slug': typeof StacksSlugRoute
@@ -284,6 +291,7 @@ export interface FileRoutesByTo {
   '/cli/auth': typeof CliAuthRoute
   '/prototype/views': typeof PrototypeViewsRoute
   '/prototype/views-entry': typeof PrototypeViewsEntryRoute
+  '/prototype/views-stack': typeof PrototypeViewsStackRoute
   '/settings/analytics': typeof SettingsAnalyticsRoute
   '/settings/machines': typeof SettingsMachinesRoute
   '/stacks/$slug': typeof StacksSlugRoute
@@ -323,6 +331,7 @@ export interface FileRoutesById {
   '/cli/auth': typeof CliAuthRoute
   '/prototype/views': typeof PrototypeViewsRoute
   '/prototype/views-entry': typeof PrototypeViewsEntryRoute
+  '/prototype/views-stack': typeof PrototypeViewsStackRoute
   '/settings/analytics': typeof SettingsAnalyticsRoute
   '/settings/machines': typeof SettingsMachinesRoute
   '/stacks/$slug': typeof StacksSlugRoute
@@ -363,6 +372,7 @@ export interface FileRouteTypes {
     | '/cli/auth'
     | '/prototype/views'
     | '/prototype/views-entry'
+    | '/prototype/views-stack'
     | '/settings/analytics'
     | '/settings/machines'
     | '/stacks/$slug'
@@ -401,6 +411,7 @@ export interface FileRouteTypes {
     | '/cli/auth'
     | '/prototype/views'
     | '/prototype/views-entry'
+    | '/prototype/views-stack'
     | '/settings/analytics'
     | '/settings/machines'
     | '/stacks/$slug'
@@ -439,6 +450,7 @@ export interface FileRouteTypes {
     | '/cli/auth'
     | '/prototype/views'
     | '/prototype/views-entry'
+    | '/prototype/views-stack'
     | '/settings/analytics'
     | '/settings/machines'
     | '/stacks/$slug'
@@ -478,6 +490,7 @@ export interface RootRouteChildren {
   CliAuthRoute: typeof CliAuthRoute
   PrototypeViewsRoute: typeof PrototypeViewsRoute
   PrototypeViewsEntryRoute: typeof PrototypeViewsEntryRoute
+  PrototypeViewsStackRoute: typeof PrototypeViewsStackRoute
   SettingsAnalyticsRoute: typeof SettingsAnalyticsRoute
   SettingsMachinesRoute: typeof SettingsMachinesRoute
   StacksSlugRoute: typeof StacksSlugRoute
@@ -639,6 +652,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsAnalyticsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/prototype/views-stack': {
+      id: '/prototype/views-stack'
+      path: '/prototype/views-stack'
+      fullPath: '/prototype/views-stack'
+      preLoaderRoute: typeof PrototypeViewsStackRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/prototype/views-entry': {
       id: '/prototype/views-entry'
       path: '/prototype/views-entry'
@@ -785,6 +805,7 @@ const rootRouteChildren: RootRouteChildren = {
   CliAuthRoute: CliAuthRoute,
   PrototypeViewsRoute: PrototypeViewsRoute,
   PrototypeViewsEntryRoute: PrototypeViewsEntryRoute,
+  PrototypeViewsStackRoute: PrototypeViewsStackRoute,
   SettingsAnalyticsRoute: SettingsAnalyticsRoute,
   SettingsMachinesRoute: SettingsMachinesRoute,
   StacksSlugRoute: StacksSlugRoute,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -29,6 +29,8 @@ import { Route as StacksNewRouteImport } from './routes/stacks.new'
 import { Route as StacksSlugRouteImport } from './routes/stacks.$slug'
 import { Route as SettingsMachinesRouteImport } from './routes/settings.machines'
 import { Route as SettingsAnalyticsRouteImport } from './routes/settings.analytics'
+import { Route as PrototypeViewsEntryRouteImport } from './routes/prototype.views-entry'
+import { Route as PrototypeViewsRouteImport } from './routes/prototype.views'
 import { Route as CliAuthRouteImport } from './routes/cli.auth'
 import { Route as ApiSyncConfigRouteImport } from './routes/api.sync-config'
 import { Route as AdminIconsRouteImport } from './routes/admin_.icons'
@@ -144,6 +146,16 @@ const SettingsAnalyticsRoute = SettingsAnalyticsRouteImport.update({
   path: '/settings/analytics',
   getParentRoute: () => rootRouteImport,
 } as any)
+const PrototypeViewsEntryRoute = PrototypeViewsEntryRouteImport.update({
+  id: '/prototype/views-entry',
+  path: '/prototype/views-entry',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PrototypeViewsRoute = PrototypeViewsRouteImport.update({
+  id: '/prototype/views',
+  path: '/prototype/views',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CliAuthRoute = CliAuthRouteImport.update({
   id: '/cli/auth',
   path: '/cli/auth',
@@ -232,6 +244,8 @@ export interface FileRoutesByFullPath {
   '/admin/icons': typeof AdminIconsRoute
   '/api/sync-config': typeof ApiSyncConfigRoute
   '/cli/auth': typeof CliAuthRoute
+  '/prototype/views': typeof PrototypeViewsRoute
+  '/prototype/views-entry': typeof PrototypeViewsEntryRoute
   '/settings/analytics': typeof SettingsAnalyticsRoute
   '/settings/machines': typeof SettingsMachinesRoute
   '/stacks/$slug': typeof StacksSlugRoute
@@ -268,6 +282,8 @@ export interface FileRoutesByTo {
   '/admin/icons': typeof AdminIconsRoute
   '/api/sync-config': typeof ApiSyncConfigRoute
   '/cli/auth': typeof CliAuthRoute
+  '/prototype/views': typeof PrototypeViewsRoute
+  '/prototype/views-entry': typeof PrototypeViewsEntryRoute
   '/settings/analytics': typeof SettingsAnalyticsRoute
   '/settings/machines': typeof SettingsMachinesRoute
   '/stacks/$slug': typeof StacksSlugRoute
@@ -305,6 +321,8 @@ export interface FileRoutesById {
   '/admin_/icons': typeof AdminIconsRoute
   '/api/sync-config': typeof ApiSyncConfigRoute
   '/cli/auth': typeof CliAuthRoute
+  '/prototype/views': typeof PrototypeViewsRoute
+  '/prototype/views-entry': typeof PrototypeViewsEntryRoute
   '/settings/analytics': typeof SettingsAnalyticsRoute
   '/settings/machines': typeof SettingsMachinesRoute
   '/stacks/$slug': typeof StacksSlugRoute
@@ -343,6 +361,8 @@ export interface FileRouteTypes {
     | '/admin/icons'
     | '/api/sync-config'
     | '/cli/auth'
+    | '/prototype/views'
+    | '/prototype/views-entry'
     | '/settings/analytics'
     | '/settings/machines'
     | '/stacks/$slug'
@@ -379,6 +399,8 @@ export interface FileRouteTypes {
     | '/admin/icons'
     | '/api/sync-config'
     | '/cli/auth'
+    | '/prototype/views'
+    | '/prototype/views-entry'
     | '/settings/analytics'
     | '/settings/machines'
     | '/stacks/$slug'
@@ -415,6 +437,8 @@ export interface FileRouteTypes {
     | '/admin_/icons'
     | '/api/sync-config'
     | '/cli/auth'
+    | '/prototype/views'
+    | '/prototype/views-entry'
     | '/settings/analytics'
     | '/settings/machines'
     | '/stacks/$slug'
@@ -452,6 +476,8 @@ export interface RootRouteChildren {
   AdminIconsRoute: typeof AdminIconsRoute
   ApiSyncConfigRoute: typeof ApiSyncConfigRoute
   CliAuthRoute: typeof CliAuthRoute
+  PrototypeViewsRoute: typeof PrototypeViewsRoute
+  PrototypeViewsEntryRoute: typeof PrototypeViewsEntryRoute
   SettingsAnalyticsRoute: typeof SettingsAnalyticsRoute
   SettingsMachinesRoute: typeof SettingsMachinesRoute
   StacksSlugRoute: typeof StacksSlugRoute
@@ -613,6 +639,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsAnalyticsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/prototype/views-entry': {
+      id: '/prototype/views-entry'
+      path: '/prototype/views-entry'
+      fullPath: '/prototype/views-entry'
+      preLoaderRoute: typeof PrototypeViewsEntryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/prototype/views': {
+      id: '/prototype/views'
+      path: '/prototype/views'
+      fullPath: '/prototype/views'
+      preLoaderRoute: typeof PrototypeViewsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/cli/auth': {
       id: '/cli/auth'
       path: '/cli/auth'
@@ -743,6 +783,8 @@ const rootRouteChildren: RootRouteChildren = {
   AdminIconsRoute: AdminIconsRoute,
   ApiSyncConfigRoute: ApiSyncConfigRoute,
   CliAuthRoute: CliAuthRoute,
+  PrototypeViewsRoute: PrototypeViewsRoute,
+  PrototypeViewsEntryRoute: PrototypeViewsEntryRoute,
   SettingsAnalyticsRoute: SettingsAnalyticsRoute,
   SettingsMachinesRoute: SettingsMachinesRoute,
   StacksSlugRoute: StacksSlugRoute,

--- a/src/routes/prototype.views-entry.tsx
+++ b/src/routes/prototype.views-entry.tsx
@@ -1,0 +1,164 @@
+/**
+ * PROTOTYPE (#98) — `/prototype/views-entry`.
+ *
+ * Throwaway route. The real profile page, rendered on fixtures, with three
+ * different owner-only view affordances in its owner region.
+ *
+ * The axis that matters most is "Seen as". Flip it to Visitor and the private
+ * region has to disappear completely, because this page is public and the
+ * number is not. That flip is the test each variant has to pass.
+ *
+ * Delete this file when #98 is decided.
+ */
+
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { PrototypeSwitcher } from "@/components/PrototypeSwitcher";
+import {
+	ProfilePage,
+	type ProfileStackCard,
+} from "@/features/profile/ProfilePage";
+import {
+	ENTRIES,
+	ENTRY_LABELS,
+	EntryE1,
+	EntryE2,
+	EntryE3,
+	type EntryKey,
+} from "@/features/profile/prototype/EntryVariants";
+import {
+	DATA_STATE_LABELS,
+	DATA_STATES,
+	type DataState,
+	fixture,
+} from "@/features/settings/prototype/fixtures";
+
+type Seen = "owner" | "visitor";
+
+type Search = { entry: EntryKey; data: DataState; as: Seen };
+
+export const Route = createFileRoute("/prototype/views-entry")({
+	component: PrototypeViewsEntry,
+	validateSearch: (search: Record<string, unknown>): Search => ({
+		entry: ENTRIES.includes(search.entry as EntryKey)
+			? (search.entry as EntryKey)
+			: "E1",
+		data: DATA_STATES.includes(search.data as DataState)
+			? (search.data as DataState)
+			: "thin",
+		as: search.as === "visitor" ? "visitor" : "owner",
+	}),
+});
+
+const PROFILE = {
+	name: "Jules Okonkwo",
+	handle: "jules",
+	bio: "Terminal-first. Two harnesses, one budget, and a lot of opinions about diff review.",
+	personalPages: [{ name: "julesok.dev", url: "https://julesok.dev" }],
+	verified: true,
+	joinedAt: Date.parse("2026-02-11T00:00:00Z"),
+};
+
+const PUBLISHED: ProfileStackCard[] = [
+	{
+		_id: "s1",
+		name: "Terminal-first daily driver",
+		slug: "terminal-first-daily-driver",
+		oneLiner:
+			"Claude Code in a tmux split, with a cheap model on the review pass.",
+		published: true,
+		updatedAt: Date.parse("2026-08-02T00:00:00Z"),
+		fixedTotal: { currency: "USD", amount: 20000, period: "month" },
+		hasUsageComponent: true,
+		toolCount: 7,
+		modelCount: 3,
+		upvoteCount: 12,
+	},
+	{
+		_id: "s2",
+		name: "Cheap research rig",
+		slug: "cheap-research-rig",
+		oneLiner: "Reading and summarizing, nothing that writes to a repo.",
+		published: true,
+		updatedAt: Date.parse("2026-07-19T00:00:00Z"),
+		fixedTotal: { currency: "USD", amount: 4000, period: "month" },
+		hasUsageComponent: false,
+		toolCount: 4,
+		modelCount: 2,
+		upvoteCount: 3,
+	},
+];
+
+const DRAFTS: ProfileStackCard[] = [
+	{
+		_id: "s3",
+		name: "Docs-heavy writing setup",
+		slug: "docs-heavy-writing-setup",
+		oneLiner: "Still deciding whether the editor plugin earns its seat.",
+		published: false,
+		updatedAt: Date.parse("2026-08-04T00:00:00Z"),
+		hasUsageComponent: false,
+		toolCount: 3,
+		modelCount: 1,
+		upvoteCount: 0,
+	},
+];
+
+function PrototypeViewsEntry() {
+	const { entry, data: state, as } = Route.useSearch();
+	const navigate = useNavigate({ from: Route.fullPath });
+	const data = fixture(state, Date.now());
+	const isOwner = as === "owner";
+
+	const slot =
+		entry === "E1" ? (
+			<EntryE1 />
+		) : entry === "E2" ? (
+			<EntryE2 data={data} />
+		) : (
+			<EntryE3 data={data} />
+		);
+
+	return (
+		<>
+			<div className="pb-24">
+				<ProfilePage
+					profile={PROFILE}
+					stacks={PUBLISHED}
+					ownProfile={isOwner ? { isOwner: true, draftStacks: DRAFTS } : null}
+					ownerViewsSlot={slot}
+				/>
+			</div>
+			<PrototypeSwitcher
+				axes={[
+					{
+						name: "Entry",
+						keys: ENTRIES,
+						labels: ENTRY_LABELS,
+						current: entry,
+						arrowKeys: true,
+						onPick: (k) =>
+							navigate({
+								search: { entry: k as EntryKey, data: state, as },
+							}),
+					},
+					{
+						name: "Seen as",
+						keys: ["owner", "visitor"],
+						labels: { owner: "Owner", visitor: "Visitor" },
+						current: as,
+						onPick: (k) =>
+							navigate({ search: { entry, data: state, as: k as Seen } }),
+					},
+					{
+						name: "Data",
+						keys: DATA_STATES,
+						labels: DATA_STATE_LABELS,
+						current: state,
+						onPick: (k) =>
+							navigate({ search: { entry, data: k as DataState, as } }),
+					},
+				]}
+			/>
+		</>
+	);
+}

--- a/src/routes/prototype.views-entry.tsx
+++ b/src/routes/prototype.views-entry.tsx
@@ -23,6 +23,7 @@ import {
 	EntryE1,
 	EntryE2,
 	EntryE3,
+	EntryE4,
 	type EntryKey,
 } from "@/features/profile/prototype/EntryVariants";
 import {
@@ -41,7 +42,7 @@ export const Route = createFileRoute("/prototype/views-entry")({
 	validateSearch: (search: Record<string, unknown>): Search => ({
 		entry: ENTRIES.includes(search.entry as EntryKey)
 			? (search.entry as EntryKey)
-			: "E1",
+			: "E4",
 		data: DATA_STATES.includes(search.data as DataState)
 			? (search.data as DataState)
 			: "thin",
@@ -114,8 +115,10 @@ function PrototypeViewsEntry() {
 			<EntryE1 />
 		) : entry === "E2" ? (
 			<EntryE2 data={data} />
-		) : (
+		) : entry === "E3" ? (
 			<EntryE3 data={data} />
+		) : (
+			<EntryE4 data={data} />
 		);
 
 	return (

--- a/src/routes/prototype.views-stack.tsx
+++ b/src/routes/prototype.views-stack.tsx
@@ -1,0 +1,147 @@
+/**
+ * PROTOTYPE (#98) — `/prototype/views-stack`.
+ *
+ * Throwaway route. A stack page is public and its owner now gets a private
+ * number on it, so this route exists to answer one question: does that number
+ * read as private, and does it vanish for everyone else?
+ *
+ * The hero here is a stand-in, not the real `StackHeader` — that component is
+ * typed against live Convex return values and mocking it whole would take
+ * longer than the question is worth. Its shape, weight and order match, which
+ * is what placement needs. Flip "Seen as" to Visitor: the strip must be gone.
+ *
+ * Delete this file when #98 is decided.
+ */
+
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { PrototypeSwitcher } from "@/components/PrototypeSwitcher";
+import {
+	DATA_STATE_LABELS,
+	DATA_STATES,
+	type DataState,
+	fixture,
+} from "@/features/settings/prototype/fixtures";
+import {
+	STACK_SHAPE_LABELS,
+	STACK_SHAPES,
+	type StackShapeKey,
+	StackViewsS1,
+	StackViewsS2,
+} from "@/features/stack-view/prototype/StackViewsLine";
+
+type Seen = "owner" | "visitor";
+
+type Search = { shape: StackShapeKey; data: DataState; as: Seen };
+
+export const Route = createFileRoute("/prototype/views-stack")({
+	component: PrototypeViewsStack,
+	validateSearch: (search: Record<string, unknown>): Search => ({
+		shape: STACK_SHAPES.includes(search.shape as StackShapeKey)
+			? (search.shape as StackShapeKey)
+			: "S1",
+		data: DATA_STATES.includes(search.data as DataState)
+			? (search.data as DataState)
+			: "thin",
+		as: search.as === "visitor" ? "visitor" : "owner",
+	}),
+});
+
+/** A stand-in for the hero: same weight and order, none of the wiring. */
+function MockHero() {
+	return (
+		<header className="border-b border-stroke-strong bg-bg-panel px-6 py-10 md:px-16">
+			<div className="mx-auto max-w-content">
+				<p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-fg-muted">
+					Stack · by Jules Okonkwo
+				</p>
+				<h1 className="mt-3 text-4xl font-black uppercase leading-[0.9] tracking-tighter text-fg-primary md:text-6xl">
+					Terminal-first daily driver
+				</h1>
+				<p className="mt-4 max-w-prose text-sm leading-relaxed text-fg-secondary">
+					Claude Code in a tmux split, with a cheap model on the review pass.
+				</p>
+				<div className="mt-6 flex flex-wrap items-end justify-between gap-4 border-t border-stroke-subtle pt-4">
+					<span className="font-mono text-[10px] uppercase tracking-wider text-fg-muted">
+						7T · 3M · ▲12 · updated Aug 2, 2026
+					</span>
+					<span className="font-mono text-2xl font-black text-fg-primary">
+						$200
+						<span className="text-[10px] text-fg-muted">+/mo</span>
+					</span>
+				</div>
+			</div>
+		</header>
+	);
+}
+
+/** A stand-in for the first numbered section, so the strip has a page to sit on. */
+function MockSection() {
+	return (
+		<section className="px-6 py-12 md:px-16">
+			<div className="mx-auto max-w-content">
+				<p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-fg-muted">
+					01 · Actual usage
+				</p>
+				<p className="mt-4 border border-dashed border-stroke-strong px-4 py-10 text-center font-mono text-xs text-fg-muted">
+					The measured reading renders here. Stand-in for placement only.
+				</p>
+			</div>
+		</section>
+	);
+}
+
+function PrototypeViewsStack() {
+	const { shape, data: state, as } = Route.useSearch();
+	const navigate = useNavigate({ from: Route.fullPath });
+	const data = fixture(state, Date.now());
+	const isOwner = as === "owner";
+
+	return (
+		<>
+			<div className="min-h-screen bg-bg-canvas pb-24 text-fg-primary">
+				<MockHero />
+				{isOwner && (
+					<div className="mx-auto max-w-content px-6 pt-6 md:px-16">
+						{shape === "S1" ? (
+							<StackViewsS1 data={data} />
+						) : (
+							<StackViewsS2 data={data} />
+						)}
+					</div>
+				)}
+				<MockSection />
+			</div>
+			<PrototypeSwitcher
+				axes={[
+					{
+						name: "Shape",
+						keys: STACK_SHAPES,
+						labels: STACK_SHAPE_LABELS,
+						current: shape,
+						arrowKeys: true,
+						onPick: (k) =>
+							navigate({
+								search: { shape: k as StackShapeKey, data: state, as },
+							}),
+					},
+					{
+						name: "Seen as",
+						keys: ["owner", "visitor"],
+						labels: { owner: "Owner", visitor: "Visitor" },
+						current: as,
+						onPick: (k) =>
+							navigate({ search: { shape, data: state, as: k as Seen } }),
+					},
+					{
+						name: "Data",
+						keys: DATA_STATES,
+						labels: DATA_STATE_LABELS,
+						current: state,
+						onPick: (k) =>
+							navigate({ search: { shape, data: k as DataState, as } }),
+					},
+				]}
+			/>
+		</>
+	);
+}

--- a/src/routes/prototype.views.tsx
+++ b/src/routes/prototype.views.tsx
@@ -1,0 +1,82 @@
+/**
+ * PROTOTYPE (#98) — `/prototype/views`.
+ *
+ * Throwaway route. Three designs for the owner-private view numbers, across
+ * three data states, switchable from the bar at the bottom.
+ *
+ * It runs on fixtures and not on `viewAnalytics.mine`, for two reasons. The
+ * reader has to be able to open the link on a phone without signing in, and the
+ * three data states have to be reachable side by side — the "open a year" state
+ * does not exist in any database yet.
+ *
+ * Delete this file when #98 is decided. The variants live on in the prototype
+ * branch, not in main.
+ */
+
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { PrototypeSwitcher } from "@/components/PrototypeSwitcher";
+import {
+	DATA_STATE_LABELS,
+	DATA_STATES,
+	type DataState,
+	fixture,
+} from "@/features/settings/prototype/fixtures";
+import {
+	VARIANT_LABELS,
+	VARIANTS,
+	VariantA,
+	VariantB,
+	VariantC,
+	type VariantKey,
+} from "@/features/settings/prototype/PageVariants";
+
+type Search = { variant: VariantKey; data: DataState };
+
+export const Route = createFileRoute("/prototype/views")({
+	component: PrototypeViews,
+	validateSearch: (search: Record<string, unknown>): Search => ({
+		variant: VARIANTS.includes(search.variant as VariantKey)
+			? (search.variant as VariantKey)
+			: "A",
+		data: DATA_STATES.includes(search.data as DataState)
+			? (search.data as DataState)
+			: "thin",
+	}),
+});
+
+function PrototypeViews() {
+	const { variant, data: state } = Route.useSearch();
+	const navigate = useNavigate({ from: Route.fullPath });
+	const data = fixture(state, Date.now());
+
+	return (
+		<>
+			<div className="pb-24">
+				{variant === "A" && <VariantA data={data} />}
+				{variant === "B" && <VariantB data={data} />}
+				{variant === "C" && <VariantC data={data} />}
+			</div>
+			<PrototypeSwitcher
+				axes={[
+					{
+						name: "Design",
+						keys: VARIANTS,
+						labels: VARIANT_LABELS,
+						current: variant,
+						arrowKeys: true,
+						onPick: (k) =>
+							navigate({ search: { variant: k as VariantKey, data: state } }),
+					},
+					{
+						name: "Data",
+						keys: DATA_STATES,
+						labels: DATA_STATE_LABELS,
+						current: state,
+						onPick: (k) =>
+							navigate({ search: { variant, data: k as DataState } }),
+					},
+				]}
+			/>
+		</>
+	);
+}

--- a/src/routes/prototype.views.tsx
+++ b/src/routes/prototype.views.tsx
@@ -35,9 +35,10 @@ type Search = { variant: VariantKey; data: DataState };
 export const Route = createFileRoute("/prototype/views")({
 	component: PrototypeViews,
 	validateSearch: (search: Record<string, unknown>): Search => ({
+		// B is the picked design (#98). A and C stay reachable for comparison.
 		variant: VARIANTS.includes(search.variant as VariantKey)
 			? (search.variant as VariantKey)
-			: "A",
+			: "B",
 		data: DATA_STATES.includes(search.data as DataState)
 			? (search.data as DataState)
 			: "thin",


### PR DESCRIPTION
Ticket: alp82/aistack#98 — [Prototype: refine the view-analytics page and its entry points](https://github.com/alp82/aistack/issues/98)

Prototype for #98 — the view-analytics page and where an owner enters it from.

Three throwaway routes on fixtures, plus the decision document the build ticket implements.

**Decided, from the live prototype:**
1. The profile gets an owner-only Views panel — shape E4: E2's headline total with E3's inline box per page, inside a private fence, plus a link to the full page. The draft box stays.
2. `/settings/analytics` keeps design B — total, one line per page, referrer bars, rows. The multi-series chart survives, so #95 keeps its target.
3. Three ways in: the account menu keeps Views, the profile gets the panel, and a stack page gets a private line for its owner. The changes page gets nothing.
4. The stack-page line is shape S1 — a one-line strip under the hero.

`docs/prototypes/view-analytics-98.md` writes all four down, names what may not change, and names the one thing the build has to solve: the stack line needs a number for one stack, and `viewAnalytics.mine` answers for all of them.

**Production code touched:** one optional prop on `ProfilePage`, `ownerViewsSlot`, gated on `isOwner` and falling back to today's planned-seam. Nothing else.

Verified without a browser: typecheck clean on the new files, the 29 existing profile and settings tests pass, every page server-renders real chart SVG, and the visitor render of every entry and stack variant contains none of the private markup.

The prototype routes and variant components are throwaway. The build rebuilds the winners against `viewAnalytics.mine` and deletes them.

---

Dispatched by the curia daemon — session `curia-98`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `d26a899` Prototype #98: write the decisions down for the build
- `2064959` Prototype #98: the owner-only view line on a public stack page
- `74c1fb4` Prototype #98: E4, the picked entry — E2 with E3's inline boxes
- `0e4a9f5` Prototype: view-analytics page and its entry points (alp82/aistack#98)