### PR TITLE
Task: build the global activity feed (alp82/aistack#85)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as activity from "../activity.js";
+import type * as activityFeed from "../activityFeed.js";
 import type * as admin from "../admin.js";
 import type * as analytics from "../analytics.js";
 import type * as auth from "../auth.js";
@@ -75,6 +76,7 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   activity: typeof activity;
+  activityFeed: typeof activityFeed;
   admin: typeof admin;
   analytics: typeof analytics;
   auth: typeof auth;

--- a/convex/activityFeed.test.ts
+++ b/convex/activityFeed.test.ts
@@ -1,0 +1,478 @@
+/// <reference types="vite/client" />
+import { convexTest } from 'convex-test'
+import { describe, expect, test } from 'vitest'
+import { api } from './_generated/api'
+import type { Id } from './_generated/dataModel'
+import schema from './schema'
+import type { ActivityEventValue } from './activity'
+
+const modules = import.meta.glob('./**/*.{js,ts}')
+
+type Ctx = ReturnType<typeof convexTest>
+
+const MINUTE = 60 * 1000
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+
+let seedCounter = 0
+
+async function seedStack(
+  t: Ctx,
+  opts: { name?: string; published?: boolean; isLowQuality?: boolean } = {}
+): Promise<Id<'stacks'>> {
+  seedCounter += 1
+  const n = seedCounter
+  return await t.run(async (ctx) => {
+    const creatorId = await ctx.db.insert('creators', {
+      name: `Creator ${n}`,
+      slug: `creator-${n}`,
+      userId: `user_${n}`,
+      verified: false,
+      personalPages: [],
+      projectPages: [],
+      createdAt: Date.now(),
+    })
+    return await ctx.db.insert('stacks', {
+      name: opts.name ?? `Stack ${n}`,
+      slug: `stack-${n}`,
+      shortId: `sid${n}`,
+      creatorId,
+      oneLiner: 'A stack',
+      toolSubscriptions: [],
+      hasUsageComponent: false,
+      published: opts.published ?? true,
+      ...(opts.isLowQuality === undefined
+        ? {}
+        : { isLowQuality: opts.isLowQuality }),
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    })
+  })
+}
+
+function syncEvent(over: {
+  harness?: string
+  sessions?: number
+  projects?: number
+  totalTokens?: number
+}): ActivityEventValue {
+  return {
+    type: 'sync.landed',
+    harnesses: [
+      {
+        harness: over.harness ?? 'claude-code',
+        windowDays: 30,
+        sessions: over.sessions ?? 10,
+        activeDays: 5,
+        projects: over.projects ?? 2,
+        totalTokens: over.totalTokens ?? 1000,
+      },
+    ],
+  }
+}
+
+async function emit(
+  t: Ctx,
+  stackId: Id<'stacks'>,
+  createdAt: number,
+  event: ActivityEventValue
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert('activityEvents', { stackId, createdAt, event })
+  })
+}
+
+/** A snapshot carrying the models and tools the band unions. */
+async function snapshot(
+  t: Ctx,
+  stackId: Id<'stacks'>,
+  over: {
+    capturedAt?: number
+    harness?: string
+    models?: string[]
+    tools?: string[]
+    totalTokens?: number
+  }
+) {
+  await t.run(async (ctx) => {
+    const harness = over.harness ?? 'claude-code'
+    await ctx.db.insert('measuredSnapshots', {
+      stackId,
+      capturedAt: over.capturedAt ?? Date.now(),
+      receivedAt: over.capturedAt ?? Date.now(),
+      schemaVersion: 1,
+      harness,
+      payload: {
+        schemaVersion: 1,
+        capturedAt: over.capturedAt ?? Date.now(),
+        window: { days: 30, from: '2026-07-05', to: '2026-08-03' },
+        harness: { name: harness, version: '1.0.0' },
+        pricingTable: null,
+        activity: {
+          sessions: 10,
+          activeDays: 5,
+          projects: 2,
+          totalTokens: over.totalTokens ?? 1000,
+          cacheHitShare: 0.9,
+          subagentShare: 0.1,
+        },
+        models: (over.models ?? ['opus']).map((id) => ({
+          id,
+          tokenShare: 1,
+          tokens: { input: 1, output: 0, cacheWrite: 0, cacheRead: 0 },
+        })),
+        inventory: {
+          builtinTools: (over.tools ?? ['Bash']).map((name) => ({
+            name,
+            callShare: 1,
+          })),
+          mcpServers: [],
+          skills: [],
+          subagents: [],
+          slashCommands: [],
+          withheld: {
+            builtinTools: 0,
+            mcpServers: 0,
+            skills: 0,
+            subagents: 0,
+            slashCommands: 0,
+          },
+        },
+        coverage: {
+          filesScanned: 1,
+          filesUnreadable: 0,
+          linesParsed: 1,
+          linesFailed: 0,
+        },
+        excludedTokens: { unpriced: 0, synthetic: 0 },
+      },
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Visibility — the sharp edge (#85). An event written while a stack was public
+// must not leak after the stack goes private.
+// ---------------------------------------------------------------------------
+
+describe('visibility', () => {
+  test('an event stops showing the moment its stack goes private', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t, { name: 'Goes Private' })
+    await emit(t, stackId, Date.now() - HOUR, { type: 'stack.published', toolCount: 3 })
+
+    const before = await t.query(api.activityFeed.stream, {})
+    expect(before.rows.map((r) => r.stack.name)).toEqual(['Goes Private'])
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(stackId, { published: false })
+    })
+
+    const after = await t.query(api.activityFeed.stream, {})
+    expect(after.rows).toEqual([])
+    const band = await t.query(api.activityFeed.band, {})
+    expect(band.rows).toEqual([])
+    expect(band.totals.updates).toBe(0)
+  })
+
+  test('a flagged stack is hidden from the feed the same way', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t, { name: 'Flagged' })
+    await emit(t, stackId, Date.now() - HOUR, { type: 'stack.published', toolCount: 1 })
+    await t.run(async (ctx) => {
+      await ctx.db.patch(stackId, { isLowQuality: true })
+    })
+
+    const feed = await t.query(api.activityFeed.stream, {})
+    expect(feed.rows).toEqual([])
+  })
+
+  test('an event whose stack was deleted is dropped, not thrown', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t)
+    await emit(t, stackId, Date.now() - HOUR, { type: 'stack.published', toolCount: 1 })
+    await t.run(async (ctx) => {
+      await ctx.db.delete(stackId)
+    })
+
+    const feed = await t.query(api.activityFeed.stream, {})
+    expect(feed.rows).toEqual([])
+  })
+
+  test('hidden rows do not eat the page — the scan refills it', async () => {
+    const t = convexTest(schema, modules)
+    const hidden = await seedStack(t, { name: 'Hidden', published: false })
+    const shown = await seedStack(t, { name: 'Shown' })
+    const now = Date.now()
+    // Newest first: three hidden rows sit above the one visible row.
+    for (let i = 0; i < 3; i += 1) {
+      await emit(t, hidden, now - i * MINUTE, { type: 'stack.published', toolCount: 1 })
+    }
+    await emit(t, shown, now - 10 * MINUTE, { type: 'stack.published', toolCount: 2 })
+
+    const feed = await t.query(api.activityFeed.stream, { limit: 1 })
+    expect(feed.rows.map((r) => r.stack.name)).toEqual(['Shown'])
+    expect(feed.hasMore).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The stream — reverse-chronological, paged 25 at a time, filtered by chip.
+// ---------------------------------------------------------------------------
+
+describe('the stream', () => {
+  test('reads newest first and reports whether more exist', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t)
+    const now = Date.now()
+    await emit(t, stackId, now - 3 * HOUR, { type: 'stack.published', toolCount: 1 })
+    await emit(t, stackId, now - 2 * HOUR, syncEvent({ totalTokens: 100 }))
+    await emit(t, stackId, now - HOUR, syncEvent({ totalTokens: 300 }))
+
+    const page = await t.query(api.activityFeed.stream, { limit: 2 })
+    expect(page.rows.map((r) => r.at)).toEqual([now - HOUR, now - 2 * HOUR])
+    expect(page.hasMore).toBe(true)
+
+    const all = await t.query(api.activityFeed.stream, { limit: 25 })
+    expect(all.rows).toHaveLength(3)
+    expect(all.hasMore).toBe(false)
+  })
+
+  test('a chip narrows the stream to one event type', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t)
+    const now = Date.now()
+    await emit(t, stackId, now - 3 * HOUR, { type: 'stack.published', toolCount: 1 })
+    await emit(t, stackId, now - 2 * HOUR, syncEvent({}))
+    await emit(t, stackId, now - HOUR, {
+      type: 'stack.composition_changed',
+      added: [{ kind: 'tool', slug: 'zed', name: 'Zed' }],
+      removed: [],
+    })
+
+    const syncs = await t.query(api.activityFeed.stream, { type: 'sync.landed' })
+    expect(syncs.rows.map((r) => r.event.type)).toEqual(['sync.landed'])
+
+    const changes = await t.query(api.activityFeed.stream, {
+      type: 'stack.composition_changed',
+    })
+    expect(changes.rows.map((r) => r.event.type)).toEqual([
+      'stack.composition_changed',
+    ])
+  })
+
+  test('a row links the stack by its public slug and names its creator', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t, { name: 'Named' })
+    await emit(t, stackId, Date.now() - HOUR, { type: 'stack.published', toolCount: 1 })
+
+    const feed = await t.query(api.activityFeed.stream, {})
+    expect(feed.rows[0].stack.slug).toMatch(/^stack-\d+-sid\d+$/)
+    expect(feed.rows[0].stack.creator).toMatch(/^Creator /)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Movement — the delta is computed across the rows; the table has no delta
+// column (#84).
+// ---------------------------------------------------------------------------
+
+describe('movement', () => {
+  test('a sync reports its movement against the stack previous sync', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t)
+    const now = Date.now()
+    await emit(t, stackId, now - 2 * HOUR, syncEvent({ totalTokens: 1_000 }))
+    await emit(t, stackId, now - HOUR, syncEvent({ totalTokens: 1_285 }))
+
+    const feed = await t.query(api.activityFeed.stream, {})
+    expect(feed.rows[0].deltaTokens).toBe(285)
+    expect(feed.rows[0].firstReading).toBe(false)
+  })
+
+  test('the first sync a stack ever published has no movement to claim', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t)
+    await emit(t, stackId, Date.now() - HOUR, syncEvent({ totalTokens: 1_000 }))
+
+    const feed = await t.query(api.activityFeed.stream, {})
+    expect(feed.rows[0].deltaTokens).toBeNull()
+    expect(feed.rows[0].firstReading).toBe(true)
+  })
+
+  test('movement can fall — a 30-day window forgets its far end', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t)
+    const now = Date.now()
+    await emit(t, stackId, now - 2 * HOUR, syncEvent({ totalTokens: 2_000 }))
+    await emit(t, stackId, now - HOUR, syncEvent({ totalTokens: 1_800 }))
+
+    const feed = await t.query(api.activityFeed.stream, {})
+    expect(feed.rows[0].deltaTokens).toBe(-200)
+  })
+
+  test('movement is measured per stack, never across stacks', async () => {
+    const t = convexTest(schema, modules)
+    const a = await seedStack(t, { name: 'A' })
+    const b = await seedStack(t, { name: 'B' })
+    const now = Date.now()
+    await emit(t, a, now - 3 * HOUR, syncEvent({ totalTokens: 1_000 }))
+    await emit(t, b, now - 2 * HOUR, syncEvent({ totalTokens: 9_000 }))
+    await emit(t, a, now - HOUR, syncEvent({ totalTokens: 1_400 }))
+
+    const feed = await t.query(api.activityFeed.stream, {})
+    const rowA = feed.rows.find((r) => r.stack.name === 'A' && r.at === now - HOUR)
+    expect(rowA?.deltaTokens).toBe(400)
+  })
+
+  test('a predecessor below the page still answers the row above it', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t)
+    const now = Date.now()
+    await emit(t, stackId, now - 3 * HOUR, syncEvent({ totalTokens: 1_000 }))
+    await emit(t, stackId, now - 2 * HOUR, syncEvent({ totalTokens: 1_100 }))
+    await emit(t, stackId, now - HOUR, syncEvent({ totalTokens: 1_500 }))
+
+    const page = await t.query(api.activityFeed.stream, { limit: 1 })
+    expect(page.rows[0].deltaTokens).toBe(400)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The band — the last 24 hours, four measured numbers and three counts (#84).
+// ---------------------------------------------------------------------------
+
+describe('the band', () => {
+  test('counts syncs and updates inside the 24-hour window only', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t)
+    const now = Date.now()
+    await emit(t, stackId, now - 30 * HOUR, syncEvent({ totalTokens: 500 }))
+    await emit(t, stackId, now - 2 * HOUR, syncEvent({ totalTokens: 800 }))
+    await emit(t, stackId, now - HOUR, {
+      type: 'stack.composition_changed',
+      added: [{ kind: 'tool', slug: 'zed', name: 'Zed' }],
+      removed: [],
+    })
+
+    const band = await t.query(api.activityFeed.band, {})
+    expect(band.totals.syncs).toBe(1)
+    expect(band.totals.updates).toBe(1)
+  })
+
+  test('tokens measured is the movement the whole site gained, floored at zero', async () => {
+    const t = convexTest(schema, modules)
+    const a = await seedStack(t, { name: 'Up' })
+    const b = await seedStack(t, { name: 'Down' })
+    const now = Date.now()
+    await emit(t, a, now - 4 * HOUR, syncEvent({ totalTokens: 1_000 }))
+    await emit(t, a, now - 2 * HOUR, syncEvent({ totalTokens: 1_300 }))
+    await emit(t, b, now - 4 * HOUR, syncEvent({ totalTokens: 5_000 }))
+    await emit(t, b, now - 2 * HOUR, syncEvent({ totalTokens: 4_000 }))
+
+    const band = await t.query(api.activityFeed.band, {})
+    // 300 gained, and the stack that fell contributes nothing rather than -1000.
+    expect(band.totals.movedTokens).toBe(300)
+  })
+
+  test('sessions and projects SUM, models and tools UNION', async () => {
+    const t = convexTest(schema, modules)
+    const a = await seedStack(t, { name: 'A' })
+    const b = await seedStack(t, { name: 'B' })
+    const now = Date.now()
+    await snapshot(t, a, { models: ['opus', 'sonnet'], tools: ['Bash', 'Read'] })
+    await snapshot(t, b, { models: ['opus'], tools: ['Bash', 'Edit'] })
+    await emit(t, a, now - 2 * HOUR, syncEvent({ sessions: 100, projects: 5 }))
+    await emit(t, b, now - HOUR, syncEvent({ sessions: 60, projects: 3 }))
+
+    const band = await t.query(api.activityFeed.band, {})
+    expect(band.usage.sessions).toBe(160)
+    expect(band.usage.projects).toBe(8)
+    // Two people running Opus is ONE model; two people running Bash is ONE tool.
+    expect(band.usage.models).toBe(2)
+    expect(band.usage.tools).toBe(3)
+    expect(band.usage.stacks).toBe(2)
+  })
+
+  test('each stack contributes only its latest sync in the window', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t)
+    const now = Date.now()
+    await snapshot(t, stackId, {})
+    await emit(t, stackId, now - 20 * HOUR, syncEvent({ sessions: 596, projects: 41 }))
+    await emit(t, stackId, now - HOUR, syncEvent({ sessions: 596, projects: 41 }))
+
+    const band = await t.query(api.activityFeed.band, {})
+    // Two syncs 19 hours apart are one reading, not 1192 sessions.
+    expect(band.totals.syncs).toBe(2)
+    expect(band.usage.sessions).toBe(596)
+    expect(band.usage.projects).toBe(41)
+  })
+
+  test('an unnamed model never counts as a model', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t)
+    await snapshot(t, stackId, { models: ['opus', 'unknown'] })
+    await emit(t, stackId, Date.now() - HOUR, syncEvent({}))
+
+    const band = await t.query(api.activityFeed.band, {})
+    expect(band.usage.models).toBe(1)
+  })
+
+  test('a quiet window reports no stacks, so the surface can render an em dash', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t)
+    await snapshot(t, stackId, {})
+    await emit(t, stackId, Date.now() - 30 * HOUR, syncEvent({ sessions: 100 }))
+
+    const band = await t.query(api.activityFeed.band, {})
+    expect(band.usage.stacks).toBe(0)
+    expect(band.usage.sessions).toBe(0)
+    expect(band.totals.movedTokens).toBe(0)
+    // The rows themselves still show: the band is quiet, not empty.
+    expect(band.rows).toHaveLength(1)
+  })
+
+  test('carries at most four rows, newest first', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t)
+    const now = Date.now()
+    for (let i = 0; i < 6; i += 1) {
+      await emit(t, stackId, now - i * HOUR, { type: 'stack.published', toolCount: i })
+    }
+
+    const band = await t.query(api.activityFeed.band, {})
+    expect(band.rows).toHaveLength(4)
+    expect(band.rows[0].at).toBe(now)
+  })
+
+  test('the watermark is one daily bucket of gained tokens per day', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t)
+    const now = Date.now()
+    await emit(t, stackId, now - 3 * DAY, syncEvent({ totalTokens: 1_000 }))
+    await emit(t, stackId, now - 2 * DAY, syncEvent({ totalTokens: 1_500 }))
+    await emit(t, stackId, now - HOUR, syncEvent({ totalTokens: 2_000 }))
+
+    const band = await t.query(api.activityFeed.band, {})
+    expect(band.points).toHaveLength(14)
+    expect(band.points[band.points.length - 1].at).toBeGreaterThan(
+      band.points[0].at
+    )
+    const gained = band.points.reduce((sum, p) => sum + p.value, 0)
+    // The first sync has nothing to compare against, so it gains nothing.
+    expect(gained).toBe(1_000)
+  })
+
+  test('counts the stacks it measured across', async () => {
+    const t = convexTest(schema, modules)
+    const a = await seedStack(t)
+    const b = await seedStack(t)
+    const now = Date.now()
+    await emit(t, a, now - 2 * DAY, syncEvent({}))
+    await emit(t, b, now - HOUR, syncEvent({}))
+
+    const band = await t.query(api.activityFeed.band, {})
+    expect(band.totals.stacksSeen).toBe(2)
+  })
+})

--- a/convex/activityFeed.ts
+++ b/convex/activityFeed.ts
@@ -1,0 +1,433 @@
+import { v } from 'convex/values'
+import type { Doc, Id } from './_generated/dataModel'
+import type { QueryCtx } from './_generated/server'
+import { query } from './_generated/server'
+import type { ActivityEventValue } from './activity'
+import { ActivityEvent } from './schema'
+
+/**
+ * The activity feed's READ side. Wayfinder ticket #85 (map #76), band locked by
+ * #84, page locked by #96, data model by #77.
+ *
+ * Two surfaces, one table. `band` is the 24-hour claim that opens both the
+ * landing page and `/activity`. `stream` is the day-grouped list under it, 25
+ * rows per click of "older".
+ *
+ * VISIBILITY IS ENFORCED HERE, at read time (#77). That is the only place it
+ * can be correct: a stack can be unpublished after its event is written, and
+ * this table never mutates. A row shows only while its stack is `published` and
+ * not `isLowQuality` — a deleted stack hides its rows the same way. The write
+ * side's draft gate is not redundant, it only stops a week of drafting from
+ * filling the table with rows that can never be shown.
+ *
+ * MOVEMENT IS DERIVED, NOT STORED (#84). `alp synced 4.99B` is the same
+ * sentence every day, because a snapshot is a rolling 30-day total. What is
+ * news is the change, so a sync row carries the difference against that stack's
+ * previous visible sync — computed across the rows the scan already walks, so
+ * the table needs no delta column and no second index.
+ *
+ * THE BAND'S FOUR NUMBERS COME FROM `measuredSnapshots`, not from the events
+ * (#84 build rule 1): `tools` and `models` are not on `sync.landed` at all.
+ * Sessions and projects SUM across stacks; models and tools UNION, because two
+ * people running Opus is one model and two people running Bash is one tool.
+ * Each stack contributes only its LATEST sync in the window, or a stack that
+ * synced twice would report its sessions twice.
+ */
+
+const HOUR_MS = 60 * 60 * 1000
+const DAY_MS = 24 * HOUR_MS
+
+/** The band's claim, in words on the surface: "the last 24 hours". */
+const BAND_WINDOW_MS = 24 * HOUR_MS
+/** How far back the watermark behind the numbers reaches. */
+const WATERMARK_DAYS = 14
+/** Evidence rows under the band. Four, locked in #84. */
+const BAND_ROWS = 4
+/** One click of "older" (#96). */
+export const PAGE_SIZE = 25
+/** The most rows one stream read returns, however many times "older" is hit. */
+export const MAX_ROWS = 500
+/**
+ * The most events one read may walk. Hidden rows and delta lookups both scan
+ * past the rows they return, so the walk is bounded rather than trusted to end.
+ */
+const SCAN_CAP = 2000
+
+const EventType = v.union(
+  v.literal('stack.published'),
+  v.literal('stack.composition_changed'),
+  v.literal('sync.landed')
+)
+
+const FeedRow = v.object({
+  /** The event document id — stable, so a live insert keys correctly. */
+  id: v.string(),
+  at: v.number(),
+  stack: v.object({
+    name: v.string(),
+    /** Public slug, `${slug}-${shortId}` — what `/stacks/$slug` resolves. */
+    slug: v.string(),
+    creator: v.string(),
+  }),
+  event: ActivityEvent,
+  /**
+   * Tokens gained or lost against this stack's previous visible sync. Null on
+   * anything that is not a sync, and on a sync with no known predecessor.
+   */
+  deltaTokens: v.union(v.number(), v.null()),
+  /**
+   * True only when the walk reached the end of the table without finding an
+   * earlier sync — so "first reading" is a fact, not the absence of one. A
+   * `deltaTokens` of null with this false means the predecessor sits beyond the
+   * scan bound, and the surface says nothing about movement rather than
+   * claiming a first.
+   */
+  firstReading: v.boolean(),
+})
+
+const Band = v.object({
+  totals: v.object({
+    syncs: v.number(),
+    /** Stacks published plus compositions changed — one number on the surface. */
+    updates: v.number(),
+    /** Movement the whole site gained in the window; a fall contributes zero. */
+    movedTokens: v.number(),
+    /** Distinct stacks with any activity in the watermark window. */
+    stacksSeen: v.number(),
+  }),
+  usage: v.object({
+    sessions: v.number(),
+    projects: v.number(),
+    models: v.number(),
+    tools: v.number(),
+    /** Stacks that synced in the window. Zero means quiet, and quiet is not 0. */
+    stacks: v.number(),
+  }),
+  /** One point per UTC day, oldest first. Tokens gained that day. */
+  points: v.array(v.object({ at: v.number(), value: v.number() })),
+  rows: v.array(FeedRow),
+})
+
+type EventTypeValue = ActivityEventValue['type']
+
+type VisibleStack = { name: string; slug: string; creator: string }
+
+type ScanRow = {
+  id: string
+  at: number
+  stackId: Id<'stacks'>
+  stack: VisibleStack
+  event: ActivityEventValue
+  deltaTokens: number | null
+  firstReading: boolean
+}
+
+/** The rolling total a sync reported, summed over the harnesses in its batch. */
+function syncTokens(event: ActivityEventValue): number | null {
+  if (event.type !== 'sync.landed') return null
+  return event.harnesses.reduce((sum, h) => sum + h.totalTokens, 0)
+}
+
+/**
+ * The stack behind an event, or null when it may not be shown.
+ *
+ * Cached per read: a feed page is mostly a handful of stacks repeating, so this
+ * turns one point-read per row into one per distinct stack.
+ */
+async function visibleStack(
+  ctx: QueryCtx,
+  cache: Map<string, VisibleStack | null>,
+  stackId: Id<'stacks'>
+): Promise<VisibleStack | null> {
+  const key = stackId as string
+  const held = cache.get(key)
+  if (held !== undefined) return held
+
+  const stack = await ctx.db.get(stackId)
+  let visible: VisibleStack | null = null
+  if (stack && stack.published && stack.isLowQuality !== true) {
+    const creator = await ctx.db.get(stack.creatorId)
+    visible = {
+      name: stack.name,
+      slug: `${stack.slug}-${stack.shortId}`,
+      creator: creator?.name ?? '',
+    }
+  }
+  cache.set(key, visible)
+  return visible
+}
+
+/**
+ * Walk `by_createdAt` newest-first and return the rows a surface may show.
+ *
+ * One walk answers three questions at once, which is why it is not three
+ * queries: which rows are visible, whether more exist below them, and what each
+ * sync moved. The delta needs the NEXT older sync of the same stack, which the
+ * descending walk reaches after the row itself — so a row is parked in
+ * `pending` until its predecessor turns up, and the walk keeps going while any
+ * row is still parked.
+ */
+async function scanFeed(
+  ctx: QueryCtx,
+  opts: { limit: number; since?: number; type?: EventTypeValue }
+): Promise<{ rows: ScanRow[]; hasMore: boolean }> {
+  const cache = new Map<string, VisibleStack | null>()
+  const rows: ScanRow[] = []
+  const pending = new Map<string, { index: number; tokens: number }>()
+  let hasMore = false
+  /** Set once nothing below can be wanted. The walk then only settles deltas. */
+  let closed = false
+  let scanned = 0
+  let exhausted = true
+
+  for await (const event of ctx.db
+    .query('activityEvents')
+    .withIndex('by_createdAt')
+    .order('desc')) {
+    scanned += 1
+    if (scanned > SCAN_CAP) {
+      exhausted = false
+      break
+    }
+
+    const stack = await visibleStack(ctx, cache, event.stackId)
+    if (!stack) continue
+
+    const key = event.stackId as string
+    const tokens = syncTokens(event.event)
+    if (tokens !== null) {
+      const waiting = pending.get(key)
+      if (waiting) {
+        rows[waiting.index].deltaTokens = waiting.tokens - tokens
+        pending.delete(key)
+      }
+    }
+
+    if (opts.since !== undefined && event.createdAt < opts.since) closed = true
+    const wanted =
+      !closed && (opts.type === undefined || event.event.type === opts.type)
+
+    if (wanted) {
+      if (rows.length >= opts.limit) {
+        // One row past the limit is proof that "older" has something to show.
+        hasMore = true
+        closed = true
+      } else {
+        rows.push({
+          id: event._id,
+          at: event.createdAt,
+          stackId: event.stackId,
+          stack,
+          event: event.event,
+          deltaTokens: null,
+          firstReading: false,
+        })
+        if (tokens !== null) {
+          pending.set(key, { index: rows.length - 1, tokens })
+        }
+      }
+    }
+
+    if (closed && pending.size === 0) {
+      exhausted = false
+      break
+    }
+  }
+
+  // A row still parked when the TABLE ran out has no earlier sync at all, which
+  // is what makes "first reading" true. A row still parked because the walk hit
+  // its bound knows nothing, and says nothing.
+  if (exhausted) {
+    for (const { index } of pending.values()) rows[index].firstReading = true
+  }
+
+  return { rows, hasMore }
+}
+
+function toPublic(row: ScanRow) {
+  return {
+    id: row.id,
+    at: row.at,
+    stack: row.stack,
+    event: row.event,
+    deltaTokens: row.deltaTokens,
+    firstReading: row.firstReading,
+  }
+}
+
+/** UTC midnight, so a bucket boundary does not depend on who is reading. */
+function dayStart(at: number): number {
+  return Math.floor(at / DAY_MS) * DAY_MS
+}
+
+/**
+ * One bucket per UTC day, oldest first, holding the tokens the site GAINED that
+ * day. A fall contributes zero rather than a negative: the watermark is a shape
+ * behind a headline, and a line that dips below its own baseline reads as a
+ * second series.
+ */
+function pointsFor(
+  rows: ScanRow[],
+  now: number
+): { at: number; value: number }[] {
+  const today = dayStart(now)
+  const buckets = new Map<number, number>()
+  for (let back = WATERMARK_DAYS - 1; back >= 0; back -= 1) {
+    buckets.set(today - back * DAY_MS, 0)
+  }
+  for (const row of rows) {
+    const key = dayStart(row.at)
+    if (!buckets.has(key)) continue
+    buckets.set(key, (buckets.get(key) ?? 0) + Math.max(row.deltaTokens ?? 0, 0))
+  }
+  return [...buckets.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([at, value]) => ({ at, value }))
+}
+
+/** The newest snapshot of each harness — the same rule every other surface reads. */
+function newestPerHarness(
+  rows: Doc<'measuredSnapshots'>[]
+): Doc<'measuredSnapshots'>[] {
+  const byHarness = new Map<string, Doc<'measuredSnapshots'>>()
+  for (const row of rows) {
+    const held = byHarness.get(row.harness)
+    if (!held || row.capturedAt > held.capturedAt) byHarness.set(row.harness, row)
+  }
+  return [...byHarness.values()]
+}
+
+/**
+ * The four measured numbers, joined from `measuredSnapshots`.
+ *
+ * The join is paid ONCE, here, for the whole band — which is exactly why the
+ * rows below it stay on event-only facts (#84, #96). One indexed read per stack
+ * that synced in the window, and nothing per row.
+ */
+async function usageFor(
+  ctx: QueryCtx,
+  rows: ScanRow[],
+  since: number
+): Promise<{
+  sessions: number
+  projects: number
+  models: number
+  tools: number
+  stacks: number
+}> {
+  // Rows arrive newest-first, so the first sync seen per stack is its latest.
+  const latest = new Map<string, ScanRow>()
+  for (const row of rows) {
+    if (row.event.type !== 'sync.landed') continue
+    if (row.at < since) continue
+    if (!latest.has(row.stackId as string)) latest.set(row.stackId as string, row)
+  }
+
+  let sessions = 0
+  let projects = 0
+  const models = new Set<string>()
+  const tools = new Set<string>()
+
+  for (const row of latest.values()) {
+    if (row.event.type !== 'sync.landed') continue
+    for (const harness of row.event.harnesses) {
+      sessions += harness.sessions
+      projects += harness.projects
+    }
+    const snapshots = await ctx.db
+      .query('measuredSnapshots')
+      .withIndex('by_stack_capturedAt', (q) => q.eq('stackId', row.stackId))
+      .collect()
+    for (const snapshot of newestPerHarness(snapshots)) {
+      for (const model of snapshot.payload.models) {
+        // `unknown` is the CLI's spelling for tokens it could not attribute. It
+        // is not a model, so it never swells the count of them.
+        if (model.id !== 'unknown') models.add(model.id)
+      }
+      for (const tool of snapshot.payload.inventory.builtinTools) {
+        tools.add(tool.name)
+      }
+    }
+  }
+
+  return {
+    sessions,
+    projects,
+    models: models.size,
+    tools: tools.size,
+    stacks: latest.size,
+  }
+}
+
+/**
+ * The band that opens the landing page and `/activity` (#84 E1, #96 F).
+ *
+ * It reads the watermark window rather than the 24 hours it claims, because the
+ * shape behind the numbers is 14 days long and the four evidence rows must
+ * still show on a day nothing happened.
+ */
+export const band = query({
+  args: {},
+  returns: Band,
+  handler: async (ctx) => {
+    const now = Date.now()
+    const windowStart = now - BAND_WINDOW_MS
+    const { rows } = await scanFeed(ctx, {
+      limit: MAX_ROWS,
+      since: now - WATERMARK_DAYS * DAY_MS,
+    })
+
+    const inWindow = rows.filter((row) => row.at >= windowStart)
+
+    return {
+      totals: {
+        syncs: inWindow.filter((r) => r.event.type === 'sync.landed').length,
+        updates: inWindow.filter((r) => r.event.type !== 'sync.landed').length,
+        movedTokens: inWindow.reduce(
+          (sum, r) => sum + Math.max(r.deltaTokens ?? 0, 0),
+          0
+        ),
+        stacksSeen: new Set(rows.map((r) => r.stackId as string)).size,
+      },
+      usage: await usageFor(ctx, rows, windowStart),
+      points: pointsFor(rows, now),
+      rows: rows.slice(0, BAND_ROWS).map(toPublic),
+    }
+  },
+})
+
+/**
+ * The day-grouped stream under the band on `/activity` (#96).
+ *
+ * `limit` grows by `PAGE_SIZE` on every "older" — one cursor read, no numbered
+ * pages and no infinite scroll, which is the shape `by_createdAt` serves
+ * directly. A chip narrows the stream through `type`; it never touches the
+ * band, because the band states the whole site's 24 hours.
+ */
+export const stream = query({
+  args: {
+    limit: v.optional(v.number()),
+    type: v.optional(EventType),
+  },
+  returns: v.object({
+    rows: v.array(FeedRow),
+    hasMore: v.boolean(),
+    /** One click of "older". The server owns it, so the surface cannot drift. */
+    pageSize: v.number(),
+    /** The ceiling one read will return, so the surface can say it was hit. */
+    maxRows: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const limit = Math.min(
+      MAX_ROWS,
+      Math.max(1, Math.round(args.limit ?? PAGE_SIZE))
+    )
+    const { rows, hasMore } = await scanFeed(ctx, { limit, type: args.type })
+    return {
+      rows: rows.map(toPublic),
+      hasMore,
+      pageSize: PAGE_SIZE,
+      maxRows: MAX_ROWS,
+    }
+  },
+})

--- a/convex/activityFeed.ts
+++ b/convex/activityFeed.ts
@@ -365,6 +365,11 @@ async function usageFor(
  * It reads the watermark window rather than the 24 hours it claims, because the
  * shape behind the numbers is 14 days long and the four evidence rows must
  * still show on a day nothing happened.
+ *
+ * The read is bounded at `MAX_ROWS` events, which is about two months of the
+ * current volume. Past that the WATERMARK loses its oldest days — never the
+ * 24-hour claim, which sits at the top of a newest-first walk. The map already
+ * carries when read-time aggregation has to become a rollup.
  */
 export const band = query({
   args: {},

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -195,6 +195,17 @@ export default function Header() {
 							>
 								Leaderboard
 							</Link>
+							<Link
+								to="/activity"
+								className={cn(
+									"font-mono text-xs font-semibold uppercase tracking-[0.15em] transition-colors",
+									isActive("/activity")
+										? "text-accent-lime"
+										: "text-fg-muted hover:text-fg-primary",
+								)}
+							>
+								Activity
+							</Link>
 							{/* <Link
 							to="/about"
 							className={cn(
@@ -426,6 +437,18 @@ export default function Header() {
 								)}
 							>
 								Leaderboard
+							</Link>
+							<Link
+								to="/activity"
+								onClick={() => setMobileMenuOpen(false)}
+								className={cn(
+									"font-mono text-sm font-semibold uppercase tracking-[0.15em] transition-colors",
+									isActive("/activity")
+										? "text-accent-lime"
+										: "text-fg-muted hover:text-fg-primary",
+								)}
+							>
+								Activity
 							</Link>
 							{isAdmin && (
 								<Link

--- a/src/features/activity/ActivityPage.tsx
+++ b/src/features/activity/ActivityPage.tsx
@@ -1,0 +1,122 @@
+import { FeedRowItem } from "./FeedRows";
+import type { Band, FeedFilter, Stream } from "./feed";
+import { dayBucket, MONO_LABEL } from "./feed";
+import { PulseBand } from "./PulseBand";
+
+/**
+ * `/activity` — variant F of the #96 prototype, sibling of `/leaderboard`.
+ *
+ * THE BAND TRAVELS. The page opens with the same 24-hour claim the landing page
+ * makes, and that is what keeps the thin case warm: three rows under four big
+ * numbers read as a quiet site, not a broken page.
+ *
+ * THE CHIPS NARROW THE STREAM ONLY. The band always states the whole site's
+ * last 24 hours — a filter must never rewrite the headline numbers.
+ *
+ * ROWS STAY ON EVENT-ONLY FACTS. A joined fact line per row lost in the
+ * prototype; the snapshot join stays paid once, in the band.
+ */
+
+const FILTERS: { key: FeedFilter; label: string }[] = [
+	{ key: "all", label: "all" },
+	{ key: "sync.landed", label: "syncs" },
+	{ key: "stack.published", label: "new stacks" },
+	{ key: "stack.composition_changed", label: "changes" },
+];
+
+export function ActivityPage({
+	band,
+	stream,
+	filter,
+	nowMs,
+	onFilter,
+	onOlder,
+}: {
+	readonly band: Band;
+	readonly stream: Stream;
+	readonly filter: FeedFilter;
+	readonly nowMs: number;
+	readonly onFilter: (next: FeedFilter) => void;
+	readonly onOlder: () => void;
+}) {
+	const atCap = !stream.hasMore && stream.rows.length >= stream.maxRows;
+	let lastDay = "";
+
+	return (
+		<div className="min-h-screen bg-bg-canvas">
+			<PulseBand band={band} variant="page" />
+
+			<div className="px-6 py-16">
+				<div className="mx-auto w-full max-w-content">
+					<div className="mb-12 flex flex-wrap gap-2">
+						{FILTERS.map((f) => (
+							<button
+								type="button"
+								key={f.key}
+								aria-pressed={filter === f.key}
+								onClick={() => onFilter(f.key)}
+								className={`${MONO_LABEL} border-2 px-3 py-2 transition-colors ${
+									filter === f.key
+										? "border-accent-lime bg-accent-lime text-accent-lime-contrast"
+										: "border-stroke-strong text-fg-muted hover:border-accent-lime hover:text-accent-lime"
+								}`}
+							>
+								{f.label}
+							</button>
+						))}
+					</div>
+
+					{stream.rows.length === 0 ? (
+						<p className="font-mono text-sm text-fg-muted/60">
+							nothing here yet.
+						</p>
+					) : null}
+
+					{stream.rows.map((row) => {
+						const day = dayBucket(row.at, nowMs);
+						const opensDay = day !== lastDay;
+						lastDay = day;
+						return (
+							<div key={row.id}>
+								{opensDay ? (
+									<div
+										className={`${MONO_LABEL} mb-4 mt-12 text-fg-muted first:mt-0`}
+										suppressHydrationWarning
+									>
+										{day}
+									</div>
+								) : null}
+								<ul>
+									<FeedRowItem row={row} />
+								</ul>
+							</div>
+						);
+					})}
+
+					{stream.hasMore ? (
+						<button
+							type="button"
+							onClick={onOlder}
+							className={`${MONO_LABEL} mt-12 border-2 border-stroke-strong px-6 py-3 text-fg-muted transition-colors hover:border-accent-lime hover:text-accent-lime`}
+						>
+							older →
+						</button>
+					) : null}
+
+					{/* A cap that says nothing reads as "that was everything". */}
+					{atCap ? (
+						<p className="mt-12 font-mono text-xs text-fg-muted/40">
+							showing the newest {stream.maxRows} events.
+						</p>
+					) : null}
+
+					{!stream.hasMore && !atCap && stream.rows.length > 0 ? (
+						<p className="mt-12 font-mono text-xs text-fg-muted/40">
+							that is everything since instrumentation went live.
+						</p>
+					) : null}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/features/activity/FeedRows.tsx
+++ b/src/features/activity/FeedRows.tsx
@@ -1,0 +1,111 @@
+import { Link } from "@tanstack/react-router";
+import type { FeedRow } from "./feed";
+import { fmtDelta, fmtTokens, syncFacts, syncTokens } from "./feed";
+import { RelativeTime } from "./RelativeTime";
+
+/**
+ * One row of the feed, in the grammar #84 locked:
+ *
+ *   **AI Stack** measured usage moved **+285M**
+ *   Claude Code + Codex · 4.99B over 30 days · 596 sessions          4h ago
+ *
+ * MOVEMENT LEADS and the total is demoted, because `alp synced 4.99B` is the
+ * same sentence every day — a snapshot is a rolling 30-day total, and a number
+ * that never changes is a status light, not news.
+ *
+ * THE STACK NAME IS THE LINK, not the person. The feed is about what the site
+ * measured, not about who pressed the button.
+ */
+
+function Headline({ row }: { readonly row: FeedRow }) {
+	const event = row.event;
+
+	if (event.type === "sync.landed") {
+		if (row.deltaTokens !== null) {
+			return (
+				<>
+					measured usage moved{" "}
+					<span className="font-semibold text-accent-lime">
+						{fmtDelta(row.deltaTokens)}
+					</span>
+				</>
+			);
+		}
+		// No movement to state. `firstReading` is the only case where that is a
+		// FACT about the stack rather than the absence of one, so it is the only
+		// case that says "first".
+		return (
+			<>
+				{row.firstReading ? "first reading — " : "measured "}
+				<span className="font-semibold text-accent-lime">
+					{fmtTokens(syncTokens(row))} tokens
+				</span>
+				{row.firstReading ? " measured" : ""}
+			</>
+		);
+	}
+
+	if (event.type === "stack.published") {
+		return (
+			<>
+				joined with{" "}
+				<span className="font-semibold text-accent-lime">
+					{event.toolCount} {event.toolCount === 1 ? "tool" : "tools"}
+				</span>
+			</>
+		);
+	}
+
+	return (
+		<>
+			{event.added.length > 0 ? (
+				<>
+					picked up{" "}
+					<span className="font-semibold text-accent-lime">
+						{event.added.map((a) => a.name).join(", ")}
+					</span>
+				</>
+			) : null}
+			{event.added.length > 0 && event.removed.length > 0 ? " · " : null}
+			{event.removed.length > 0 ? (
+				<>
+					dropped{" "}
+					<span className="font-semibold text-fg-secondary">
+						{event.removed.map((a) => a.name).join(", ")}
+					</span>
+				</>
+			) : null}
+		</>
+	);
+}
+
+export function FeedRowItem({ row }: { readonly row: FeedRow }) {
+	const facts =
+		row.event.type === "sync.landed"
+			? syncFacts(row)
+			: [`by ${row.stack.creator}`];
+
+	return (
+		<li className="flex gap-5 border-l-2 border-stroke-subtle py-4 pl-5">
+			<div className="min-w-0 flex-1">
+				<div className="text-base text-fg-muted">
+					<Link
+						to="/stacks/$slug"
+						params={{ slug: row.stack.slug }}
+						className="font-semibold text-fg-primary underline decoration-stroke-subtle underline-offset-4 hover:text-accent-lime hover:decoration-accent-lime"
+					>
+						{row.stack.name}
+					</Link>{" "}
+					<Headline row={row} />
+				</div>
+				<div className="mt-1.5 font-mono text-xs text-fg-muted/50">
+					{facts.join(" · ")}
+				</div>
+			</div>
+			<RelativeTime
+				at={row.at}
+				className="shrink-0 pt-1 font-mono text-xs text-fg-muted/50"
+			/>
+		</li>
+	);
+}

--- a/src/features/activity/PulseBand.tsx
+++ b/src/features/activity/PulseBand.tsx
@@ -1,0 +1,202 @@
+import { Link } from "@tanstack/react-router";
+import { ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Sparkline } from "@/features/charts";
+import { FeedRowItem } from "./FeedRows";
+import type { Band } from "./feed";
+import { fmtCount, fmtTokens, liveDays, MONO_LABEL } from "./feed";
+
+/**
+ * The pulse of the site — variant E1, locked in #84 over four rounds, and
+ * carried verbatim onto `/activity` by #96.
+ *
+ *   // the last 24 hours              2 syncs · 1 stack update · 8 models
+ *
+ *   +285M            596              41               22
+ *   TOKENS MEASURED  SESSIONS         PROJECTS         TOOLS
+ *
+ *   as it lands
+ *     AI Stack measured usage moved +285M ...
+ *
+ *   measured across 4 stacks                        [ ALL ACTIVITY → ]
+ *
+ * HEADLINE IS WHAT THE SITE MEASURED, secondary is what the site did. A visitor
+ * who reads only the big row learns how much real work these machines carry,
+ * and never has to care that a sync is the mechanism that reported it.
+ *
+ * RULE BUDGET — ONE horizontal line inside the band, the one across the tile
+ * tops. Everything below is separated by space. Vertical rules stay: the feed
+ * rows keep their left border.
+ *
+ * QUIET IS NOT ZERO. With no sync in the window every measured tile renders an
+ * em dash. A row of zeroes reads as a broken site rather than a quiet one.
+ *
+ * The two `page` trims (#96): a tighter header, and no footer row — the page
+ * does not repeat the landing band's footnote, and the button that led there
+ * has nowhere left to go.
+ */
+
+const WATERMARK_MIN_DAYS = 3;
+const WATERMARK_HEIGHT = 224;
+
+function Stat({
+	value,
+	label,
+	accent,
+}: {
+	readonly value: string;
+	readonly label: string;
+	readonly accent?: boolean;
+}) {
+	return (
+		<div className="border-t-2 border-stroke-strong pt-4">
+			<div
+				className={`text-5xl font-black leading-none tracking-tighter tabular-nums md:text-6xl ${
+					accent ? "text-accent-lime" : "text-fg-primary"
+				}`}
+			>
+				{value}
+			</div>
+			<div className={`${MONO_LABEL} mt-3 text-fg-muted`}>{label}</div>
+		</div>
+	);
+}
+
+function Fact({
+	value,
+	label,
+}: {
+	readonly value: string;
+	readonly label: string;
+}) {
+	return (
+		<span className="flex items-baseline gap-2">
+			<span className="font-mono text-sm font-semibold tabular-nums text-fg-secondary">
+				{value}
+			</span>
+			<span className={`${MONO_LABEL} text-fg-muted/60`}>{label}</span>
+		</span>
+	);
+}
+
+export function PulseBand({
+	band,
+	variant,
+}: {
+	readonly band: Band;
+	readonly variant: "landing" | "page";
+}) {
+	const { totals, usage, points, rows } = band;
+	const quiet = usage.stacks === 0;
+	const showWatermark = liveDays(points) >= WATERMARK_MIN_DAYS;
+	const onPage = variant === "page";
+
+	return (
+		<section
+			className={`relative overflow-hidden border-b-2 border-stroke-strong bg-bg-panel px-6 ${
+				onPage ? "py-10" : "py-20"
+			}`}
+		>
+			{showWatermark ? (
+				<div
+					aria-hidden="true"
+					className="pointer-events-none absolute inset-x-0 bottom-0 h-56 opacity-[0.18] [mask-image:linear-gradient(to_top,black,transparent)]"
+				>
+					<Sparkline
+						points={points}
+						ariaLabel=""
+						width={1600}
+						height={WATERMARK_HEIGHT}
+						fluid
+						className="h-full w-full"
+					/>
+				</div>
+			) : null}
+
+			<div className="relative mx-auto w-full max-w-content">
+				{onPage ? (
+					<h1 className="mb-6 text-4xl font-black tracking-tighter text-fg-primary md:text-5xl">
+						ACTIVITY
+					</h1>
+				) : null}
+
+				{/* The secondary three live HERE, in a row the band already pays for:
+				    no extra rule, no extra row of vertical space. */}
+				<div
+					className={`flex flex-wrap items-baseline justify-between gap-x-10 gap-y-3 ${
+						onPage ? "mb-8" : "mb-12"
+					}`}
+				>
+					<span className="flex items-center gap-3">
+						<span className="relative flex h-2 w-2">
+							<span className="absolute inline-flex h-full w-full animate-ping bg-accent-lime opacity-60" />
+							<span className="relative inline-flex h-2 w-2 bg-accent-lime" />
+						</span>
+						<span className={`${MONO_LABEL} text-accent-lime`}>
+							{"// the last 24 hours"}
+						</span>
+					</span>
+					<span className="flex flex-wrap items-baseline gap-x-8 gap-y-2">
+						<Fact
+							value={String(totals.syncs)}
+							label={totals.syncs === 1 ? "sync" : "syncs"}
+						/>
+						<Fact
+							value={String(totals.updates)}
+							label={totals.updates === 1 ? "stack update" : "stack updates"}
+						/>
+						<Fact value={quiet ? "—" : String(usage.models)} label="models" />
+					</span>
+				</div>
+
+				<div className="grid grid-cols-2 gap-x-8 gap-y-12 md:grid-cols-4">
+					<Stat
+						value={
+							totals.movedTokens === 0
+								? "—"
+								: `+${fmtTokens(totals.movedTokens)}`
+						}
+						label="tokens measured"
+						accent
+					/>
+					<Stat
+						value={quiet ? "—" : fmtCount(usage.sessions)}
+						label="sessions"
+					/>
+					<Stat
+						value={quiet ? "—" : fmtCount(usage.projects)}
+						label="projects"
+					/>
+					<Stat value={quiet ? "—" : fmtCount(usage.tools)} label="tools" />
+				</div>
+
+				{onPage ? null : (
+					<>
+						<div className="mt-16">
+							<div className={`${MONO_LABEL} mb-6 text-fg-muted`}>
+								as it lands
+							</div>
+							<ul className="space-y-2">
+								{rows.map((row) => (
+									<FeedRowItem key={row.id} row={row} />
+								))}
+							</ul>
+						</div>
+
+						<div className="mt-10 flex flex-wrap items-center justify-between gap-6">
+							<span className="font-mono text-xs text-fg-muted/50">
+								measured across {totals.stacksSeen}{" "}
+								{totals.stacksSeen === 1 ? "stack" : "stacks"}
+							</span>
+							<Button asChild variant="outline" size="lg">
+								<Link to="/activity" className={MONO_LABEL}>
+									all activity <ArrowRight className="h-3 w-3" />
+								</Link>
+							</Button>
+						</div>
+					</>
+				)}
+			</div>
+		</section>
+	);
+}

--- a/src/features/activity/RelativeTime.tsx
+++ b/src/features/activity/RelativeTime.tsx
@@ -1,0 +1,69 @@
+import { useSyncExternalStore } from "react";
+import { relativeLabel } from "./feed";
+
+/**
+ * "4 minutes ago", kept true without a re-render storm.
+ *
+ * ONE interval for the whole page, not one per row: every `RelativeTime`
+ * subscribes to the same clock store, and the store is torn down when the last
+ * one unmounts.
+ *
+ * The snapshot is the FORMATTED STRING, not the clock. React bails out of a
+ * re-render when a snapshot is unchanged, so a tick re-renders only the rows
+ * whose words actually moved — a page of 25 rows mostly hours old re-renders
+ * nothing at all, while "just now" still becomes "1m ago" on time.
+ */
+
+const TICK_MS = 20_000;
+
+let now = Date.now();
+const listeners = new Set<() => void>();
+let timer: ReturnType<typeof setInterval> | null = null;
+
+function subscribe(onChange: () => void): () => void {
+	listeners.add(onChange);
+	if (timer === null) {
+		now = Date.now();
+		timer = setInterval(() => {
+			now = Date.now();
+			for (const listener of listeners) listener();
+		}, TICK_MS);
+	}
+	return () => {
+		listeners.delete(onChange);
+		if (listeners.size === 0 && timer !== null) {
+			clearInterval(timer);
+			timer = null;
+		}
+	};
+}
+
+export function useRelativeLabel(at: number): string {
+	return useSyncExternalStore(
+		subscribe,
+		() => relativeLabel(at, now),
+		// The server has its own clock and no ticker. The first client render may
+		// land a minute away from it, which is why the element below suppresses
+		// the hydration warning rather than rendering nothing until mount.
+		() => relativeLabel(at, Date.now()),
+	);
+}
+
+export function RelativeTime({
+	at,
+	className,
+}: {
+	readonly at: number;
+	readonly className?: string;
+}) {
+	const label = useRelativeLabel(at);
+	return (
+		<time
+			dateTime={new Date(at).toISOString()}
+			className={className}
+			suppressHydrationWarning
+		>
+			{label}
+		</time>
+	);
+}

--- a/src/features/activity/__tests__/activity-page.test.tsx
+++ b/src/features/activity/__tests__/activity-page.test.tsx
@@ -1,0 +1,139 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ActivityPage } from "../ActivityPage";
+import {
+	band,
+	changedRow,
+	NOW,
+	publishedRow,
+	stream,
+	syncRow,
+} from "./fixture";
+
+vi.mock("@tanstack/react-router", () => ({
+	Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+		<a href={to}>{children}</a>
+	),
+}));
+
+afterEach(cleanup);
+
+function setup(over: Parameters<typeof page>[0] = {}) {
+	return page(over);
+}
+
+function page({
+	streamOver = {},
+	bandOver = {},
+	filter = "all" as const,
+	onFilter = () => {},
+	onOlder = () => {},
+}: {
+	streamOver?: Parameters<typeof stream>[0];
+	bandOver?: Parameters<typeof band>[0];
+	filter?: Parameters<typeof ActivityPage>[0]["filter"];
+	onFilter?: (f: Parameters<typeof ActivityPage>[0]["filter"]) => void;
+	onOlder?: () => void;
+} = {}) {
+	return render(
+		<ActivityPage
+			band={band(bandOver)}
+			stream={stream(streamOver)}
+			filter={filter}
+			nowMs={NOW}
+			onFilter={onFilter}
+			onOlder={onOlder}
+		/>,
+	);
+}
+
+describe("the page", () => {
+	it("opens with the band the landing page states", () => {
+		setup();
+		expect(
+			screen.getByRole("heading", { name: "ACTIVITY" }),
+		).toBeInTheDocument();
+		expect(screen.getByText("+512M")).toBeInTheDocument();
+		expect(screen.getByText("tokens measured")).toBeInTheDocument();
+	});
+
+	it("groups the stream by day", () => {
+		setup({
+			streamOver: {
+				rows: [
+					syncRow({ at: NOW - 60 * 60 * 1000 }),
+					changedRow(),
+					publishedRow(),
+				],
+			},
+		});
+		expect(screen.getByText("TODAY")).toBeInTheDocument();
+		expect(screen.getByText("YESTERDAY")).toBeInTheDocument();
+	});
+
+	it("offers four chips and marks the live one", () => {
+		setup({ filter: "sync.landed" });
+		const chip = (name: string) => screen.getByRole("button", { name });
+		expect(chip("all")).toHaveAttribute("aria-pressed", "false");
+		expect(chip("syncs")).toHaveAttribute("aria-pressed", "true");
+		expect(chip("new stacks")).toBeInTheDocument();
+		expect(chip("changes")).toBeInTheDocument();
+	});
+
+	it("narrows the stream only — the band still states the whole site", () => {
+		setup({
+			filter: "sync.landed",
+			streamOver: { rows: [syncRow()] },
+		});
+		// The band's counts are untouched by the chip.
+		expect(screen.getByText("2")).toBeInTheDocument();
+		expect(screen.getByText("syncs", { selector: "span" })).toBeInTheDocument();
+		expect(screen.queryByText("Halfpipe")).not.toBeInTheDocument();
+	});
+
+	it("asks for the next 25 when older is pressed", () => {
+		const onOlder = vi.fn();
+		setup({ streamOver: { hasMore: true }, onOlder });
+		fireEvent.click(screen.getByText("older →"));
+		expect(onOlder).toHaveBeenCalledTimes(1);
+	});
+
+	it("hides older when nothing older exists, and says so", () => {
+		setup({ streamOver: { hasMore: false } });
+		expect(screen.queryByText("older →")).not.toBeInTheDocument();
+		expect(
+			screen.getByText("that is everything since instrumentation went live."),
+		).toBeInTheDocument();
+	});
+
+	it("says an emptied stream is empty rather than showing a blank page", () => {
+		setup({ filter: "stack.published", streamOver: { rows: [] } });
+		expect(screen.getByText("nothing here yet.")).toBeInTheDocument();
+		expect(
+			screen.queryByText("that is everything since instrumentation went live."),
+		).not.toBeInTheDocument();
+	});
+
+	it("never lets a capped read read as the end of the record", () => {
+		setup({
+			streamOver: {
+				rows: Array.from({ length: 3 }, () => syncRow()),
+				hasMore: false,
+				maxRows: 3,
+			},
+		});
+		expect(
+			screen.getByText("showing the newest 3 events."),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText("that is everything since instrumentation went live."),
+		).not.toBeInTheDocument();
+	});
+
+	it("moves the chip when one is pressed", () => {
+		const onFilter = vi.fn();
+		setup({ onFilter });
+		fireEvent.click(screen.getByText("changes"));
+		expect(onFilter).toHaveBeenCalledWith("stack.composition_changed");
+	});
+});

--- a/src/features/activity/__tests__/feed.test.ts
+++ b/src/features/activity/__tests__/feed.test.ts
@@ -38,6 +38,14 @@ describe("relative time", () => {
 		expect(relativeLabel(NOW - 21 * DAY, NOW)).toBe("3w ago");
 	});
 
+	it("never overstates an age, at any boundary", () => {
+		expect(relativeLabel(NOW - 59.9 * MINUTE, NOW)).toBe("59m ago");
+		expect(relativeLabel(NOW - 23.9 * HOUR, NOW)).toBe("23h ago");
+		// The row a day kicker calls YESTERDAY must not call itself two days old.
+		expect(relativeLabel(NOW - 1.6 * DAY, NOW)).toBe("1d ago");
+		expect(relativeLabel(NOW - 13.9 * DAY, NOW)).toBe("1w ago");
+	});
+
 	it("never runs forward when a client clock lags the server", () => {
 		expect(relativeLabel(NOW + 5 * MINUTE, NOW)).toBe("just now");
 	});

--- a/src/features/activity/__tests__/feed.test.ts
+++ b/src/features/activity/__tests__/feed.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+	dayBucket,
+	fmtDelta,
+	fmtTokens,
+	harnessList,
+	liveDays,
+	relativeLabel,
+	syncFacts,
+	syncTokens,
+} from "../feed";
+import { NOW, points, publishedRow, syncRow } from "./fixture";
+
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+describe("numbers", () => {
+	it("shortens tokens and keeps two decimals where the difference is money", () => {
+		expect(fmtTokens(4_990_000_000)).toBe("4.99B");
+		expect(fmtTokens(285_000_000)).toBe("285M");
+		expect(fmtTokens(1_200)).toBe("1K");
+		expect(fmtTokens(42)).toBe("42");
+	});
+
+	it("signs a movement, because a 30-day window can fall", () => {
+		expect(fmtDelta(285_000_000)).toBe("+285M");
+		expect(fmtDelta(-285_000_000)).toBe("−285M");
+	});
+});
+
+describe("relative time", () => {
+	it("reads as the feed's own clock, minute by minute", () => {
+		expect(relativeLabel(NOW - 20_000, NOW)).toBe("just now");
+		expect(relativeLabel(NOW - 4 * MINUTE, NOW)).toBe("4m ago");
+		expect(relativeLabel(NOW - 4 * HOUR, NOW)).toBe("4h ago");
+		expect(relativeLabel(NOW - 3 * DAY, NOW)).toBe("3d ago");
+		expect(relativeLabel(NOW - 21 * DAY, NOW)).toBe("3w ago");
+	});
+
+	it("never runs forward when a client clock lags the server", () => {
+		expect(relativeLabel(NOW + 5 * MINUTE, NOW)).toBe("just now");
+	});
+});
+
+describe("day kickers", () => {
+	it("names today and yesterday, then the date", () => {
+		expect(dayBucket(NOW, NOW)).toBe("TODAY");
+		expect(dayBucket(NOW - DAY, NOW)).toBe("YESTERDAY");
+		expect(dayBucket(NOW - 3 * DAY, NOW)).toBe("SUN 02 AUG");
+	});
+});
+
+describe("the watermark", () => {
+	it("counts only days that carry a reading", () => {
+		expect(liveDays(points([0, 0, 5, 0, 7]))).toBe(2);
+		expect(liveDays(points([0, 0, 0]))).toBe(0);
+	});
+});
+
+describe("a sync row", () => {
+	it("sums the tokens of every harness in the batch", () => {
+		expect(syncTokens(syncRow())).toBe(4_990_000_000);
+		expect(syncTokens(publishedRow())).toBe(0);
+	});
+
+	it("carries three facts, all of them on the event itself", () => {
+		expect(syncFacts(syncRow())).toEqual([
+			"Claude Code + Codex",
+			"4.99B over 30 days",
+			"596 sessions",
+		]);
+	});
+
+	it("names harnesses in words and keeps an unknown one as it came", () => {
+		expect(harnessList(["claude-code"])).toBe("Claude Code");
+		expect(harnessList(["claude-code", "codex"])).toBe("Claude Code + Codex");
+		expect(harnessList(["cursor"])).toBe("cursor");
+	});
+});

--- a/src/features/activity/__tests__/fixture.ts
+++ b/src/features/activity/__tests__/fixture.ts
@@ -1,0 +1,110 @@
+import type { Band, FeedRow, Stream } from "../feed";
+
+export const NOW = new Date("2026-08-05T12:00:00Z").getTime();
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+let counter = 0;
+
+export function syncRow(over: Partial<FeedRow> = {}): FeedRow {
+	counter += 1;
+	return {
+		id: `row-${counter}`,
+		at: NOW - 4 * HOUR,
+		stack: { name: "AI Stack", slug: "ai-stack-ab12", creator: "alp" },
+		event: {
+			type: "sync.landed",
+			harnesses: [
+				{
+					harness: "claude-code",
+					windowDays: 30,
+					sessions: 400,
+					activeDays: 20,
+					projects: 30,
+					totalTokens: 3_000_000_000,
+				},
+				{
+					harness: "codex",
+					windowDays: 30,
+					sessions: 196,
+					activeDays: 9,
+					projects: 11,
+					totalTokens: 1_990_000_000,
+				},
+			],
+		},
+		deltaTokens: 285_000_000,
+		firstReading: false,
+		...over,
+	};
+}
+
+export function publishedRow(over: Partial<FeedRow> = {}): FeedRow {
+	counter += 1;
+	return {
+		id: `row-${counter}`,
+		at: NOW - 2 * DAY,
+		stack: { name: "Kestrel", slug: "kestrel-cd34", creator: "diego" },
+		event: { type: "stack.published", toolCount: 7 },
+		deltaTokens: null,
+		firstReading: false,
+		...over,
+	};
+}
+
+export function changedRow(over: Partial<FeedRow> = {}): FeedRow {
+	counter += 1;
+	return {
+		id: `row-${counter}`,
+		at: NOW - 26 * HOUR,
+		stack: { name: "Halfpipe", slug: "halfpipe-ef56", creator: "rin" },
+		event: {
+			type: "stack.composition_changed",
+			added: [{ kind: "tool", slug: "zed", name: "Zed" }],
+			removed: [{ kind: "tool", slug: "vscode", name: "VS Code" }],
+		},
+		deltaTokens: null,
+		firstReading: false,
+		...over,
+	};
+}
+
+export function points(values: number[]): Band["points"] {
+	return values.map((value, i) => ({
+		at: NOW - (values.length - 1 - i) * DAY,
+		value,
+	}));
+}
+
+export function band(over: Partial<Band> = {}): Band {
+	return {
+		totals: {
+			syncs: 2,
+			updates: 1,
+			// Deliberately NOT one row's delta: the tile is the whole site's
+			// movement, and a test that shares a number cannot tell them apart.
+			movedTokens: 512_000_000,
+			stacksSeen: 4,
+		},
+		usage: {
+			sessions: 596,
+			projects: 41,
+			models: 8,
+			tools: 22,
+			stacks: 2,
+		},
+		points: points([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1e8, 2e8, 0, 3e8]),
+		rows: [syncRow(), changedRow(), publishedRow()],
+		...over,
+	};
+}
+
+export function stream(over: Partial<Stream> = {}): Stream {
+	return {
+		rows: [syncRow(), changedRow(), publishedRow()],
+		hasMore: false,
+		pageSize: 25,
+		maxRows: 500,
+		...over,
+	};
+}

--- a/src/features/activity/__tests__/pulse-band.test.tsx
+++ b/src/features/activity/__tests__/pulse-band.test.tsx
@@ -1,0 +1,151 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PulseBand } from "../PulseBand";
+import { band, points, syncRow } from "./fixture";
+
+vi.mock("@tanstack/react-router", () => ({
+	Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+		<a href={to}>{children}</a>
+	),
+}));
+
+afterEach(cleanup);
+
+describe("the band", () => {
+	it("leads with what the site measured, tokens on the accent", () => {
+		render(<PulseBand band={band()} variant="landing" />);
+		const tokens = screen.getByText("+512M");
+		expect(tokens).toHaveClass("text-accent-lime");
+		expect(screen.getByText("tokens measured")).toBeInTheDocument();
+		expect(screen.getByText("596")).toBeInTheDocument();
+		expect(screen.getByText("41")).toBeInTheDocument();
+		expect(screen.getByText("22")).toBeInTheDocument();
+	});
+
+	it("puts what the site DID in the header bar, at kicker size", () => {
+		render(<PulseBand band={band()} variant="landing" />);
+		expect(screen.getByText("syncs")).toBeInTheDocument();
+		expect(screen.getByText("stack update")).toBeInTheDocument();
+		expect(screen.getByText("models")).toBeInTheDocument();
+		expect(screen.getByText("2")).toBeInTheDocument();
+	});
+
+	it("renders a quiet window as em dashes, never as zeroes", () => {
+		render(
+			<PulseBand
+				band={band({
+					totals: {
+						syncs: 0,
+						updates: 0,
+						movedTokens: 0,
+						stacksSeen: 4,
+					},
+					usage: {
+						sessions: 0,
+						projects: 0,
+						models: 0,
+						tools: 0,
+						stacks: 0,
+					},
+				})}
+				variant="landing"
+			/>,
+		);
+		// Four measured tiles plus the model count. The two event COUNTS stay
+		// numeric: "0 syncs" counts what happened, it does not measure anything.
+		expect(screen.getAllByText("—")).toHaveLength(5);
+		expect(screen.getAllByText("0")).toHaveLength(2);
+	});
+
+	it("drops the watermark below three days with a reading", () => {
+		const { container } = render(
+			<PulseBand
+				band={band({ points: points([0, 0, 5, 0, 0]) })}
+				variant="landing"
+			/>,
+		);
+		expect(container.querySelector('[aria-hidden="true"] svg')).toBeNull();
+	});
+
+	it("draws the watermark once there is a shape to draw", () => {
+		const { container } = render(
+			<PulseBand
+				band={band({ points: points([1, 0, 5, 2, 0]) })}
+				variant="landing"
+			/>,
+		);
+		expect(container.querySelector('[aria-hidden="true"] svg')).not.toBeNull();
+	});
+
+	it("sends the landing reader on to the whole stream", () => {
+		render(<PulseBand band={band()} variant="landing" />);
+		const button = screen.getByText(/all activity/i).closest("a");
+		expect(button).toHaveAttribute("href", "/activity");
+		expect(screen.getByText("measured across 4 stacks")).toBeInTheDocument();
+	});
+
+	it("drops the footnote row on the page, which does not repeat itself", () => {
+		render(<PulseBand band={band()} variant="page" />);
+		expect(screen.queryByText(/all activity/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/measured across/)).not.toBeInTheDocument();
+		expect(
+			screen.getByRole("heading", { name: "ACTIVITY" }),
+		).toBeInTheDocument();
+	});
+
+	it("shows its evidence rows on the landing page only", () => {
+		const only = { rows: [syncRow()] };
+		render(<PulseBand band={band(only)} variant="landing" />);
+		expect(screen.getByText("AI Stack")).toBeInTheDocument();
+		cleanup();
+		render(<PulseBand band={band(only)} variant="page" />);
+		expect(screen.queryByText("AI Stack")).not.toBeInTheDocument();
+	});
+});
+
+describe("a row", () => {
+	it("leads with movement and demotes the total", () => {
+		render(<PulseBand band={band({ rows: [syncRow()] })} variant="landing" />);
+		expect(screen.getByText(/measured usage moved/)).toBeInTheDocument();
+		expect(screen.getByText("+285M")).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"Claude Code + Codex · 4.99B over 30 days · 596 sessions",
+			),
+		).toBeInTheDocument();
+	});
+
+	it("links the stack, not the person", () => {
+		render(<PulseBand band={band({ rows: [syncRow()] })} variant="landing" />);
+		expect(screen.getByText("AI Stack").closest("a")).toHaveAttribute(
+			"href",
+			"/stacks/$slug",
+		);
+	});
+
+	it("says first reading only when it is one", () => {
+		render(
+			<PulseBand
+				band={band({
+					rows: [syncRow({ deltaTokens: null, firstReading: true })],
+				})}
+				variant="landing"
+			/>,
+		);
+		expect(screen.getByText(/first reading/)).toBeInTheDocument();
+	});
+
+	it("claims nothing about movement it could not measure", () => {
+		render(
+			<PulseBand
+				band={band({
+					rows: [syncRow({ deltaTokens: null, firstReading: false })],
+				})}
+				variant="landing"
+			/>,
+		);
+		expect(screen.queryByText(/first reading/)).not.toBeInTheDocument();
+		expect(screen.queryByText(/moved/)).not.toBeInTheDocument();
+		expect(screen.getByText("4.99B tokens")).toBeInTheDocument();
+	});
+});

--- a/src/features/activity/__tests__/relative-time.test.tsx
+++ b/src/features/activity/__tests__/relative-time.test.tsx
@@ -1,0 +1,80 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RelativeTime, useRelativeLabel } from "../RelativeTime";
+
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+const TICK = 20_000;
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.setSystemTime(new Date("2026-08-05T12:00:00Z"));
+});
+
+afterEach(() => {
+	cleanup();
+	vi.useRealTimers();
+});
+
+/** Counts its own renders, so a needless one is visible. */
+function Probe({ at, onRender }: { at: number; onRender: () => void }) {
+	const label = useRelativeLabel(at);
+	onRender();
+	return <span>{label}</span>;
+}
+
+describe("relative time", () => {
+	it("keeps one interval for the whole page, however many rows subscribe", () => {
+		const now = Date.now();
+		render(
+			<>
+				<RelativeTime at={now - HOUR} />
+				<RelativeTime at={now - 2 * HOUR} />
+				<RelativeTime at={now - 3 * HOUR} />
+			</>,
+		);
+		expect(vi.getTimerCount()).toBe(1);
+	});
+
+	it("stops ticking when the last row unmounts", () => {
+		const { unmount } = render(<RelativeTime at={Date.now()} />);
+		expect(vi.getTimerCount()).toBe(1);
+		unmount();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("moves a fresh row on without a re-render storm on the old ones", () => {
+		const now = Date.now();
+		const fresh = vi.fn();
+		const old = vi.fn();
+		render(
+			<>
+				<Probe at={now} onRender={fresh} />
+				<Probe at={now - 5 * HOUR} onRender={old} />
+			</>,
+		);
+
+		const freshFirst = fresh.mock.calls.length;
+		const oldFirst = old.mock.calls.length;
+		expect(screen.getByText("just now")).toBeInTheDocument();
+
+		// Past a minute the fresh row has new words; the five-hour row does not.
+		act(() => {
+			vi.advanceTimersByTime(4 * TICK);
+		});
+
+		expect(screen.getByText("1m ago")).toBeInTheDocument();
+		expect(fresh.mock.calls.length).toBeGreaterThan(freshFirst);
+		expect(old.mock.calls.length).toBe(oldFirst);
+	});
+
+	it("carries the exact moment in the markup, whatever the words say", () => {
+		const at = Date.now() - HOUR;
+		render(<RelativeTime at={at} />);
+		expect(screen.getByText("1h ago").tagName).toBe("TIME");
+		expect(screen.getByText("1h ago")).toHaveAttribute(
+			"datetime",
+			new Date(at).toISOString(),
+		);
+	});
+});

--- a/src/features/activity/__tests__/ssr.test.tsx
+++ b/src/features/activity/__tests__/ssr.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * The pulse must be in the FIRST HTML, not painted in after hydration.
+ *
+ * The band is what a first-time visitor reads above the featured stacks, and a
+ * crawler reads nothing else. These assertions are about the rendered text and
+ * real SVG marks, so a regression that pushes the band behind an effect fails
+ * here instead of quietly shipping an empty strip.
+ */
+
+import { renderToString } from "react-dom/server";
+import { describe, expect, test, vi } from "vitest";
+import { PulseBand } from "../PulseBand";
+import { band, syncRow } from "./fixture";
+
+vi.mock("@tanstack/react-router", () => ({
+	Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+		<a href={to}>{children}</a>
+	),
+}));
+
+describe("server rendering", () => {
+	test("the numbers, the rows and the watermark all arrive complete", () => {
+		const html = renderToString(
+			<PulseBand band={band({ rows: [syncRow()] })} variant="landing" />,
+		);
+
+		expect(html).toContain("+512M");
+		// Uppercased by CSS, so the markup carries the words as written.
+		expect(html).toContain("tokens measured");
+		expect(html).toContain("596");
+		expect(html).toContain("AI Stack");
+		expect(html).toContain("measured usage moved");
+		// The watermark is a real path, not a wrapper waiting to be measured.
+		expect(html).toContain("<path");
+	});
+
+	test("relative time ships as words and as a machine-readable moment", () => {
+		const html = renderToString(
+			<PulseBand band={band({ rows: [syncRow()] })} variant="landing" />,
+		);
+		expect(html).toContain("<time");
+		expect(html).toContain("ago");
+	});
+});

--- a/src/features/activity/feed.ts
+++ b/src/features/activity/feed.ts
@@ -50,11 +50,14 @@ export function fmtCount(n: number): string {
 export function relativeLabel(at: number, now: number): string {
 	const ms = Math.max(0, now - at);
 	if (ms < MINUTE_MS) return "just now";
-	if (ms < HOUR_MS) return `${Math.round(ms / MINUTE_MS)}m ago`;
-	if (ms < DAY_MS) return `${Math.round(ms / HOUR_MS)}h ago`;
-	const days = ms / DAY_MS;
-	if (days < 7) return `${Math.round(days)}d ago`;
-	return `${Math.round(days / 7)}w ago`;
+	// FLOOR, never round. Rounding overstates age at every boundary — it prints
+	// "60m ago" instead of "1h ago", and it puts "2d ago" on a row the day
+	// kicker above it calls YESTERDAY.
+	if (ms < HOUR_MS) return `${Math.floor(ms / MINUTE_MS)}m ago`;
+	if (ms < DAY_MS) return `${Math.floor(ms / HOUR_MS)}h ago`;
+	const days = Math.floor(ms / DAY_MS);
+	if (days < 7) return `${days}d ago`;
+	return `${Math.floor(days / 7)}w ago`;
 }
 
 /** The calendar kicker over a group of rows: TODAY, YESTERDAY, WED 05 AUG. */

--- a/src/features/activity/feed.ts
+++ b/src/features/activity/feed.ts
@@ -1,0 +1,124 @@
+import type { FunctionReturnType } from "convex/server";
+import type { api } from "../../../convex/_generated/api";
+
+/**
+ * The activity feed's read model, exactly as Convex returns it, plus the
+ * formatters both surfaces share.
+ *
+ * The server owns every figure and every exclusion. This module only decides
+ * how a figure reads on screen — and the row GRAMMAR, which #84 locked:
+ * movement leads, the total is demoted, the stack name is the link.
+ */
+
+export type Band = FunctionReturnType<typeof api.activityFeed.band>;
+export type Stream = FunctionReturnType<typeof api.activityFeed.stream>;
+export type FeedRow = Band["rows"][number];
+export type DayPoint = Band["points"][number];
+export type FeedFilter =
+	| "all"
+	| NonNullable<Stream["rows"][number]["event"]>["type"];
+
+export const MONO_LABEL =
+	"font-mono text-[11px] font-semibold uppercase tracking-[0.25em]";
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+/** Short scale, two decimals at billions where the difference is money. */
+export function fmtTokens(n: number): string {
+	const abs = Math.abs(n);
+	if (abs >= 1e9) return `${(n / 1e9).toFixed(2)}B`;
+	if (abs >= 1e6) return `${(n / 1e6).toFixed(0)}M`;
+	if (abs >= 1e3) return `${(n / 1e3).toFixed(0)}K`;
+	return String(n);
+}
+
+/** A movement always carries its sign, because a fall is real (#84). */
+export function fmtDelta(n: number): string {
+	return `${n >= 0 ? "+" : "−"}${fmtTokens(Math.abs(n))}`;
+}
+
+export function fmtCount(n: number): string {
+	return n.toLocaleString("en-US");
+}
+
+/**
+ * Relative time. The feed lives or dies on this feeling true, so it is computed
+ * against a clock that ticks — never baked into the HTML and left there.
+ */
+export function relativeLabel(at: number, now: number): string {
+	const ms = Math.max(0, now - at);
+	if (ms < MINUTE_MS) return "just now";
+	if (ms < HOUR_MS) return `${Math.round(ms / MINUTE_MS)}m ago`;
+	if (ms < DAY_MS) return `${Math.round(ms / HOUR_MS)}h ago`;
+	const days = ms / DAY_MS;
+	if (days < 7) return `${Math.round(days)}d ago`;
+	return `${Math.round(days / 7)}w ago`;
+}
+
+/** The calendar kicker over a group of rows: TODAY, YESTERDAY, WED 05 AUG. */
+export function dayBucket(at: number, now: number): string {
+	const startOf = (ms: number) => {
+		const d = new Date(ms);
+		return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+	};
+	const daysBack = Math.round((startOf(now) - startOf(at)) / DAY_MS);
+	if (daysBack === 0) return "TODAY";
+	if (daysBack === 1) return "YESTERDAY";
+	// `WED 05 AUG`, assembled part by part: the locale's own short date puts a
+	// comma in ("Wed, Aug 05") and orders it the other way.
+	const d = new Date(at);
+	const weekday = d.toLocaleDateString("en-US", { weekday: "short" });
+	const month = d.toLocaleDateString("en-US", { month: "short" });
+	const day = String(d.getDate()).padStart(2, "0");
+	return `${weekday} ${day} ${month}`.toUpperCase();
+}
+
+const HARNESS_LABELS: Record<string, string> = {
+	"claude-code": "Claude Code",
+	codex: "Codex",
+};
+
+/** Wire names in words. An unknown harness keeps its wire spelling. */
+export function harnessLabel(name: string): string {
+	return HARNESS_LABELS[name] ?? name;
+}
+
+export function harnessList(names: readonly string[]): string {
+	const labels = names.map(harnessLabel);
+	if (labels.length <= 1) return labels[0] ?? "";
+	return `${labels.slice(0, -1).join(", ")} + ${labels[labels.length - 1]}`;
+}
+
+/**
+ * Days the watermark actually has a reading for. Below three there is no shape
+ * to draw, so the band drops the watermark rather than drawing a straight line
+ * through days nobody measured (#80, #84).
+ */
+export function liveDays(points: readonly DayPoint[]): number {
+	return points.filter((p) => p.value > 0).length;
+}
+
+/** Total tokens a sync reported, summed over the harnesses in its batch. */
+export function syncTokens(row: FeedRow): number {
+	if (row.event.type !== "sync.landed") return 0;
+	return row.event.harnesses.reduce((sum, h) => sum + h.totalTokens, 0);
+}
+
+/**
+ * The facts under a sync row — EVENT-ONLY, all three of them (#84, #96).
+ * Anything richer needs the snapshot join, and the band already pays for that
+ * once; paying per row turns a four-row strip into forty document reads.
+ */
+export function syncFacts(row: FeedRow): string[] {
+	if (row.event.type !== "sync.landed") return [];
+	const harnesses = row.event.harnesses;
+	const sessions = harnesses.reduce((sum, h) => sum + h.sessions, 0);
+	const windowDays = harnesses[0]?.windowDays ?? 30;
+	return [
+		harnessList(harnesses.map((h) => h.harness)),
+		`${fmtTokens(syncTokens(row))} over ${windowDays} days`,
+		`${fmtCount(sessions)} ${sessions === 1 ? "session" : "sessions"}`,
+	];
+}

--- a/src/features/landing/LandingPageShell.tsx
+++ b/src/features/landing/LandingPageShell.tsx
@@ -1,4 +1,6 @@
 import { GridBackground } from "@/components/GridBackground";
+import type { Band } from "@/features/activity/feed";
+import { PulseBand } from "@/features/activity/PulseBand";
 import { ExplainerSection } from "@/features/landing/sections/ExplainerSection";
 import {
 	FeaturedStacksSection,
@@ -10,13 +12,20 @@ import { PublishCTASection } from "@/features/landing/sections/PublishCTASection
 type LandingPageShellProps = {
 	stacks: LandingStackPreview[];
 	me?: { handle: string; hasStack: boolean } | null;
+	band?: Band | null;
 };
 
-function LandingPageShell({ stacks, me }: LandingPageShellProps) {
+function LandingPageShell({ stacks, me, band }: LandingPageShellProps) {
 	return (
 		<div className="min-h-screen bg-bg-canvas">
 			<GridBackground />
 			<HeroSection />
+			{/* The pulse sits between the hero and the featured stacks (#84). A site
+			    with nothing to report shows no band at all — four em dashes under a
+			    live dot is a claim about nothing. */}
+			{band && band.rows.length > 0 ? (
+				<PulseBand band={band} variant="landing" />
+			) : null}
 			<FeaturedStacksSection stacks={stacks} />
 			<ExplainerSection />
 			<PublishCTASection me={me} />

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as LeaderboardRouteImport } from './routes/leaderboard'
 import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
 import { Route as AuthCallbackRouteImport } from './routes/auth-callback'
 import { Route as AdminRouteImport } from './routes/admin'
+import { Route as ActivityRouteImport } from './routes/activity'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as CreatorRouteImport } from './routes/$creator'
 import { Route as IndexRouteImport } from './routes/index'
@@ -96,6 +97,11 @@ const AuthCallbackRoute = AuthCallbackRouteImport.update({
 const AdminRoute = AdminRouteImport.update({
   id: '/admin',
   path: '/admin',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ActivityRoute = ActivityRouteImport.update({
+  id: '/activity',
+  path: '/activity',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AboutRoute = AboutRouteImport.update({
@@ -243,6 +249,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$creator': typeof CreatorRoute
   '/about': typeof AboutRoute
+  '/activity': typeof ActivityRoute
   '/admin': typeof AdminRoute
   '/auth-callback': typeof AuthCallbackRoute
   '/forgot-password': typeof ForgotPasswordRoute
@@ -283,6 +290,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$creator': typeof CreatorRoute
   '/about': typeof AboutRoute
+  '/activity': typeof ActivityRoute
   '/admin': typeof AdminRoute
   '/auth-callback': typeof AuthCallbackRoute
   '/forgot-password': typeof ForgotPasswordRoute
@@ -324,6 +332,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/$creator': typeof CreatorRoute
   '/about': typeof AboutRoute
+  '/activity': typeof ActivityRoute
   '/admin': typeof AdminRoute
   '/auth-callback': typeof AuthCallbackRoute
   '/forgot-password': typeof ForgotPasswordRoute
@@ -366,6 +375,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$creator'
     | '/about'
+    | '/activity'
     | '/admin'
     | '/auth-callback'
     | '/forgot-password'
@@ -406,6 +416,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$creator'
     | '/about'
+    | '/activity'
     | '/admin'
     | '/auth-callback'
     | '/forgot-password'
@@ -446,6 +457,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$creator'
     | '/about'
+    | '/activity'
     | '/admin'
     | '/auth-callback'
     | '/forgot-password'
@@ -487,6 +499,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   CreatorRoute: typeof CreatorRoute
   AboutRoute: typeof AboutRoute
+  ActivityRoute: typeof ActivityRoute
   AdminRoute: typeof AdminRoute
   AuthCallbackRoute: typeof AuthCallbackRoute
   ForgotPasswordRoute: typeof ForgotPasswordRoute
@@ -593,6 +606,13 @@ declare module '@tanstack/react-router' {
       path: '/admin'
       fullPath: '/admin'
       preLoaderRoute: typeof AdminRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/activity': {
+      id: '/activity'
+      path: '/activity'
+      fullPath: '/activity'
+      preLoaderRoute: typeof ActivityRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/about': {
@@ -810,6 +830,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   CreatorRoute: CreatorRoute,
   AboutRoute: AboutRoute,
+  ActivityRoute: ActivityRoute,
   AdminRoute: AdminRoute,
   AuthCallbackRoute: AuthCallbackRoute,
   ForgotPasswordRoute: ForgotPasswordRoute,

--- a/src/routes/activity.tsx
+++ b/src/routes/activity.tsx
@@ -1,0 +1,79 @@
+import { convexQuery } from "@convex-dev/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { useQuery } from "convex/react";
+import { useMemo, useRef, useState } from "react";
+import { ActivityPage } from "@/features/activity/ActivityPage";
+import type { FeedFilter } from "@/features/activity/feed";
+import { seoMeta } from "@/lib/seo";
+import { api } from "../../convex/_generated/api";
+
+/**
+ * `/activity` — the whole stream behind the landing band's "all activity"
+ * button (#96), sibling of `/leaderboard`.
+ *
+ * The loader returns both reads, so the first HTML carries the band and the
+ * first page of rows. The component upgrades to the live subscription once
+ * mounted: new events arrive without a reload, and nothing reorders under the
+ * reader.
+ */
+
+export const Route = createFileRoute("/activity")({
+	component: Activity,
+	loader: async ({ context }) => {
+		const [band, stream] = await Promise.all([
+			context.queryClient.ensureQueryData(
+				convexQuery(api.activityFeed.band, {}),
+			),
+			context.queryClient.ensureQueryData(
+				convexQuery(api.activityFeed.stream, {}),
+			),
+		]);
+		return { band, stream };
+	},
+	head: () => ({
+		meta: seoMeta({
+			title: "Activity - Syncs, New Stacks and Changes as They Land",
+			description:
+				"Every sync, new stack and composition change across published AI stacks, newest first — with the measured tokens, sessions and projects of the last 24 hours.",
+			url: "/activity",
+			keywords:
+				"AI stack activity, developer tool changes, measured usage, Claude Code, Codex",
+		}),
+	}),
+});
+
+function Activity() {
+	const { band: loadedBand, stream: loadedStream } = Route.useLoaderData();
+	const [filter, setFilter] = useState<FeedFilter>("all");
+	const [limit, setLimit] = useState<number | undefined>(undefined);
+
+	const band = useQuery(api.activityFeed.band, {}) ?? loadedBand;
+	const live = useQuery(api.activityFeed.stream, {
+		...(limit === undefined ? {} : { limit }),
+		...(filter === "all" ? {} : { type: filter }),
+	});
+	// Hold the last answer while a chip or an "older" press is in flight, so the
+	// stream does not blink through an empty list on the way to its next state.
+	const held = useRef(loadedStream);
+	if (live !== undefined) held.current = live;
+	const stream = live ?? held.current;
+
+	// One clock per mount: the day kickers must not disagree between rows.
+	const nowMs = useMemo(() => Date.now(), []);
+
+	return (
+		<ActivityPage
+			band={band}
+			stream={stream}
+			filter={filter}
+			nowMs={nowMs}
+			onFilter={(next) => {
+				setFilter(next);
+				setLimit(undefined);
+			}}
+			onOlder={() =>
+				setLimit((current) => (current ?? stream.pageSize) + stream.pageSize)
+			}
+		/>
+	);
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -31,10 +31,19 @@ export const Route = createFileRoute("/")({
 		page: coercePage(search.page),
 	}),
 	search: { middlewares: [stripSearchParams(LANDING_SEARCH_DEFAULTS)] },
+	// The band ships in the first HTML like the featured stacks do: the pulse is
+	// what a first-time visitor reads above the fold, and it should not wait for
+	// a hydrated client.
 	loader: async ({ context }) => {
-		await context.queryClient.ensureQueryData(
-			convexQuery(api.stacks.listPublished, {}),
-		);
+		const [, band] = await Promise.all([
+			context.queryClient.ensureQueryData(
+				convexQuery(api.stacks.listPublished, {}),
+			),
+			context.queryClient.ensureQueryData(
+				convexQuery(api.activityFeed.band, {}),
+			),
+		]);
+		return { band };
 	},
 	head: () => ({
 		meta: seoMeta({
@@ -52,6 +61,8 @@ function IndexRoute() {
 	const stacks = (useQuery(api.stacks.listPublished) ??
 		[]) as LandingStackPreview[];
 	const me = useQuery(api.creators.getMe);
+	const { band: loadedBand } = Route.useLoaderData();
+	const band = useQuery(api.activityFeed.band, {}) ?? loadedBand;
 
 	return (
 		<>
@@ -62,7 +73,7 @@ function IndexRoute() {
 						"Explore the AI stacks indie builders run in production. Compare tools, costs, and workflows.",
 				}}
 			/>
-			<LandingPageShell stacks={stacks} me={me} />
+			<LandingPageShell stacks={stacks} me={me} band={band} />
 		</>
 	);
 }


### PR DESCRIPTION
Ticket: alp82/aistack#85 — [Task: build the global activity feed](https://github.com/alp82/aistack/issues/85)

Adds one comment stating the band's read bound where it is set: past `MAX_ROWS` events the watermark loses its oldest days, never the 24-hour claim.

---

Dispatched by the curia daemon — session `curia-85`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `e2868bd` docs(activity): state the band's read bound where it is set (#85)
- `a8e7b16` fix(activity): relative time floors, so it never overstates an age (#85)
- `1860456` feat(activity): the global activity feed — band and /activity page (#85)