### PR TITLE
Task: web — the auto-sync switch in the owner box (alp82/aistack#104)

### DIFF
--- a/convex/autoSync.test.ts
+++ b/convex/autoSync.test.ts
@@ -547,3 +547,53 @@ test('nobody but the owner reads or writes the schedule', async () => {
     t.mutation(api.autoSync.set, { stackId, enabled: true }),
   ).rejects.toThrow()
 })
+
+/**
+ * The done-bar of #104, end to end: a revoke made FROM THE WEB stops the next
+ * `--auto` publish.
+ *
+ * The pieces exist separately — #102 proved the 409 against a flag patched
+ * straight into the row, and the owner's setter against a query. This joins
+ * them, because the switch is only a revoke if the mutation it calls is the one
+ * the wire refuses on. It also checks what the machine itself is told, since
+ * #103's client-side gate reads `sync-config` and not this route's status.
+ */
+test('a revoke from the web stops the next automatic publish', async () => {
+  const t = convexTest(schema, modules)
+  const { stackId, tokenId, bearer, asCreator } = await seedStack(t, 'web1')
+
+  await asCreator.mutation(api.autoSync.set, { stackId, enabled: true })
+  const landed = await t.mutation(internal.measured.publishForToken, {
+    tokenId,
+    payloads: [payload('claude-code', 1)],
+    trigger: 'auto',
+  })
+
+  // The owner flips the switch off in the browser.
+  await asCreator.mutation(api.autoSync.set, { stackId, enabled: false })
+
+  // A machine whose hook is still installed fires anyway (#103: stale hooks).
+  const res = await asMachine(t, bearer).post('/api/cli/sync', {
+    payloads: [payload('claude-code', 2)],
+    trigger: 'auto',
+  })
+  expect(res.status).toBe(409)
+
+  // Nothing new was stored, and the reading from before the revoke is intact:
+  // a revoke takes the permission, never the record.
+  const snapshots = await t.run((ctx: MutationCtx) =>
+    ctx.db.query('measuredSnapshots').collect(),
+  )
+  expect(snapshots).toHaveLength(1)
+  expect(await asCreator.query(api.autoSync.get, { stackId })).toEqual({
+    autoSync: { enabled: false, frequencyHours: 24 },
+    lastAutoSyncAt: landed.receivedAt,
+  })
+
+  // And the machine's own gate sees the off, so #103 exits before it publishes.
+  const config = await asMachine(t, bearer).get('/api/cli/sync-config')
+  expect((await config.json()).autoSync).toEqual({
+    enabled: false,
+    frequencyHours: 24,
+  })
+})

--- a/src/features/measured/AutoSyncBox.tsx
+++ b/src/features/measured/AutoSyncBox.tsx
@@ -1,0 +1,154 @@
+import { useMutation, useQuery } from "convex/react";
+import { useState } from "react";
+import { BrutalistSelect } from "@/components/ui/brutalist-select";
+import { BrutalistToggle } from "@/components/ui/brutalist-toggle";
+import { cn, timeAgo } from "@/lib/utils";
+import { api } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
+import {
+	autoSyncState,
+	frequencyChoices,
+	frequencyLabel,
+	NEVER_FIRED_FIX,
+	NEVER_FIRED_LINE,
+	OFF_LINE,
+	OFF_REVOKE_NOTE,
+	ON_NOTE,
+	runningLine,
+	SWITCH_TITLE,
+} from "./autoSync";
+import { CommandBlock } from "./CommandLine";
+import { MONO_LABEL, SYNC_CMD } from "./copy";
+
+/**
+ * The auto-sync switch in the owner box (#104, map #76, from #100 decision 5).
+ *
+ * The permission used to live on the machine that turned it on, so "stop
+ * publishing on a timer" was a sentence only that machine could say. #102 moved
+ * it onto the stack. This box is where the owner says it, from any browser.
+ *
+ * OWNER-ONLY, AND SKIPPED FOR EVERYONE ELSE. `autoSync.get` refuses a
+ * non-owner, so asking it from a public page would be a thrown query on every
+ * visitor's render. The gate is the argument, not a hidden element: a visitor's
+ * HTML carries no box and no schedule.
+ *
+ * OFF IS A COMPLETE REVOKE, and the box says what a revoke leaves behind. Hooks
+ * are dumb local triggers. They keep firing on machines this browser has never
+ * seen, and #102 refuses what they send, so the honest sentence is "they
+ * publish nothing" and not "remove them".
+ */
+export function AutoSyncBox({
+	stackId,
+	isOwner,
+}: {
+	stackId: Id<"stacks">;
+	isOwner: boolean;
+}) {
+	const flag = useQuery(api.autoSync.get, isOwner ? { stackId } : "skip");
+	const set = useMutation(api.autoSync.set);
+	const [saving, setSaving] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	// Undefined is "not answered yet". Drawing off before the server has spoken
+	// tells the owner their automation is revoked while it is still running.
+	if (!isOwner || flag === undefined) return null;
+
+	const state = autoSyncState(flag);
+	const on = state.kind !== "off";
+	// An off stack still remembers its interval, and the switch sends what it is
+	// showing — turning automation back on must not move a machine that chose six
+	// hours onto the default.
+	const hours = flag.autoSync?.frequencyHours ?? 24;
+
+	async function write(enabled: boolean, frequencyHours: number) {
+		setSaving(true);
+		setError(null);
+		try {
+			await set({ stackId, enabled, frequencyHours });
+		} catch (e) {
+			setError(e instanceof Error ? e.message : "Could not save that.");
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	return (
+		<div className="mt-10 border border-stroke-strong bg-bg-panel px-6 py-6 md:px-8">
+			<div className="flex flex-wrap items-center justify-between gap-4">
+				<div>
+					<p className={cn(MONO_LABEL, "text-fg-muted")}>{SWITCH_TITLE}</p>
+					<p className="mt-2 text-sm text-fg-primary">
+						{state.kind === "off" ? (
+							OFF_LINE
+						) : state.kind === "running" ? (
+							<>
+								{runningLine(state.frequencyHours)}{" "}
+								<span className="text-fg-muted">
+									Last automatic sync {timeAgo(state.at)}.
+								</span>
+							</>
+						) : (
+							<>
+								{runningLine(state.frequencyHours)}{" "}
+								<span className="text-fg-muted">{NEVER_FIRED_LINE}</span>
+							</>
+						)}
+					</p>
+				</div>
+				<div className="flex items-center gap-3">
+					{on && (
+						<BrutalistSelect
+							size="sm"
+							className="w-40"
+							value={String(hours)}
+							options={frequencyChoices(hours).map((h) => ({
+								value: String(h),
+								label: frequencyLabel(h),
+							}))}
+							onChange={(v) => write(true, Number(v))}
+						/>
+					)}
+					<BrutalistToggle
+						size="sm"
+						value={on ? "on" : "off"}
+						options={[
+							{ value: "off", label: "off" },
+							{ value: "on", label: "on" },
+						]}
+						onChange={(v) => write(v === "on", hours)}
+					/>
+				</div>
+			</div>
+
+			{state.kind === "off" && (
+				<p className="mt-3 max-w-prose text-xs leading-relaxed text-fg-muted">
+					{OFF_REVOKE_NOTE}
+				</p>
+			)}
+
+			{state.kind === "never-fired" && (
+				<div className="mt-4 max-w-xl">
+					<p className="mb-3 max-w-prose text-xs leading-relaxed text-fg-muted">
+						{NEVER_FIRED_FIX}
+					</p>
+					<CommandBlock commands={[{ cmd: SYNC_CMD, comment: "once" }]} />
+				</div>
+			)}
+
+			{state.kind === "running" && (
+				<p className="mt-3 max-w-prose text-xs leading-relaxed text-fg-muted">
+					{ON_NOTE}
+				</p>
+			)}
+
+			{saving && (
+				<p className={cn(MONO_LABEL, "mt-3 text-fg-muted")}>saving…</p>
+			)}
+			{error && (
+				<p className="mt-3 text-xs text-destructive" role="alert">
+					{error}
+				</p>
+			)}
+		</div>
+	);
+}

--- a/src/features/measured/AutoSyncNote.tsx
+++ b/src/features/measured/AutoSyncNote.tsx
@@ -1,0 +1,36 @@
+import { Link } from "@tanstack/react-router";
+import { ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { SWITCH_TITLE } from "./autoSync";
+import { MONO_LABEL } from "./copy";
+
+/**
+ * What `/sync` says about auto-sync (#104).
+ *
+ * A MENTION, NOT A SECOND CONTROL. The permission belongs to one stack (#102),
+ * and this page has no stack in hand. It names the switch, says where it is and
+ * what it does, and leaves the acting to the owner box.
+ */
+export function AutoSyncNote() {
+	return (
+		<div className="mt-14 border border-stroke-strong bg-bg-panel px-6 py-6">
+			<p className={cn(MONO_LABEL, "text-accent-lime")}>{SWITCH_TITLE}</p>
+			<p className="mt-3 max-w-xl text-sm text-fg-primary">
+				Your stack can also publish on a schedule, when a session starts on a
+				machine you have linked.
+			</p>
+			<p className="mt-2 max-w-xl text-sm text-fg-muted">
+				The switch is on your own stack page, above the numbers it keeps
+				current. It is the one place this is decided, so you can turn it off
+				from any browser, and the machines stop publishing even when their
+				triggers keep firing.
+			</p>
+			<Link
+				to="/stacks"
+				className="mt-4 inline-flex items-center gap-2 font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent-lime"
+			>
+				find your stack <ArrowRight size={12} />
+			</Link>
+		</div>
+	);
+}

--- a/src/features/measured/MeasuredSection.tsx
+++ b/src/features/measured/MeasuredSection.tsx
@@ -4,6 +4,8 @@ import { ArrowRight } from "lucide-react";
 import { Section, SectionHeader } from "@/features/stack-view/ui";
 import { cn, timeAgo } from "@/lib/utils";
 import { api } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
+import { AutoSyncBox } from "./AutoSyncBox";
 import { CommandBlock } from "./CommandLine";
 import {
 	coverageCaveat,
@@ -63,10 +65,12 @@ import { ModelShareRows } from "./ModelShareRows";
 export function MeasuredSection({
 	index,
 	slug,
+	stackId,
 	isOwner,
 }: {
 	index: number;
 	slug: string;
+	stackId: Id<"stacks">;
 	isOwner: boolean;
 }) {
 	const snapshot = useQuery(api.measured.getCurrentByStackSlug, { slug });
@@ -91,6 +95,11 @@ export function MeasuredSection({
 			) : (
 				<Reading snapshot={snapshot} points={history?.points ?? []} />
 			)}
+			{/* The owner box (#104). It sits inside the section it governs —
+			    automation is what keeps this reading arriving — and it does NOT
+			    wait for a reading, because it is the fix for a stack that has
+			    none. Renders nothing for a visitor, query and all. */}
+			<AutoSyncBox stackId={stackId} isOwner={isOwner} />
 		</Section>
 	);
 }

--- a/src/features/measured/__tests__/auto-sync-box.test.tsx
+++ b/src/features/measured/__tests__/auto-sync-box.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+/**
+ * The auto-sync switch in the owner box (#104, map #76).
+ *
+ * The decisions these tests guard, rather than layout:
+ *
+ *   1. STRICTLY OWNER-ONLY. The pair says when this person's machines run — a
+ *      schedule nobody else has a reason to read. A visitor's render carries no
+ *      box, and the query is never even asked.
+ *   2. THREE HONEST STATES, from the pair and not from the flag alone. On with
+ *      no stamp says so and names the one command that closes it.
+ *   3. AN UNANSWERED QUERY IS NOT OFF. Drawing "off" before the server has
+ *      spoken tells the owner their automation is revoked when it is running.
+ *   4. OFF IS A COMPLETE REVOKE, and the box says what that leaves behind:
+ *      hooks on machines keep firing and publish nothing (#103).
+ *   5. THE INTERVAL RIDES WITH THE FLAG. Editing it never turns automation off.
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { getFunctionName } from "convex/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../../../convex/_generated/api";
+import { AutoSyncBox } from "../AutoSyncBox";
+import type { AutoSyncFlag } from "../autoSync";
+
+type SetArgs = {
+	stackId: string;
+	enabled: boolean;
+	frequencyHours?: number;
+};
+
+const queryMock = vi.fn();
+const setMock = vi.fn((_args: SetArgs) => Promise.resolve());
+
+vi.mock("convex/react", () => ({
+	useQuery: (ref: unknown, args: unknown) => queryMock(ref, args),
+	useMutation: () => setMock,
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+	Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+		<a href={to}>{children}</a>
+	),
+}));
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+const STACK_ID = "stack_abc" as never;
+
+function setup(
+	flag: AutoSyncFlag | undefined,
+	{ isOwner = true }: { isOwner?: boolean } = {},
+) {
+	queryMock.mockReturnValue(flag);
+	render(<AutoSyncBox stackId={STACK_ID} isOwner={isOwner} />);
+}
+
+/** The last argument the switch handed `autoSync.set`. */
+function lastSet(): SetArgs | undefined {
+	return setMock.mock.calls.at(-1)?.[0];
+}
+
+describe("the owner gate", () => {
+	it("renders nothing for a visitor", () => {
+		setup(
+			{ autoSync: { enabled: true, frequencyHours: 24 }, lastAutoSyncAt: 1 },
+			{
+				isOwner: false,
+			},
+		);
+		expect(screen.queryByText(/auto-sync/i)).toBeNull();
+	});
+
+	it("never asks for the schedule as a visitor", () => {
+		setup(undefined, { isOwner: false });
+		expect(queryMock).toHaveBeenCalledWith(expect.anything(), "skip");
+	});
+
+	it("asks for this stack's schedule as the owner", () => {
+		setup(undefined);
+		const [ref, args] = queryMock.mock.calls[0];
+		expect(getFunctionName(ref)).toBe(getFunctionName(api.autoSync.get));
+		expect(args).toEqual({ stackId: STACK_ID });
+	});
+
+	it("renders nothing until the query has answered", () => {
+		setup(undefined);
+		expect(screen.queryByText(/auto-sync/i)).toBeNull();
+	});
+});
+
+describe("the three states", () => {
+	it("draws off for a stack no owner has decided on", () => {
+		setup({ autoSync: null, lastAutoSyncAt: null });
+		expect(screen.getByText(/auto-sync/i)).toBeTruthy();
+		expect(
+			screen.getByText(/only a sync you run yourself publishes/i),
+		).toBeTruthy();
+	});
+
+	it("says a revoke leaves stale hooks publishing nothing", () => {
+		setup({
+			autoSync: { enabled: false, frequencyHours: 24 },
+			lastAutoSyncAt: 1,
+		});
+		expect(screen.getByText(/publish nothing/i)).toBeTruthy();
+	});
+
+	it("dates the last automatic sync when one has fired", () => {
+		setup({
+			autoSync: { enabled: true, frequencyHours: 24 },
+			lastAutoSyncAt: Date.now() - 2 * 60 * 60 * 1000,
+		});
+		expect(screen.getByText(/last automatic sync/i)).toBeTruthy();
+		expect(screen.getByText(/2h ago/)).toBeTruthy();
+	});
+
+	it("admits when no machine has synced automatically yet", () => {
+		setup({
+			autoSync: { enabled: true, frequencyHours: 24 },
+			lastAutoSyncAt: null,
+		});
+		expect(
+			screen.getByText(/no machine has synced automatically yet/i),
+		).toBeTruthy();
+	});
+
+	it("names the one command that closes the never-fired state", () => {
+		setup({
+			autoSync: { enabled: true, frequencyHours: 24 },
+			lastAutoSyncAt: null,
+		});
+		expect(screen.getByText("npx @use-aistack/cli sync")).toBeTruthy();
+	});
+
+	it("does not name that command once automation is working", () => {
+		setup({
+			autoSync: { enabled: true, frequencyHours: 24 },
+			lastAutoSyncAt: Date.now() - 1000,
+		});
+		expect(screen.queryByText("npx @use-aistack/cli sync")).toBeNull();
+	});
+});
+
+describe("the switch", () => {
+	it("turns automation on", () => {
+		setup({ autoSync: null, lastAutoSyncAt: null });
+		fireEvent.click(screen.getByRole("button", { name: /^on$/i }));
+		expect(lastSet()).toMatchObject({ stackId: STACK_ID, enabled: true });
+	});
+
+	it("turns automation off", () => {
+		setup({
+			autoSync: { enabled: true, frequencyHours: 24 },
+			lastAutoSyncAt: null,
+		});
+		fireEvent.click(screen.getByRole("button", { name: /^off$/i }));
+		expect(lastSet()).toMatchObject({ stackId: STACK_ID, enabled: false });
+	});
+
+	// The stored interval is a schedule the owner chose. Turning automation back
+	// on must not silently move a machine that chose six hours onto the default,
+	// so the switch sends what it is showing.
+	it("keeps the stored interval when it turns automation back on", () => {
+		setup({
+			autoSync: { enabled: false, frequencyHours: 6 },
+			lastAutoSyncAt: null,
+		});
+		fireEvent.click(screen.getByRole("button", { name: /^on$/i }));
+		expect(lastSet()).toMatchObject({ enabled: true, frequencyHours: 6 });
+	});
+});
+
+describe("the interval", () => {
+	function openTheSelect() {
+		fireEvent.click(screen.getByRole("button", { name: /every day/i }));
+	}
+
+	it("is editable while automation is on", () => {
+		setup({
+			autoSync: { enabled: true, frequencyHours: 24 },
+			lastAutoSyncAt: null,
+		});
+		openTheSelect();
+		fireEvent.click(screen.getByRole("button", { name: /every 6 hours/i }));
+		expect(lastSet()).toMatchObject({ enabled: true, frequencyHours: 6 });
+	});
+
+	it("is not offered while automation is off", () => {
+		setup({
+			autoSync: { enabled: false, frequencyHours: 24 },
+			lastAutoSyncAt: null,
+		});
+		expect(screen.queryByRole("button", { name: /every day/i })).toBeNull();
+	});
+});

--- a/src/features/measured/__tests__/auto-sync-note.test.tsx
+++ b/src/features/measured/__tests__/auto-sync-note.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+/**
+ * What `/sync` says about the switch (#104).
+ *
+ * The guide page teaches the command. The switch is a permission on ONE stack,
+ * and `/sync` is a page about syncing in general — it has no stack to act on.
+ * So it points at the switch and stops. A second copy of the control here would
+ * be a second place the permission appears to live, which is the exact problem
+ * #102 moved the flag onto the stack to end.
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AutoSyncNote } from "../AutoSyncNote";
+
+vi.mock("@tanstack/react-router", () => ({
+	Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+		<a href={to}>{children}</a>
+	),
+}));
+
+afterEach(cleanup);
+
+describe("the /sync note", () => {
+	it("names auto-sync and where its switch is", () => {
+		render(<AutoSyncNote />);
+		expect(screen.getByText(/auto-sync/i)).toBeTruthy();
+		expect(screen.getByText(/stack page/i)).toBeTruthy();
+	});
+
+	it("says the switch is what turns it off, from any browser", () => {
+		render(<AutoSyncNote />);
+		expect(document.body.textContent).toMatch(/turn it off/i);
+	});
+
+	it("duplicates no control", () => {
+		render(<AutoSyncNote />);
+		expect(screen.queryAllByRole("button")).toHaveLength(0);
+		expect(screen.queryAllByRole("switch")).toHaveLength(0);
+		expect(screen.queryAllByRole("checkbox")).toHaveLength(0);
+	});
+});

--- a/src/features/measured/__tests__/auto-sync.test.ts
+++ b/src/features/measured/__tests__/auto-sync.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The auto-sync switch's three honest states (#104, map #76, from #100
+ * decision 5).
+ *
+ * The switch renders from the PAIR the server keeps (#102): the flag and the
+ * newest automatic-sync stamp. The stamp survives a revoke, because it records
+ * what happened and a revoke only takes the permission away. So the flag alone
+ * cannot say whether automation is working, and the pair can:
+ *
+ *   off          — nobody decided, or the owner said no.
+ *   never-fired  — on, and no machine has ever fired one.
+ *   running      — on, and a machine fired one at this time.
+ */
+import { describe, expect, it } from "vitest";
+import { autoSyncState, frequencyChoices, frequencyLabel } from "../autoSync";
+
+describe("autoSyncState", () => {
+	it("reads an absent flag as off", () => {
+		expect(autoSyncState({ autoSync: null, lastAutoSyncAt: null })).toEqual({
+			kind: "off",
+		});
+	});
+
+	it("reads an explicit false as off", () => {
+		expect(
+			autoSyncState({
+				autoSync: { enabled: false, frequencyHours: 6 },
+				lastAutoSyncAt: null,
+			}),
+		).toEqual({ kind: "off" });
+	});
+
+	// A revoke takes the permission, never the record. The box must not claim
+	// automation is running because a stamp from last week is still stored.
+	it("stays off when a stamp outlives the revoke", () => {
+		expect(
+			autoSyncState({
+				autoSync: { enabled: false, frequencyHours: 24 },
+				lastAutoSyncAt: 1_700_000_000_000,
+			}),
+		).toEqual({ kind: "off" });
+	});
+
+	it("reads on with no stamp as never-fired", () => {
+		expect(
+			autoSyncState({
+				autoSync: { enabled: true, frequencyHours: 6 },
+				lastAutoSyncAt: null,
+			}),
+		).toEqual({ kind: "never-fired", frequencyHours: 6 });
+	});
+
+	it("reads on with a stamp as running", () => {
+		expect(
+			autoSyncState({
+				autoSync: { enabled: true, frequencyHours: 12 },
+				lastAutoSyncAt: 1_700_000_000_000,
+			}),
+		).toEqual({
+			kind: "running",
+			frequencyHours: 12,
+			at: 1_700_000_000_000,
+		});
+	});
+});
+
+/**
+ * The interval the owner edits. A machine may already hold an interval this
+ * list never offers — the CLI took any number and #102 clamps to 1..168 — so
+ * the select has to be able to draw what is stored, or the box would silently
+ * misreport the schedule it is showing.
+ */
+describe("frequencyChoices", () => {
+	it("offers a rising list within the range the server allows", () => {
+		const hours = frequencyChoices(24);
+		expect(hours).toEqual([...hours].sort((a, b) => a - b));
+		expect(hours[0]).toBeGreaterThanOrEqual(1);
+		expect(hours[hours.length - 1]).toBeLessThanOrEqual(168);
+	});
+
+	it("offers the daily default", () => {
+		expect(frequencyChoices(24)).toContain(24);
+	});
+
+	it("keeps a stored interval it does not offer", () => {
+		expect(frequencyChoices(3)).toContain(3);
+	});
+
+	it("does not repeat a stored interval it already offers", () => {
+		const hours = frequencyChoices(24);
+		expect(hours.filter((h) => h === 24)).toHaveLength(1);
+	});
+});
+
+describe("frequencyLabel", () => {
+	it("says hours below a day", () => {
+		expect(frequencyLabel(6)).toBe("every 6 hours");
+	});
+
+	it("says one hour without a plural", () => {
+		expect(frequencyLabel(1)).toBe("every hour");
+	});
+
+	it("says a day rather than 24 hours", () => {
+		expect(frequencyLabel(24)).toBe("every day");
+	});
+
+	it("says days at a whole multiple of a day", () => {
+		expect(frequencyLabel(48)).toBe("every 2 days");
+	});
+
+	it("says a week at the top of the range", () => {
+		expect(frequencyLabel(168)).toBe("every week");
+	});
+});

--- a/src/features/measured/__tests__/measured-section.test.tsx
+++ b/src/features/measured/__tests__/measured-section.test.tsx
@@ -22,6 +22,7 @@ import { getFunctionName } from "convex/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MeasuredSection } from "@/features/measured/MeasuredSection";
 import { api } from "../../../../convex/_generated/api";
+import type { AutoSyncFlag } from "../autoSync";
 import type { MeasuredSnapshot } from "../copy";
 import type { MeasuredHistory } from "../history";
 import { DAY } from "./fixture";
@@ -31,6 +32,7 @@ const queryMock = vi.fn();
 
 vi.mock("convex/react", () => ({
 	useQuery: (ref: unknown, args: unknown) => queryMock(ref, args),
+	useMutation: () => vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -47,14 +49,26 @@ afterEach(() => {
 function setup(
 	snapshot: MeasuredSnapshot | null | undefined,
 	history: MeasuredHistory | null | undefined = null,
-	{ isOwner = false }: { isOwner?: boolean } = {},
+	{
+		isOwner = false,
+		autoSync = { autoSync: null, lastAutoSyncAt: null },
+	}: { isOwner?: boolean; autoSync?: AutoSyncFlag } = {},
 ) {
 	const historyRef = getFunctionName(api.measured.getHistoryByStackSlug);
-	queryMock.mockImplementation((ref: Parameters<typeof getFunctionName>[0]) =>
-		getFunctionName(ref) === historyRef ? history : snapshot,
-	);
+	const autoSyncRef = getFunctionName(api.autoSync.get);
+	queryMock.mockImplementation((ref: Parameters<typeof getFunctionName>[0]) => {
+		const name = getFunctionName(ref);
+		if (name === historyRef) return history;
+		if (name === autoSyncRef) return autoSync;
+		return snapshot;
+	});
 	render(
-		<MeasuredSection index={1} slug="alps-stack-ab12" isOwner={isOwner} />,
+		<MeasuredSection
+			index={1}
+			slug="alps-stack-ab12"
+			stackId={"stack_ab12" as never}
+			isOwner={isOwner}
+		/>,
 	);
 }
 
@@ -71,7 +85,9 @@ describe("the reading", () => {
 		expect(screen.getByText("4.70B")).toBeInTheDocument();
 		expect(screen.getByText("tokens · last 30 days")).toBeInTheDocument();
 		expect(screen.getByText("≥$6,014")).toBeInTheDocument();
-		expect(screen.getByText("at least, at api list prices")).toBeInTheDocument();
+		expect(
+			screen.getByText("at least, at api list prices"),
+		).toBeInTheDocument();
 	});
 
 	it("names the window as the thing that moves", () => {
@@ -325,6 +341,31 @@ describe("a stack that has never synced, seen by its owner", () => {
 			screen.queryByText("Your stack has not been measured yet."),
 		).not.toBeInTheDocument();
 		expect(screen.getByText("4.71B")).toBeInTheDocument();
+	});
+});
+
+/**
+ * The auto-sync switch (#104) lives in the owner box, inside the section it
+ * governs: automation is what keeps this reading arriving.
+ */
+describe("the auto-sync switch", () => {
+	it("reaches the owner of a stack that has readings", () => {
+		const { current, history } = live();
+		setup(current, history, { isOwner: true });
+		expect(screen.getByText("// auto-sync")).toBeInTheDocument();
+	});
+
+	// The switch is the fix for a stack with no readings, so it must not wait
+	// for the readings it exists to produce.
+	it("reaches the owner of a stack that has none", () => {
+		setup(null, null, { isOwner: true });
+		expect(screen.getByText("// auto-sync")).toBeInTheDocument();
+	});
+
+	it("is absent for a visitor", () => {
+		const { current, history } = live();
+		setup(current, history);
+		expect(screen.queryByText("// auto-sync")).not.toBeInTheDocument();
 	});
 });
 

--- a/src/features/measured/autoSync.ts
+++ b/src/features/measured/autoSync.ts
@@ -1,0 +1,100 @@
+/**
+ * The owner's auto-sync switch — its state machine and its words (#104, map
+ * #76, building #100 decision 5).
+ *
+ * The permission moved to the stack in #102. This file is the web half: it
+ * turns the pair the server keeps — `autoSync` and `lastAutoSyncAt` — into the
+ * one honest sentence the owner box prints.
+ *
+ * THE PAIR IS THE POINT. The flag says what is allowed. The stamp says what
+ * happened. A revoke takes the first and never the second, so a stack can be
+ * off with a stamp (automation ran, then the owner stopped it) and on without
+ * one (the owner said yes, and no machine has acted on it yet). A switch that
+ * read the flag alone would call that second state "working" and be wrong on
+ * the exact day the owner needs the truth.
+ *
+ * OWNER VOICE, distinct from the public voice in `copy.ts`: the reader here
+ * owns the machines and the stack, so it is "your machines", not "this machine".
+ */
+
+/** What `autoSync.get` answers — the flag and the stamp, together. */
+export type AutoSyncFlag = {
+	autoSync: { enabled: boolean; frequencyHours: number } | null;
+	lastAutoSyncAt: number | null;
+};
+
+export type AutoSyncState =
+	/** Nobody decided, or the owner said no. Both draw the same switch. */
+	| { kind: "off" }
+	/** On, and no machine has ever fired an automatic sync. */
+	| { kind: "never-fired"; frequencyHours: number }
+	/** On, and a machine fired one at this time. */
+	| { kind: "running"; frequencyHours: number; at: number };
+
+export function autoSyncState(flag: AutoSyncFlag): AutoSyncState {
+	if (!flag.autoSync?.enabled) return { kind: "off" };
+	const { frequencyHours } = flag.autoSync;
+	if (flag.lastAutoSyncAt === null)
+		return { kind: "never-fired", frequencyHours };
+	return { kind: "running", frequencyHours, at: flag.lastAutoSyncAt };
+}
+
+/**
+ * The intervals the select offers, inside the 1..168 range `#102` clamps to.
+ *
+ * Short enough to feel live, long enough to feel unobtrusive, with the CLI's
+ * own default (a day) in the middle.
+ */
+const OFFERED_HOURS = [1, 6, 12, 24, 48, 168] as const;
+
+/**
+ * The list to draw, with the STORED interval folded in.
+ *
+ * A machine could have seeded any whole number of hours, so the current value
+ * is not always one this list offers. It is added rather than replaced: a
+ * select that cannot show its own value shows the wrong schedule.
+ */
+export function frequencyChoices(current: number): number[] {
+	const hours = new Set<number>(OFFERED_HOURS);
+	hours.add(current);
+	return [...hours].sort((a, b) => a - b);
+}
+
+/** How an interval reads in the owner box: a phrase, never a bare number. */
+export function frequencyLabel(hours: number): string {
+	if (hours === 168) return "every week";
+	if (hours === 24) return "every day";
+	if (hours % 24 === 0) return `every ${hours / 24} days`;
+	if (hours === 1) return "every hour";
+	return `every ${hours} hours`;
+}
+
+export const SWITCH_TITLE = "// auto-sync";
+
+/**
+ * OFF NAMES THE ALTERNATIVE, never a lack. Automation off is a working stack
+ * that publishes when its owner says so, not a stack with a missing feature.
+ */
+export const OFF_LINE = "Off. Only a sync you run yourself publishes.";
+
+/**
+ * What a revoke leaves behind (#103). Hooks are dumb local triggers, and a
+ * browser cannot reach the machines that hold them, so the honest sentence is
+ * that they keep firing and land nothing — not "go remove them".
+ */
+export const OFF_REVOKE_NOTE =
+	"Machines that still have a hook keep firing on their own schedule. They publish nothing while this is off.";
+
+/** The on sentence, with the schedule it is running. */
+export function runningLine(frequencyHours: number): string {
+	return `On, ${frequencyLabel(frequencyHours)} at most.`;
+}
+
+/** ON WITHOUT A STAMP SAYS SO. This is the sentence the whole `trigger` field on the wire (#102) exists to make true. */
+export const NEVER_FIRED_LINE = "No machine has synced automatically yet.";
+
+export const NEVER_FIRED_FIX =
+	"Run this once on the machine you want to publish from. It installs the trigger for every harness you use, and after that the schedule runs on its own.";
+
+export const ON_NOTE =
+	"A sync fires when a session starts on a linked machine, and at most once per interval. Turn this off and it stops everywhere.";

--- a/src/routes/stacks.$slug.tsx
+++ b/src/routes/stacks.$slug.tsx
@@ -326,6 +326,7 @@ function StackDetailsPage() {
 					<MeasuredSection
 						index={1}
 						slug={stack.slug}
+						stackId={stack._id}
 						isOwner={upvoteStatus?.isOwner ?? false}
 					/>
 

--- a/src/routes/sync.tsx
+++ b/src/routes/sync.tsx
@@ -6,6 +6,7 @@ import {
 	useRouter,
 } from "@tanstack/react-router";
 import { ArrowLeft, ArrowRight } from "lucide-react";
+import { AutoSyncNote } from "@/features/measured/AutoSyncNote";
 import { CommandLine } from "@/features/measured/CommandLine";
 import {
 	HARNESS,
@@ -122,6 +123,10 @@ function SyncPage() {
 						</ul>
 					</div>
 				</div>
+
+				{/* The switch itself lives in the owner box on a stack page (#104).
+				    This page names it and points at it. It never repeats it. */}
+				<AutoSyncNote />
 
 				<Link
 					to="/settings/machines"


### PR DESCRIPTION
Ticket: alp82/aistack#104 — [Task: web — the auto-sync switch in the owner box](https://github.com/alp82/aistack/issues/104)

The owner-facing auto-sync switch (#104, map #76).

#102 moved the auto-sync permission onto the stack. This is the owner's half.

**The box.** `AutoSyncBox` sits in section 01 on the stack page, inside the section it governs. It does not wait for a reading, because it is the fix for a stack that has none. Owner-only by argument: a visitor skips the query and renders no box and no schedule.

**Three honest states**, read from the pair (`autoSync` + `lastAutoSyncAt`) and never from the flag alone:
- off — "Only a sync you run yourself publishes."
- on with a stamp — "Last automatic sync 2h ago."
- on with no stamp — "No machine has synced automatically yet", plus the one command to run once.

An unanswered query renders nothing. Drawing off before the server has spoken tells the owner their automation is revoked while it is running.

**Off is a complete revoke**, and the box says what that leaves behind: hooks keep firing on machines the browser cannot reach, and they publish nothing. A new end-to-end test in `convex/autoSync.test.ts` holds that claim — the owner's own mutation, then 409 on `/api/cli/sync`, the earlier reading intact, and `sync-config` answering the off that #103 reads.

**The interval** is a select while automation is on, hidden while it is off. Turning automation back on sends the stored interval, so a machine that chose six hours does not silently move onto the default. A stored value the list does not offer is folded in rather than replaced.

**`/sync`** names the switch and points at it. It repeats no control.

No schema change and no new Convex function — `autoSync.get` and `autoSync.set` are the seams #102 built for this.

Tests: 33 new (14 pure, 15 component, 3 note, 1 end-to-end). Whole suite passes, 1580.

---

Dispatched by the curia daemon — session `curia-104`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `e1fdd5c` feat(web): the auto-sync switch in the owner box (#104)