### PR TITLE
Task: CLI — the server flag gates --auto, interactive sync reconciles hooks (alp82/aistack#103)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -22,7 +22,7 @@ On an unlinked machine, `sync` starts the login flow inline — your browser ope
 
 ### `npx @use-aistack/cli sync --auto on` / `off`
 
-Optional: keep your stack fresh without manual syncs. `on` writes a `SessionStart` hook (`async: true`) into `~/.claude/settings.json`. The hook runs a silent sync at most once per day when a Claude Code session starts. `off` removes the hook and revokes the standing opt-in.
+Optional: keep your stack fresh without manual syncs. `on` asks your stack for the permission, then writes a `SessionStart` hook into the harnesses you actually use — `~/.claude/settings.json` for Claude Code, `~/.codex/hooks.json` for Codex. The hook runs a silent sync at most once per day when a session starts. `off` removes the hooks and takes the permission back.
 
 ```sh
 npx @use-aistack/cli sync --auto on            # enable, default every 24h
@@ -30,7 +30,9 @@ npx @use-aistack/cli sync --auto on --every 12 # custom frequency in hours
 npx @use-aistack/cli sync --auto off           # revoke
 ```
 
-The silent run (`sync --auto`) never prompts and publishes only under this opt-in. Each run appends one line to `~/.config/aistack/sync.log` (capped at 200 lines). The next interactive `sync` reports the last result. After 3 failures in a row, one visible message appears in Claude Code and names the fix. No email, no dialogs.
+**Your stack owns the permission, not this machine.** The silent run asks aistack.to before it publishes anything, so the switch on your stack page is a complete revoke: it stops every machine, even one whose hooks are still installed. It works the other way too — turn the switch on, run one `sync`, and that machine installs its own triggers. A harness you adopt months later gets its trigger the same way.
+
+The silent run (`sync --auto`) never prompts and never installs a hook. Each run appends one line to `~/.config/aistack/sync.log` (capped at 200 lines). The next interactive `sync` reports the last result. After 3 failures in a row, one visible message appears in Claude Code and names the fix. No email, no dialogs.
 
 ### `npx @use-aistack/cli login`
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@use-aistack/cli",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Measure and share your AI stack from your terminal",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/src/api.test.ts
+++ b/packages/cli/src/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { authPoll, authStart, stackGet } from "./api";
+import { authPoll, authStart, setAutoSync, stackGet } from "./api";
 
 /**
  * The two statuses #52 introduced, as the user reads them.
@@ -58,5 +58,94 @@ describe("HTTP failures the user can act on", () => {
 			vi.fn(() => respond(503)),
 		);
 		await expect(authStart()).rejects.toThrow(/Auth start failed: 503/);
+	});
+});
+
+/**
+ * Setting the stack's auto-sync permission (#102's route, called by #103).
+ *
+ * The destination is the stack bound to the BEARER, never anything the caller
+ * names, so these only pin the request the CLI makes and the sentences a
+ * refusal turns into.
+ */
+describe("setAutoSync", () => {
+	test("posts the flag to the bound stack", async () => {
+		const fetchMock = vi.fn(() =>
+			Promise.resolve(
+				new Response(
+					JSON.stringify({
+						autoSync: { enabled: true, frequencyHours: 12 },
+						lastAutoSyncAt: null,
+					}),
+					{ status: 200 },
+				),
+			),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const res = await setAutoSync("tok", {
+			enabled: true,
+			frequencyHours: 12,
+		});
+		expect(res.autoSync).toEqual({ enabled: true, frequencyHours: 12 });
+		const [url, init] = fetchMock.mock.calls[0] as unknown as [
+			string,
+			RequestInit,
+		];
+		expect(url).toMatch(/\/api\/cli\/auto-sync$/);
+		expect(init.method).toBe("POST");
+		expect(JSON.parse(init.body as string)).toEqual({
+			enabled: true,
+			frequencyHours: 12,
+		});
+	});
+
+	test("a revoke sends no frequency — off keeps no schedule", async () => {
+		const fetchMock = vi.fn(() =>
+			Promise.resolve(
+				new Response(
+					JSON.stringify({
+						autoSync: { enabled: false, frequencyHours: 24 },
+						lastAutoSyncAt: null,
+					}),
+					{ status: 200 },
+				),
+			),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		await setAutoSync("tok", { enabled: false });
+		const [, init] = fetchMock.mock.calls[0] as unknown as [
+			string,
+			RequestInit,
+		];
+		expect(JSON.parse(init.body as string)).toEqual({ enabled: false });
+	});
+
+	test("401 says the link expired, not that the flag is off", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => respond(401)),
+		);
+		await expect(setAutoSync("tok", { enabled: true })).rejects.toThrow(
+			/Authentication expired/,
+		);
+	});
+
+	test("409 carries the server's reason — the token has no stack", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() =>
+				Promise.resolve(
+					new Response(
+						JSON.stringify({ error: "This machine is not linked" }),
+						{
+							status: 409,
+						},
+					),
+				),
+			),
+		);
+		await expect(setAutoSync("tok", { enabled: true })).rejects.toThrow(
+			/not linked/,
+		);
 	});
 });

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -148,6 +148,44 @@ export async function syncPublish(
 	return res.json();
 }
 
+export type AutoSyncSetResult = {
+	autoSync: { enabled: boolean; frequencyHours: number };
+	lastAutoSyncAt: number | null;
+};
+
+/**
+ * Set the auto-sync permission on the stack this machine is linked to (#103).
+ *
+ * The destination is the stack bound to the BEARER, exactly like a publish —
+ * the body says what the permission is, never whose it is. The frequency goes
+ * out only when the flag goes on: off keeps no schedule, and sending a number
+ * with it would overwrite the interval the owner picked for the next enable.
+ */
+export async function setAutoSync(
+	token: string,
+	flag: { enabled: boolean; frequencyHours?: number },
+): Promise<AutoSyncSetResult> {
+	const res = await request("/api/cli/auto-sync", {
+		method: "POST",
+		headers: authHeaders(token),
+		body: JSON.stringify(
+			flag.enabled && flag.frequencyHours !== undefined
+				? { enabled: true, frequencyHours: flag.frequencyHours }
+				: { enabled: flag.enabled },
+		),
+	});
+	if (res.status === 401)
+		throw new Error(
+			"Authentication expired. Run `npx @use-aistack/cli login` again.",
+		);
+	if (res.status === 403 || res.status === 429)
+		throw failure("Auto-sync update failed", res);
+	if (!res.ok) {
+		throw new Error(await formatHttpError(res, "Auto-sync update failed"));
+	}
+	return res.json();
+}
+
 export async function stackGet(token: string): Promise<StackData | null> {
 	const res = await request("/api/cli/stacks", {
 		headers: authHeaders(token),

--- a/packages/cli/src/autosync/optin.test.ts
+++ b/packages/cli/src/autosync/optin.test.ts
@@ -10,6 +10,8 @@ import {
 	enableAutoSync,
 	NOTHING_TO_TRIGGER,
 	offerAutoSyncOptIn,
+	reconcileAutoSync,
+	settleAutoSync,
 } from "./optin.js";
 
 /**
@@ -33,6 +35,18 @@ vi.mock("@clack/prompts", () => ({
 let dir: string;
 let settingsFile: string;
 
+/** What aistack.to did with the permission. Re-armed per test. */
+let setAutoSyncMock: ReturnType<typeof vi.fn>;
+
+/**
+ * A linked machine whose server write succeeds. The permission lives on the
+ * stack now (#102/#103), so every enable and every revoke has a server half.
+ */
+const linked: Pick<EnableDeps, "getTokenImpl" | "setAutoSyncImpl"> = {
+	getTokenImpl: () => "tok",
+	setAutoSyncImpl: (token, flag) => setAutoSyncMock(token, flag),
+};
+
 /** Only Claude Code ran on the imaginary test machine unless a test says otherwise. */
 const claudeOnly: Pick<EnableDeps, "detectedImpl"> = {
 	detectedImpl: async () => [claudeAdapter],
@@ -51,6 +65,10 @@ beforeEach(() => {
 	dir = mkdtempSync(join(tmpdir(), "aistack-optin-"));
 	settingsFile = join(dir, "settings.json");
 	selectMock.mockReset();
+	setAutoSyncMock = vi.fn(async () => ({
+		autoSync: { enabled: true, frequencyHours: 24 },
+		lastAutoSyncAt: null,
+	}));
 });
 
 afterEach(() => {
@@ -62,6 +80,7 @@ describe("enableAutoSync", () => {
 		const installHook = vi.fn(() => ({ ok: true, message: "written" }));
 		const res = await enableAutoSync(24, {
 			settingsFile,
+			...linked,
 			installHook,
 			...claudeOnly,
 		});
@@ -76,6 +95,7 @@ describe("enableAutoSync", () => {
 		const installHook = vi.fn(() => ({ ok: false, message: "bad json" }));
 		const res = await enableAutoSync(24, {
 			settingsFile,
+			...linked,
 			installHook,
 			...claudeOnly,
 		});
@@ -87,6 +107,7 @@ describe("enableAutoSync", () => {
 	test("a custom frequency persists", async () => {
 		await enableAutoSync(6, {
 			settingsFile,
+			...linked,
 			installHook: () => ({ ok: true, message: "" }),
 			...claudeOnly,
 		});
@@ -101,6 +122,7 @@ describe("enableAutoSync", () => {
 		}));
 		const res = await enableAutoSync(24, {
 			settingsFile,
+			...linked,
 			installHook: () => ({ ok: true, message: "" }),
 			installCodexHook,
 			...bothHarnesses,
@@ -114,6 +136,7 @@ describe("enableAutoSync", () => {
 	test("a failed Codex hook write persists nothing", async () => {
 		const res = await enableAutoSync(24, {
 			settingsFile,
+			...linked,
 			installHook: () => ({ ok: true, message: "" }),
 			installCodexHook: () => ({ ok: false, message: "bad json" }),
 			...bothHarnesses,
@@ -129,6 +152,7 @@ describe("enableAutoSync", () => {
 		const installCodexHook = vi.fn(() => ({ ok: true, message: "" }));
 		const res = await enableAutoSync(24, {
 			settingsFile,
+			...linked,
 			installHook,
 			installCodexHook,
 			...codexOnly,
@@ -142,6 +166,7 @@ describe("enableAutoSync", () => {
 		const installCodexHook = vi.fn(() => ({ ok: true, message: "" }));
 		await enableAutoSync(24, {
 			settingsFile,
+			...linked,
 			installHook: () => ({ ok: true, message: "" }),
 			installCodexHook,
 			...claudeOnly,
@@ -152,6 +177,7 @@ describe("enableAutoSync", () => {
 	test("the confirmation names the active harnesses, not Claude Code by default", async () => {
 		const codex = await enableAutoSync(24, {
 			settingsFile,
+			...linked,
 			installCodexHook: () => ({ ok: true, message: "" }),
 			...codexOnly,
 		});
@@ -160,6 +186,7 @@ describe("enableAutoSync", () => {
 
 		const both = await enableAutoSync(24, {
 			settingsFile,
+			...linked,
 			installHook: () => ({ ok: true, message: "" }),
 			installCodexHook: () => ({ ok: true, message: "" }),
 			...bothHarnesses,
@@ -174,6 +201,7 @@ describe("enableAutoSync", () => {
 		const installCodexHook = vi.fn(() => ({ ok: true, message: "" }));
 		const res = await enableAutoSync(24, {
 			settingsFile,
+			...linked,
 			installHook,
 			installCodexHook,
 			...nothingActive,
@@ -187,14 +215,19 @@ describe("enableAutoSync", () => {
 });
 
 describe("disableAutoSync", () => {
-	test("flips the flag and removes the hooks", () => {
+	test("flips the flag and removes the hooks", async () => {
 		saveSettings(
 			{ autoSync: { enabled: true, frequencyHours: 6 } },
 			settingsFile,
 		);
 		const removeHook = vi.fn(() => ({ ok: true, message: "removed" }));
 		const removeCodexHook = vi.fn(() => ({ ok: true, message: "removed" }));
-		const res = disableAutoSync({ settingsFile, removeHook, removeCodexHook });
+		const res = await disableAutoSync({
+			settingsFile,
+			...linked,
+			removeHook,
+			removeCodexHook,
+		});
 		expect(res.ok).toBe(true);
 		expect(removeHook).toHaveBeenCalledOnce();
 		expect(removeCodexHook).toHaveBeenCalledOnce();
@@ -204,11 +237,12 @@ describe("disableAutoSync", () => {
 	});
 
 	// #101: a revoke must reach a hook whose harness has since gone quiet.
-	test("removes both hooks even when neither harness is active", () => {
+	test("removes both hooks even when neither harness is active", async () => {
 		const removeHook = vi.fn(() => ({ ok: true, message: "removed" }));
 		const removeCodexHook = vi.fn(() => ({ ok: true, message: "removed" }));
-		disableAutoSync({
+		await disableAutoSync({
 			settingsFile,
+			...linked,
 			removeHook,
 			removeCodexHook,
 			...nothingActive,
@@ -217,19 +251,304 @@ describe("disableAutoSync", () => {
 		expect(removeCodexHook).toHaveBeenCalledOnce();
 	});
 
-	test("flips the flag even when a hook cannot be removed", () => {
+	test("flips the flag even when a hook cannot be removed", async () => {
 		saveSettings(
 			{ autoSync: { enabled: true, frequencyHours: 24 } },
 			settingsFile,
 		);
-		const res = disableAutoSync({
+		const res = await disableAutoSync({
 			settingsFile,
+			...linked,
 			removeHook: () => ({ ok: false, message: "bad json" }),
 			removeCodexHook: () => ({ ok: true, message: "" }),
 		});
 		expect(res.ok).toBe(false);
 		expect(getSettings(settingsFile).autoSync?.enabled).toBe(false);
 		expect(res.message).toContain("nothing will publish");
+	});
+});
+
+/**
+ * The server half (#103). The stack holds the permission, the hooks are dumb
+ * local triggers, and the two are written in an order that leaves no state
+ * claiming more than the machine can deliver.
+ */
+describe("the server half of enable and revoke", () => {
+	test("enable grants the permission on the stack before it writes a hook", async () => {
+		const order: string[] = [];
+		setAutoSyncMock = vi.fn(async () => {
+			order.push("server");
+			return {
+				autoSync: { enabled: true, frequencyHours: 6 },
+				lastAutoSyncAt: null,
+			};
+		});
+		await enableAutoSync(6, {
+			settingsFile,
+			...linked,
+			installHook: () => {
+				order.push("hook");
+				return { ok: true, message: "" };
+			},
+			...claudeOnly,
+		});
+		expect(setAutoSyncMock).toHaveBeenCalledWith("tok", {
+			enabled: true,
+			frequencyHours: 6,
+		});
+		// Server first: a refusal there must leave the machine untouched.
+		expect(order).toEqual(["server", "hook"]);
+	});
+
+	test("a refused server write changes nothing on the machine", async () => {
+		setAutoSyncMock = vi.fn(async () => {
+			throw new Error("This machine is not linked");
+		});
+		const installHook = vi.fn(() => ({ ok: true, message: "" }));
+		const res = await enableAutoSync(24, {
+			settingsFile,
+			...linked,
+			installHook,
+			...claudeOnly,
+		});
+		expect(res.ok).toBe(false);
+		expect(res.message).toContain("not linked");
+		expect(installHook).not.toHaveBeenCalled();
+		expect(getSettings(settingsFile).autoSync).toBeUndefined();
+	});
+
+	test("an unlinked machine cannot enable, and is told to sync first", async () => {
+		// The permission lives on a stack. With no token there is no stack to
+		// grant it on, so there is no half of this the machine can do alone.
+		const installHook = vi.fn(() => ({ ok: true, message: "" }));
+		const res = await enableAutoSync(24, {
+			settingsFile,
+			getTokenImpl: () => null,
+			setAutoSyncImpl: (token, flag) => setAutoSyncMock(token, flag),
+			installHook,
+			...claudeOnly,
+		});
+		expect(res.ok).toBe(false);
+		expect(res.message).toContain("sync");
+		expect(setAutoSyncMock).not.toHaveBeenCalled();
+		expect(installHook).not.toHaveBeenCalled();
+		expect(getSettings(settingsFile).autoSync).toBeUndefined();
+	});
+
+	test("revoke takes the permission off the stack too", async () => {
+		saveSettings(
+			{ autoSync: { enabled: true, frequencyHours: 6 } },
+			settingsFile,
+		);
+		const res = await disableAutoSync({
+			settingsFile,
+			...linked,
+			removeHook: () => ({ ok: true, message: "" }),
+			removeCodexHook: () => ({ ok: true, message: "" }),
+		});
+		expect(res.ok).toBe(true);
+		expect(setAutoSyncMock).toHaveBeenCalledWith("tok", { enabled: false });
+	});
+
+	test("a revoke lands on this machine even when the server cannot be told", async () => {
+		// A revoke must never be blocked by the network. The local half runs
+		// first and is complete on its own — `sync --auto` gates on it.
+		setAutoSyncMock = vi.fn(async () => {
+			throw new Error("ENOTFOUND");
+		});
+		saveSettings(
+			{ autoSync: { enabled: true, frequencyHours: 6 } },
+			settingsFile,
+		);
+		const removeHook = vi.fn(() => ({ ok: true, message: "" }));
+		const res = await disableAutoSync({
+			settingsFile,
+			...linked,
+			removeHook,
+			removeCodexHook: () => ({ ok: true, message: "" }),
+		});
+		expect(removeHook).toHaveBeenCalledOnce();
+		expect(getSettings(settingsFile).autoSync?.enabled).toBe(false);
+		// Reported, not hidden: other machines still hold the permission.
+		expect(res.ok).toBe(false);
+		expect(res.message).toContain("ENOTFOUND");
+	});
+
+	test("an unlinked machine can still revoke locally", async () => {
+		saveSettings(
+			{ autoSync: { enabled: true, frequencyHours: 6 } },
+			settingsFile,
+		);
+		const res = await disableAutoSync({
+			settingsFile,
+			getTokenImpl: () => null,
+			setAutoSyncImpl: (token, flag) => setAutoSyncMock(token, flag),
+			removeHook: () => ({ ok: true, message: "" }),
+			removeCodexHook: () => ({ ok: true, message: "" }),
+		});
+		expect(res.ok).toBe(true);
+		expect(setAutoSyncMock).not.toHaveBeenCalled();
+		expect(getSettings(settingsFile).autoSync?.enabled).toBe(false);
+	});
+});
+
+/**
+ * The reconcile (#103). Not a prompt and not an ask: the owner already
+ * answered on the web, and this is the machine catching up with them.
+ */
+describe("reconcileAutoSync", () => {
+	test("the stack says on and a hook is missing: it installs one and says so", async () => {
+		const installHook = vi.fn(() => ({ ok: true, message: "" }));
+		const res = await reconcileAutoSync(
+			{ enabled: true, frequencyHours: 24 },
+			{
+				settingsFile,
+				installHook,
+				hookInstalledImpl: () => false,
+				...claudeOnly,
+			},
+		);
+		expect(installHook).toHaveBeenCalledOnce();
+		expect(res?.ok).toBe(true);
+		expect(res?.message).toContain("Claude Code");
+		// The local flag mirrors the server's, or `sync --auto` stops at its own
+		// gate and the web switch never takes effect.
+		expect(getSettings(settingsFile).autoSync).toEqual({
+			enabled: true,
+			frequencyHours: 24,
+		});
+	});
+
+	test("a hook that is already there is not rewritten, and nothing is said", async () => {
+		saveSettings(
+			{
+				autoSync: { enabled: true, frequencyHours: 24 },
+				autoSyncAnswered: true,
+			},
+			settingsFile,
+		);
+		const installHook = vi.fn(() => ({ ok: true, message: "" }));
+		const res = await reconcileAutoSync(
+			{ enabled: true, frequencyHours: 24 },
+			{
+				settingsFile,
+				installHook,
+				hookInstalledImpl: () => true,
+				...claudeOnly,
+			},
+		);
+		expect(installHook).not.toHaveBeenCalled();
+		expect(res).toBeNull();
+	});
+
+	// The late second-harness adopter (#100 decision 6): Codex arrives months
+	// after the opt-in, and one interactive sync gives it its trigger.
+	test("a harness adopted later gets its trigger on the next sync", async () => {
+		saveSettings(
+			{
+				autoSync: { enabled: true, frequencyHours: 24 },
+				autoSyncAnswered: true,
+			},
+			settingsFile,
+		);
+		const installHook = vi.fn(() => ({ ok: true, message: "" }));
+		const installCodexHook = vi.fn(() => ({ ok: true, message: "" }));
+		const res = await reconcileAutoSync(
+			{ enabled: true, frequencyHours: 24 },
+			{
+				settingsFile,
+				installHook,
+				installCodexHook,
+				hookInstalledImpl: () => true,
+				codexHookInstalledImpl: () => false,
+				...bothHarnesses,
+			},
+		);
+		expect(installHook).not.toHaveBeenCalled();
+		expect(installCodexHook).toHaveBeenCalledOnce();
+		expect(res?.message).toContain("Codex");
+	});
+
+	test("the stack says off: it touches nothing", async () => {
+		const installHook = vi.fn(() => ({ ok: true, message: "" }));
+		const res = await reconcileAutoSync(
+			{ enabled: false, frequencyHours: 24 },
+			{
+				settingsFile,
+				installHook,
+				hookInstalledImpl: () => false,
+				...claudeOnly,
+			},
+		);
+		expect(installHook).not.toHaveBeenCalled();
+		expect(res).toBeNull();
+		expect(getSettings(settingsFile).autoSync).toBeUndefined();
+	});
+
+	test("no stack has decided: it touches nothing, and the ask still owns this", async () => {
+		const installHook = vi.fn(() => ({ ok: true, message: "" }));
+		const res = await reconcileAutoSync(null, {
+			settingsFile,
+			installHook,
+			hookInstalledImpl: () => false,
+			...claudeOnly,
+		});
+		expect(installHook).not.toHaveBeenCalled();
+		expect(res).toBeNull();
+		expect(getSettings(settingsFile).autoSyncAnswered).toBeUndefined();
+	});
+
+	test("a hook that cannot be written is reported, and the flag is not mirrored", async () => {
+		const res = await reconcileAutoSync(
+			{ enabled: true, frequencyHours: 24 },
+			{
+				settingsFile,
+				installHook: () => ({ ok: false, message: "bad json" }),
+				hookInstalledImpl: () => false,
+				...claudeOnly,
+			},
+		);
+		expect(res?.ok).toBe(false);
+		expect(res?.message).toContain("bad json");
+		expect(getSettings(settingsFile).autoSync).toBeUndefined();
+	});
+});
+
+/**
+ * What an interactive sync does about auto-sync after it publishes (#103).
+ * One step, three inputs: the stack decided, the stack refused, or nobody has.
+ */
+describe("settleAutoSync", () => {
+	test("the stack has decided, so the machine reconciles and is not asked", async () => {
+		const installHook = vi.fn(() => ({ ok: true, message: "" }));
+		const asked = await settleAutoSync(
+			{ enabled: true, frequencyHours: 24 },
+			{
+				settingsFile,
+				installHook,
+				hookInstalledImpl: () => false,
+				...claudeOnly,
+			},
+		);
+		expect(asked).toBe(false);
+		expect(selectMock).not.toHaveBeenCalled();
+		expect(installHook).toHaveBeenCalledOnce();
+	});
+
+	test("the stack refused, so the machine is not asked either", async () => {
+		const asked = await settleAutoSync(
+			{ enabled: false, frequencyHours: 24 },
+			{ settingsFile, hookInstalledImpl: () => false, ...claudeOnly },
+		);
+		expect(asked).toBe(false);
+		expect(selectMock).not.toHaveBeenCalled();
+	});
+
+	test("nobody has decided, so the ask runs", async () => {
+		selectMock.mockResolvedValue("later");
+		const asked = await settleAutoSync(null, { settingsFile, ...claudeOnly });
+		expect(asked).toBe(true);
+		expect(selectMock).toHaveBeenCalledOnce();
 	});
 });
 
@@ -280,6 +599,7 @@ describe("offerAutoSyncOptIn", () => {
 		const installCodexHook = vi.fn(() => ({ ok: true, message: "" }));
 		await offerAutoSyncOptIn({
 			settingsFile,
+			...linked,
 			installHook,
 			installCodexHook,
 			...codexOnly,

--- a/packages/cli/src/autosync/optin.ts
+++ b/packages/cli/src/autosync/optin.ts
@@ -1,31 +1,46 @@
-// The auto-sync opt-in (#62, map #60), narrowed to active harnesses by #101.
+// The auto-sync opt-in (#62, map #60), narrowed to active harnesses by #101,
+// and moved onto the stack by #103.
+//
+// WHERE THE PERMISSION LIVES: on the stack, in Convex (#100 decision 2, #102).
+// The local flag and the SessionStart hooks are what this machine holds, and
+// neither of them grants anything — `sync --auto` asks the stack before it
+// publishes. So enable grants on the stack first, revoke revokes here first,
+// and `reconcileAutoSync` brings a machine in line with an answer the owner
+// gave somewhere else.
 //
 // This ask is the PRIMARY post-sync ask: it runs first, and the connect-claude
 // upsell yields to a later sync (at most one ask per sync, each asked once,
 // each persisted). Any explicit answer persists to
 // ~/.config/aistack/settings.json; ctrl-C is not an answer and the question
-// returns on the next sync.
+// returns on the next sync. A stack that has already decided is never asked at
+// all — `settleAutoSync` reconciles it instead.
 
 import * as p from "@clack/prompts";
+import { setAutoSync } from "../api.js";
 import {
 	DEFAULT_FREQUENCY_HOURS,
 	getSettings,
+	getToken,
 	saveSettings,
 } from "../config.js";
 import { CLAUDE_HARNESS_NAME } from "../harness/claude/adapter.js";
 import { CODEX_HARNESS_NAME } from "../harness/codex/adapter.js";
 import {
+	type AutoSyncPermission,
 	DEFAULT_WINDOW_DAYS,
 	detectedAdapters,
+	harnessLabel,
 	harnessListLabel,
 } from "../harness/index.js";
 import type { HarnessAdapter } from "../harness/types.js";
 import { dim, limeBold } from "../theme.js";
 import {
+	codexAutoSyncHookInstalled,
 	installCodexAutoSyncHook,
 	removeCodexAutoSyncHook,
 } from "./codexHook.js";
 import {
+	autoSyncHookInstalled,
 	type HookResult,
 	installAutoSyncHook,
 	removeAutoSyncHook,
@@ -37,21 +52,37 @@ export interface EnableDeps {
 	removeHook?: () => HookResult;
 	installCodexHook?: () => HookResult;
 	removeCodexHook?: () => HookResult;
+	/** Is the Claude Code trigger already on this machine? */
+	hookInstalledImpl?: () => boolean;
+	/** Is the Codex trigger already on this machine? */
+	codexHookInstalledImpl?: () => boolean;
 	/** Override the detected harness set. Tests only. */
 	detectedImpl?: () => Promise<HarnessAdapter[]>;
+	getTokenImpl?: () => string | null;
+	setAutoSyncImpl?: typeof setAutoSync;
 }
+
+/** What an unlinked machine is told when it tries to grant the permission. */
+export const NOT_LINKED =
+	"This machine is not linked to an aistack account, and the auto-sync permission lives on your stack. Run `npx @use-aistack/cli sync` first.";
 
 /** The message when the machine has no active harness to trigger anything. */
 export const NOTHING_TO_TRIGGER = `No Claude Code or Codex session on this machine in the last ${DEFAULT_WINDOW_DAYS} days, so nothing would trigger an auto-sync. Nothing was changed.`;
 
 /**
- * Turn the standing opt-in on: persist the flag, write the SessionStart hooks
- * — one per DETECTED harness (#101). A hook for a harness whose last session
- * predates the window is a trigger that will never fire, and its install is the
- * step that made a dead Claude Code install look alive.
+ * Turn auto-sync on: grant the permission on the STACK, then write the
+ * SessionStart hooks — one per DETECTED harness (#101). A hook for a harness
+ * whose last session predates the window is a trigger that will never fire, and
+ * its install is the step that made a dead Claude Code install look alive.
  *
- * When a hook write fails, the flag is NOT persisted — a half-enabled state
- * (flag on, no hook) would claim a freshness the machine cannot deliver.
+ * THE STACK IS ASKED FIRST (#103). The permission is the thing that lets a
+ * publish happen, and the hooks are dumb local triggers for it — so a refusal
+ * from aistack.to leaves the machine exactly as it was, with no hook running an
+ * npx at every session start for a permission nobody granted.
+ *
+ * When a hook write then fails, the local flag is NOT persisted. The stack
+ * shows on-but-never-fired, which is true, and the next interactive sync
+ * reconciles the missing trigger.
  */
 export async function enableAutoSync(
 	frequencyHours: number = DEFAULT_FREQUENCY_HOURS,
@@ -62,6 +93,20 @@ export async function enableAutoSync(
 		return { ok: false, message: NOTHING_TO_TRIGGER };
 	}
 	const names = new Set(detected.map((a) => a.name));
+
+	const token = (deps.getTokenImpl ?? getToken)();
+	if (token === null) return { ok: false, message: NOT_LINKED };
+	try {
+		await (deps.setAutoSyncImpl ?? setAutoSync)(token, {
+			enabled: true,
+			frequencyHours,
+		});
+	} catch (e) {
+		return {
+			ok: false,
+			message: `Auto-sync was not turned on: ${e instanceof Error ? e.message : String(e)}`,
+		};
+	}
 
 	if (names.has(CLAUDE_HARNESS_NAME)) {
 		const result = (deps.installHook ?? installAutoSyncHook)();
@@ -94,14 +139,22 @@ export async function enableAutoSync(
 }
 
 /**
- * Revoke: remove the hooks AND flip the flag. The flag flips even when a hook
- * file cannot be edited, because `sync --auto` gates on the flag — a stale hook
- * without the flag publishes nothing.
+ * Revoke: flip the local flag, remove the hooks, then take the permission off
+ * the stack. The flag flips even when a hook file cannot be edited, because
+ * `sync --auto` gates on it — a stale hook without the flag publishes nothing.
+ *
+ * THE LOCAL HALF RUNS FIRST, the mirror image of enable (#103). A revoke must
+ * never be blocked by an unreachable network: this machine stops publishing the
+ * moment the flag flips, whatever aistack.to says next. The server half is
+ * still reported when it fails, because it is the half that reaches every OTHER
+ * machine, and the owner can also use the switch on their stack page.
  *
  * Removal is unconditional, unlike install: a revoke must reach the hook of a
  * harness that has since gone quiet, and removing an absent hook is success.
  */
-export function disableAutoSync(deps: EnableDeps = {}): HookResult {
+export async function disableAutoSync(
+	deps: EnableDeps = {},
+): Promise<HookResult> {
 	const settings = getSettings(deps.settingsFile);
 	saveSettings(
 		{
@@ -119,13 +172,137 @@ export function disableAutoSync(deps: EnableDeps = {}): HookResult {
 	const failures = [result, codexResult]
 		.filter((r) => !r.ok)
 		.map((r) => r.message);
+
+	const token = (deps.getTokenImpl ?? getToken)();
+	if (token !== null) {
+		try {
+			await (deps.setAutoSyncImpl ?? setAutoSync)(token, { enabled: false });
+		} catch (e) {
+			failures.push(
+				`aistack.to was not told (${e instanceof Error ? e.message : String(e)}) — your other machines keep the permission`,
+			);
+		}
+	}
+
 	if (failures.length > 0) {
 		return {
 			ok: false,
-			message: `Auto-sync is off (nothing will publish), but a hook could not be removed: ${failures.join("; ")}`,
+			message: `Auto-sync is off on this machine (nothing will publish), but: ${failures.join("; ")}`,
 		};
 	}
-	return { ok: true, message: "Auto-sync is off. The hooks were removed." };
+	return {
+		ok: true,
+		message: "Auto-sync is off. The hooks were removed.",
+	};
+}
+
+/**
+ * Bring the machine in line with the permission the stack holds (#103).
+ *
+ * This is not an ask and never prompts. The owner already answered, on the web
+ * switch or on another machine, and this is the machine catching up with them:
+ *
+ *   - flag ON  — install a trigger for every DETECTED harness that lacks one,
+ *                and mirror the flag locally so `sync --auto` passes its own
+ *                gate. That is what makes "flip the web switch, run one sync"
+ *                the whole enable story, and it is also what gives a harness
+ *                adopted months later its trigger.
+ *   - flag OFF — touch nothing. The revoke is already in force: `sync --auto`
+ *                asks the stack before it publishes, so a live hook on this
+ *                machine publishes nothing.
+ *   - ABSENT   — touch nothing. Nobody has decided, and the post-sync ask still
+ *                owns that case.
+ *
+ * Returns the one line to print, or `null` when there was nothing to do.
+ */
+export async function reconcileAutoSync(
+	permission: AutoSyncPermission | null,
+	deps: EnableDeps = {},
+): Promise<HookResult | null> {
+	if (permission?.enabled !== true) return null;
+
+	const detected = await (deps.detectedImpl ?? detectedAdapters)();
+	if (detected.length === 0) return null;
+	const names = new Set(detected.map((a) => a.name));
+
+	const installed: string[] = [];
+	const failures: string[] = [];
+	const install = (
+		harnessName: string,
+		isInstalled: () => boolean,
+		write: () => HookResult,
+	) => {
+		if (!names.has(harnessName) || isInstalled()) return;
+		const result = write();
+		if (result.ok) installed.push(harnessLabel(harnessName));
+		else failures.push(result.message);
+	};
+
+	install(
+		CLAUDE_HARNESS_NAME,
+		deps.hookInstalledImpl ?? autoSyncHookInstalled,
+		deps.installHook ?? installAutoSyncHook,
+	);
+	install(
+		CODEX_HARNESS_NAME,
+		deps.codexHookInstalledImpl ?? codexAutoSyncHookInstalled,
+		deps.installCodexHook ?? installCodexAutoSyncHook,
+	);
+
+	if (failures.length > 0) {
+		return {
+			ok: false,
+			message: `Auto-sync is on for this stack, but a trigger could not be written: ${failures.join("; ")}`,
+		};
+	}
+
+	const frequencyHours = permission.frequencyHours ?? DEFAULT_FREQUENCY_HOURS;
+	const local = getSettings(deps.settingsFile).autoSync;
+	const mirrored =
+		local?.enabled === true && local.frequencyHours === frequencyHours;
+	if (!mirrored) {
+		saveSettings(
+			{ autoSyncAnswered: true, autoSync: { enabled: true, frequencyHours } },
+			deps.settingsFile,
+		);
+	}
+
+	// Quiet when nothing changed. The steady state is already reported by the
+	// `auto-sync: <last result>` line the interactive sync prints.
+	if (installed.length === 0 && mirrored) return null;
+	return {
+		ok: true,
+		message:
+			installed.length > 0
+				? `Auto-sync is on for this stack — installed the ${installed.join(" and ")} trigger on this machine. About every ${frequencyHours}h when a session starts.`
+				: `Auto-sync is on for this stack — about every ${frequencyHours}h when a ${harnessListLabel(detected)} session starts.`,
+	};
+}
+
+/**
+ * Everything an interactive sync does about auto-sync, after it publishes.
+ *
+ * One step with three inputs, because the stack's answer is what decides which
+ * of them applies (#103): a stack that has decided is reconciled and never
+ * asked again, and only a stack nobody has decided for reaches the ask. The ask
+ * asked once and persisted is #62's rule, and the switch now outranks it —
+ * re-asking an owner who already answered on the web is asking them twice.
+ *
+ * Returns true when it ASKED, so the caller knows to hold the connect upsell
+ * back to a later sync (at most one ask per sync, #62).
+ */
+export async function settleAutoSync(
+	permission: AutoSyncPermission | null,
+	deps: EnableDeps = {},
+): Promise<boolean> {
+	if (permission !== null) {
+		const result = await reconcileAutoSync(permission, deps);
+		if (result === null) return false;
+		if (result.ok) p.log.success(result.message);
+		else p.log.warn(result.message);
+		return false;
+	}
+	return offerAutoSyncOptIn(deps);
 }
 
 /**

--- a/packages/cli/src/autosync/run.test.ts
+++ b/packages/cli/src/autosync/run.test.ts
@@ -3,7 +3,17 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { getSettings, saveSettings } from "../config.js";
+import {
+	BUNDLED_SYNC_CONFIG,
+	type LoadedSyncConfig,
+	type SyncConfig,
+} from "../harness/index.js";
 import type { StagedSend } from "../sync/stage.js";
+import {
+	codexAutoSyncHookInstalled,
+	installCodexAutoSyncHook,
+} from "./codexHook.js";
+import { autoSyncHookInstalled, installAutoSyncHook } from "./hook.js";
 import { appendLogLine, runAutoSync, SYNC_LOG_MAX_LINES } from "./run.js";
 
 /**
@@ -55,6 +65,14 @@ function publishOk() {
 	});
 }
 
+/** The stack's permission, as `/api/sync-config` answers it (#102). */
+function serverConfig(autoSync: SyncConfig["autoSync"]): LoadedSyncConfig {
+	return {
+		config: { ...BUNDLED_SYNC_CONFIG, autoSync },
+		source: "fetched",
+	};
+}
+
 function deps(over: Partial<Parameters<typeof runAutoSync>[0]> = {}) {
 	return {
 		baseUrl: "https://aistack.to",
@@ -62,6 +80,9 @@ function deps(over: Partial<Parameters<typeof runAutoSync>[0]> = {}) {
 		settingsFile,
 		logFile,
 		emit: vi.fn(),
+		getTokenImpl: () => "tok",
+		// No stack has ever set the flag — the state a local opt-in still seeds.
+		loadConfigImpl: vi.fn(async () => serverConfig(null)),
 		stageImpl: vi.fn(async () => stagedOk()),
 		publishImpl: vi.fn(publishOk),
 		...over,
@@ -91,6 +112,123 @@ describe("the opt-in gate", () => {
 		const d = deps();
 		await runAutoSync(d);
 		expect(d.publishImpl).not.toHaveBeenCalled();
+	});
+});
+
+/**
+ * The server-side gate (#103). The stack owns the permission now, so a hook
+ * that outlives a web revoke is a trigger with nothing to trigger.
+ */
+describe("the server gate", () => {
+	beforeEach(() => {
+		saveSettings(
+			{ autoSync: { enabled: true, frequencyHours: 24 } },
+			settingsFile,
+		);
+	});
+
+	test("the stack says off: nothing is scanned and nothing is published", async () => {
+		const d = deps({
+			loadConfigImpl: vi.fn(async () =>
+				serverConfig({ enabled: false, frequencyHours: 24 }),
+			),
+		});
+		await runAutoSync(d);
+		expect(d.stageImpl).not.toHaveBeenCalled();
+		expect(d.publishImpl).not.toHaveBeenCalled();
+		expect(logLines()[0]).toContain("off");
+	});
+
+	test("a revoke is not a failure, so it never reaches the escalation", async () => {
+		saveSettings(
+			{
+				autoSync: { enabled: true, frequencyHours: 24 },
+				autoSyncState: { consecutiveFailures: 2 },
+			},
+			settingsFile,
+		);
+		const d = deps({
+			loadConfigImpl: vi.fn(async () =>
+				serverConfig({ enabled: false, frequencyHours: 24 }),
+			),
+		});
+		await runAutoSync(d);
+		expect(d.emit).not.toHaveBeenCalled();
+		expect(getSettings(settingsFile).autoSyncState?.consecutiveFailures).toBe(
+			2,
+		);
+		// The attempt is stamped, so a revoked machine asks once per window and
+		// not once per session start.
+		expect(getSettings(settingsFile).autoSyncState?.lastRunAt).toBe(NOW);
+	});
+
+	test("the stack says on: it publishes", async () => {
+		const d = deps({
+			loadConfigImpl: vi.fn(async () =>
+				serverConfig({ enabled: true, frequencyHours: 24 }),
+			),
+		});
+		await runAutoSync(d);
+		expect(d.publishImpl).toHaveBeenCalledOnce();
+	});
+
+	// #102's first fact for this ticket: the seed only lands on a sync that
+	// publishes, so ABSENT must publish. Only an explicit off exits silently.
+	test("no stack has decided: it publishes, because that publish is the seed", async () => {
+		const d = deps({ loadConfigImpl: vi.fn(async () => serverConfig(null)) });
+		await runAutoSync(d);
+		expect(d.publishImpl).toHaveBeenCalledOnce();
+	});
+
+	test("the config is fetched once and handed to the stage", async () => {
+		// One fetch per run: the gate reads the same body the stage builds from,
+		// so the permission and the destination cannot disagree.
+		const loaded = serverConfig({ enabled: true, frequencyHours: 24 });
+		const d = deps({ loadConfigImpl: vi.fn(async () => loaded) });
+		await runAutoSync(d);
+		expect(d.loadConfigImpl).toHaveBeenCalledOnce();
+		const stageArgs = vi.mocked(d.stageImpl).mock.calls[0][0];
+		expect(await stageArgs.loadConfigImpl?.({ baseUrl: "x" })).toBe(loaded);
+	});
+
+	test("the background run stamps its sync auto", async () => {
+		const d = deps();
+		await runAutoSync(d);
+		expect(vi.mocked(d.stageImpl).mock.calls[0][0].trigger).toBe("auto");
+	});
+});
+
+/**
+ * #103's done-bar, on a real filesystem: a web-side revoke stops a machine
+ * with LIVE HOOKS from publishing. This is the state the old design could not
+ * reach — the hooks are on disk, the local flag says yes, and the machine still
+ * publishes nothing, because the stack is what decides.
+ */
+describe("the done-bar: a revoke reaches a machine with live hooks", () => {
+	test("hooks installed, local flag on, stack off — nothing is published", async () => {
+		const claudeSettings = join(dir, "claude-settings.json");
+		const codexHooks = join(dir, "codex-hooks.json");
+		expect(installAutoSyncHook(claudeSettings).ok).toBe(true);
+		expect(installCodexAutoSyncHook(codexHooks).ok).toBe(true);
+		expect(autoSyncHookInstalled(claudeSettings)).toBe(true);
+		expect(codexAutoSyncHookInstalled(codexHooks)).toBe(true);
+
+		saveSettings(
+			{ autoSync: { enabled: true, frequencyHours: 24 } },
+			settingsFile,
+		);
+		const d = deps({
+			loadConfigImpl: vi.fn(async () =>
+				serverConfig({ enabled: false, frequencyHours: 24 }),
+			),
+		});
+		await runAutoSync(d);
+
+		expect(d.publishImpl).not.toHaveBeenCalled();
+		// The hooks are untouched. They are dumb triggers, and the revoke does
+		// not depend on reaching them — `--auto` never edits a hook file.
+		expect(autoSyncHookInstalled(claudeSettings)).toBe(true);
+		expect(codexAutoSyncHookInstalled(codexHooks)).toBe(true);
 	});
 });
 

--- a/packages/cli/src/autosync/run.ts
+++ b/packages/cli/src/autosync/run.ts
@@ -1,11 +1,19 @@
 // `sync --auto` — the silent background run (#62, map #60).
 //
-// The tenets from map #29 hold: passive analysis, never passive publish. The
-// standing opt-in (`autoSync.enabled` in ~/.config/aistack/settings.json) is
-// the ONLY thing that lets this path publish, and the user can revoke it with
-// one command. No prompts, no upsells, no email, no dialogs. The escalation
-// ladder is: one log line per run → the next interactive sync reports the last
-// result → after 3 consecutive failures, one visible systemMessage line.
+// The tenets from map #29 hold: passive analysis, never passive publish. TWO
+// gates let this path publish, and either one closes it:
+//
+//   1. The machine's own flag (`autoSync.enabled` in
+//      ~/.config/aistack/settings.json). Local, free, and checked first.
+//   2. The STACK's permission, read from `/api/sync-config` (#102, #103). The
+//      owner holds this one, from any machine and from the web switch, so a
+//      revoke reaches a machine whose hooks are still live.
+//
+// No prompts, no upsells, no email, no dialogs. This path also never installs
+// or removes a hook — the interactive sync owns that (`reconcileAutoSync`).
+// The escalation ladder is: one log line per run → the next interactive sync
+// reports the last result → after 3 consecutive failures, one visible
+// systemMessage line.
 //
 // This function never sets a nonzero exit code. The hook command falls back to
 // the npx cache on `||`, and a nonzero exit from a mere sync failure would
@@ -24,8 +32,10 @@ import {
 	type AutoSyncState,
 	DEFAULT_FREQUENCY_HOURS,
 	getSettings,
+	getToken,
 	saveSettings,
 } from "../config.js";
+import { loadSyncConfig } from "../harness/shared/allowlist.js";
 import { stageSync } from "../sync/stage.js";
 
 export const SYNC_LOG_FILE = join(homedir(), ".config", "aistack", "sync.log");
@@ -43,9 +53,14 @@ export type AutoSyncDeps = {
 	logFile?: string;
 	stageImpl?: typeof stageSync;
 	publishImpl?: typeof syncPublish;
+	getTokenImpl?: () => string | null;
+	loadConfigImpl?: typeof loadSyncConfig;
 	/** Where the systemMessage JSON goes. Defaults to stdout. */
 	emit?: (line: string) => void;
 };
+
+/** What the next interactive sync says when the stack has taken the permission away. */
+export const REVOKED_RESULT = "off — auto-sync is switched off for this stack";
 
 export function appendLogLine(file: string, line: string): void {
 	mkdirSync(dirname(file), { recursive: true });
@@ -83,19 +98,57 @@ export async function runAutoSync(deps: AutoSyncDeps): Promise<void> {
 
 	const stage = deps.stageImpl ?? stageSync;
 	const publish = deps.publishImpl ?? syncPublish;
+	const loadConfig = deps.loadConfigImpl ?? loadSyncConfig;
+	const token = (deps.getTokenImpl ?? getToken)();
 
 	let failure: string | null = null;
 	let url: string | undefined;
+	let revoked = false;
 	try {
-		const staged = await stage({ baseUrl: deps.baseUrl, now: () => now });
-		if (staged.blockedReason !== null) {
-			failure = staged.blockedReason;
+		// The permission the STACK holds (#102/#103), read BEFORE the scan. The
+		// run needs the network to publish anyway, so asking first costs nothing
+		// and spares a revoked machine a full walk of its own history.
+		const loaded = await loadConfig({
+			baseUrl: deps.baseUrl,
+			...(token ? { token } : {}),
+		});
+		if (loaded.config.autoSync?.enabled === false) {
+			// EXPLICIT OFF ONLY. An absent flag still publishes, because that
+			// publish is what seeds the stack from this machine (#102).
+			revoked = true;
 		} else {
-			const res = await publish(staged.token as string, staged.bodyJson);
-			url = res.url;
+			const staged = await stage({
+				baseUrl: deps.baseUrl,
+				now: () => now,
+				trigger: "auto",
+				// The same body the gate above read, so the permission and the
+				// destination cannot come from two different fetches.
+				loadConfigImpl: async () => loaded,
+				getTokenImpl: () => token,
+			});
+			if (staged.blockedReason !== null) {
+				failure = staged.blockedReason;
+			} else {
+				const res = await publish(staged.token as string, staged.bodyJson);
+				url = res.url;
+			}
 		}
 	} catch (e) {
 		failure = e instanceof Error ? e.message : String(e);
+	}
+
+	// A revoke is not a failure: the streak, the warning and the last success
+	// all stay as they were. Only the attempt is stamped, so the machine asks
+	// once per frequency window instead of once per session start.
+	if (revoked) {
+		saveSettings(
+			{
+				autoSyncState: { ...state, lastRunAt: now, lastResult: REVOKED_RESULT },
+			},
+			settingsFile,
+		);
+		appendLogLine(logFile, `${stamp} skipped — ${REVOKED_RESULT}`);
+		return;
 	}
 
 	if (failure === null) {

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -19,7 +19,7 @@ import {
 import {
 	disableAutoSync,
 	enableAutoSync,
-	offerAutoSyncOptIn,
+	settleAutoSync,
 } from "../autosync/optin.js";
 import { runAutoSync } from "../autosync/run.js";
 import { DEFAULT_FREQUENCY_HOURS, getSettings, getToken } from "../config.js";
@@ -53,7 +53,7 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
 							? Number.parseInt(options.every, 10) || DEFAULT_FREQUENCY_HOURS
 							: DEFAULT_FREQUENCY_HOURS,
 					)
-				: disableAutoSync();
+				: await disableAutoSync();
 		if (result.ok) {
 			p.log.success(result.message);
 			outro("done");
@@ -167,9 +167,15 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
 			);
 		}
 		p.log.message(lines.join("\n"));
+		// EVERY interactive sync settles auto-sync against the stack's own
+		// answer (#103): it reconciles the missing triggers when the switch is
+		// on, keeps quiet when it is off, and asks only when nobody has decided.
+		// This is what completes a web-first enable, and what gives a harness
+		// adopted months later its trigger.
+		//
 		// At most one ask per sync (#62): the auto-sync opt-in is the primary
 		// ask; the connect upsell yields and waits for a later sync.
-		const asked = await offerAutoSyncOptIn();
+		const asked = await settleAutoSync(staged.config.autoSync);
 		if (!asked) await offerConnectUpsell();
 		outro("done");
 	} catch (e) {

--- a/packages/cli/src/harness/detect.test.ts
+++ b/packages/cli/src/harness/detect.test.ts
@@ -189,6 +189,14 @@ describe("a machine with only stale Claude logs", () => {
 		const installCodexHook = vi.fn(() => ({ ok: true, message: "" }));
 		const result = await enableAutoSync(24, {
 			settingsFile,
+			// The permission lives on the stack now (#103). This machine is
+			// linked and aistack.to says yes, so what is left to check is which
+			// harness gets a trigger.
+			getTokenImpl: () => "tok",
+			setAutoSyncImpl: async () => ({
+				autoSync: { enabled: true, frequencyHours: 24 },
+				lastAutoSyncAt: null,
+			}),
 			installHook,
 			installCodexHook,
 		});

--- a/packages/cli/src/harness/index.ts
+++ b/packages/cli/src/harness/index.ts
@@ -26,6 +26,21 @@ import { CODEX_HARNESS_NAME, codexAdapter } from "./codex/adapter.js";
 import { DEFAULT_WINDOW_DAYS, windowStartMs } from "./shared/window.js";
 import type { HarnessAdapter } from "./types.js";
 
+export {
+	apiEquivalentCost,
+	baseModelId,
+	CACHE_READ_MULTIPLIER,
+	CACHE_WRITE_1H_MULTIPLIER,
+	CACHE_WRITE_5M_MULTIPLIER,
+	isPricedModel,
+	normalizeModel,
+	OPENAI_PRICING_TABLE_VERSION,
+	PRICING_TABLE_VERSION,
+	type PricePeriod,
+	priceAt,
+	SONNET_5_INTRO_ENDS_MS,
+	type TokenCounts,
+} from "@aistack/pricing";
 export { CLAUDE_HARNESS_NAME, claudeAdapter } from "./claude/adapter.js";
 export {
 	type Aggregate as ClaudeAggregate,
@@ -47,6 +62,7 @@ export {
 } from "./shared/aggregate.js";
 export {
 	type Atom,
+	type AutoSyncPermission,
 	BUILTIN_TOOLS,
 	BUNDLED_SYNC_CONFIG,
 	type CuratedAllowlist,
@@ -79,21 +95,6 @@ export {
 	type SyncBody,
 	sanitizeModelId,
 } from "./shared/payload.js";
-export {
-	apiEquivalentCost,
-	baseModelId,
-	CACHE_READ_MULTIPLIER,
-	CACHE_WRITE_1H_MULTIPLIER,
-	CACHE_WRITE_5M_MULTIPLIER,
-	isPricedModel,
-	normalizeModel,
-	OPENAI_PRICING_TABLE_VERSION,
-	PRICING_TABLE_VERSION,
-	type PricePeriod,
-	priceAt,
-	SONNET_5_INTRO_ENDS_MS,
-	type TokenCounts,
-} from "@aistack/pricing";
 export { hasRecentFile } from "./shared/recency.js";
 export {
 	DEFAULT_WINDOW_DAYS,

--- a/packages/cli/src/harness/shared/allowlist.test.ts
+++ b/packages/cli/src/harness/shared/allowlist.test.ts
@@ -324,6 +324,58 @@ describe("loadSyncConfig", () => {
 		expect(await read(undefined)).toBe(false);
 	});
 
+	it("reads the server auto-sync permission, and tells absent from off", async () => {
+		// Three states, not two (#103). Absent is the ONE state a local opt-in may
+		// still seed, so it must never be folded into off.
+		const read = async (value: unknown) => {
+			const loaded = await loadSyncConfig({
+				baseUrl: "https://aistack.to",
+				fetchImpl: (() =>
+					Promise.resolve(
+						jsonResponse({ ...GOOD_BODY, autoSync: value }),
+					)) as unknown as typeof fetch,
+			});
+			return loaded.config.autoSync;
+		};
+		expect(await read({ enabled: true, frequencyHours: 12 })).toEqual({
+			enabled: true,
+			frequencyHours: 12,
+		});
+		expect(await read({ enabled: false, frequencyHours: 24 })).toEqual({
+			enabled: false,
+			frequencyHours: 24,
+		});
+		expect(await read(null)).toBeNull();
+		expect(await read(undefined)).toBeNull();
+	});
+
+	it("reads an unreadable auto-sync permission as off, not as absent", async () => {
+		// A permission the machine cannot read is a permission it does not hold.
+		// Absent would let a local flag seed the server, which is the one thing a
+		// garbled value must not be allowed to do.
+		const read = async (value: unknown) => {
+			const loaded = await loadSyncConfig({
+				baseUrl: "https://aistack.to",
+				fetchImpl: (() =>
+					Promise.resolve(
+						jsonResponse({ ...GOOD_BODY, autoSync: value }),
+					)) as unknown as typeof fetch,
+			});
+			return loaded.config.autoSync;
+		};
+		// The frequency is left OUT, not guessed: an unreadable value tells us
+		// nothing about a schedule, and off has no schedule to keep anyway.
+		for (const value of ["on", 1, [], {}, { enabled: "yes" }]) {
+			expect(await read(value)).toEqual({ enabled: false });
+		}
+	});
+
+	it("holds no auto-sync permission when the config could not be read", () => {
+		// Bundled means the fetch failed. `stack` is null there too, so the stage
+		// blocks before any publish — this only has to not claim a permission.
+		expect(BUNDLED_SYNC_CONFIG.autoSync).toBeNull();
+	});
+
 	it("drops names from the server that fail the charset or length bound", async () => {
 		// A server-supplied list can widen what publishes — that is accepted,
 		// because the gate renders every name. It cannot smuggle a control

--- a/packages/cli/src/harness/shared/allowlist.ts
+++ b/packages/cli/src/harness/shared/allowlist.ts
@@ -161,6 +161,24 @@ export type SyncConfig = {
 	 * gate that cannot name its destination must not publish.
 	 */
 	stack: { name: string; slug: string } | null;
+	/**
+	 * The auto-sync permission the STACK holds (#102, read by #103).
+	 *
+	 * Three states, not two, and the third is the whole point. `null` means no
+	 * owner has ever decided, and that is the one state a machine's local opt-in
+	 * may still seed. `{ enabled: false }` means the owner said no, and
+	 * `sync --auto` publishes nothing on this machine until they say otherwise.
+	 *
+	 * `frequencyHours` is absent when the value could not be read — see
+	 * `readAutoSync`.
+	 */
+	autoSync: AutoSyncPermission | null;
+};
+
+/** What the stack allows, as the CLI reads it off the wire. */
+export type AutoSyncPermission = {
+	enabled: boolean;
+	frequencyHours?: number;
 };
 
 /**
@@ -185,6 +203,9 @@ export const BUNDLED_SYNC_CONFIG: SyncConfig = {
 	reviewKeptPrivate: false,
 	// No fetch, no destination — and the gate refuses to publish without one.
 	stack: null,
+	// No fetch, no permission either. This costs nothing on its own: `stack` is
+	// null in the same breath, so the stage blocks before any publish.
+	autoSync: null,
 };
 
 // ---------------------------------------------------------------------------
@@ -268,6 +289,29 @@ function readStack(v: unknown): SyncConfig["stack"] {
 	return { name: obj.name, slug: obj.slug };
 }
 
+/**
+ * Read the stack's auto-sync permission (#103).
+ *
+ * ABSENT AND OFF ARE DIFFERENT ANSWERS. Absent — the key is missing or null —
+ * means no owner has decided, and only that lets a local flag seed the server.
+ * A value that is PRESENT but unreadable is not that state: a permission the
+ * machine cannot read is a permission it does not hold, so it reads as off.
+ * The frequency is left out there rather than guessed, because off keeps no
+ * schedule and a made-up number would outlive the garbled value that caused it.
+ */
+function readAutoSync(v: unknown): AutoSyncPermission | null {
+	if (v === undefined || v === null) return null;
+	if (typeof v !== "object" || Array.isArray(v)) return { enabled: false };
+	const obj = v as Record<string, unknown>;
+	if (typeof obj.enabled !== "boolean") return { enabled: false };
+	if (
+		typeof obj.frequencyHours !== "number" ||
+		!Number.isFinite(obj.frequencyHours)
+	)
+		return { enabled: false };
+	return { enabled: obj.enabled, frequencyHours: obj.frequencyHours };
+}
+
 function readSyncConfig(raw: unknown): SyncConfig | null {
 	if (typeof raw !== "object" || raw === null || Array.isArray(raw))
 		return null;
@@ -290,6 +334,7 @@ function readSyncConfig(raw: unknown): SyncConfig | null {
 		// Anything other than an explicit `true` keeps the names on the machine.
 		reviewKeptPrivate: obj.reviewKeptPrivate === true,
 		stack: readStack(obj.stack),
+		autoSync: readAutoSync(obj.autoSync),
 	};
 }
 

--- a/packages/cli/src/harness/shared/payload.test.ts
+++ b/packages/cli/src/harness/shared/payload.test.ts
@@ -1,3 +1,4 @@
+import { PRICING_TABLE_VERSION } from "@aistack/pricing";
 import { describe, expect, it } from "vitest";
 import {
 	cleanName,
@@ -19,7 +20,6 @@ import {
 	type MeasuredPayload,
 	sanitizeModelId,
 } from "./payload.js";
-import { PRICING_TABLE_VERSION } from "@aistack/pricing";
 import type { ScanStats } from "./window.js";
 
 const NOW = Date.UTC(2026, 6, 25, 12, 0, 0); // 2026-07-25
@@ -44,6 +44,7 @@ const HARNESS_PARAMS = {
 
 const config = (over: Partial<SyncConfig> = {}): SyncConfig => ({
 	publishCost: true,
+	autoSync: null,
 	allowlist: {
 		mcpServers: ["github"],
 		skills: ["grilling"],

--- a/packages/cli/src/harness/shared/payload.ts
+++ b/packages/cli/src/harness/shared/payload.ts
@@ -13,6 +13,7 @@
 //      not in the payload at all (#33 decision 11) — there is nothing to
 //      "reveal" server-side, because nothing was transmitted.
 
+import { baseModelId } from "@aistack/pricing";
 import {
 	type Aggregate,
 	cleanName,
@@ -28,7 +29,6 @@ import {
 	type NameCategory,
 	type SyncConfig,
 } from "./allowlist.js";
-import { baseModelId } from "@aistack/pricing";
 import { type ScanStats, windowStartMs } from "./window.js";
 
 export const SCHEMA_VERSION = 1;
@@ -427,7 +427,19 @@ export type SyncBody = {
 	 * closed, and that closedness is the privacy claim.
 	 */
 	autoSync?: { enabled: boolean; frequencyHours: number };
+	/**
+	 * How this sync fired (#102, sent by #103). `auto` means a SessionStart hook
+	 * ran it with nobody watching; `manual` means a human typed the command.
+	 *
+	 * The server stamps `lastAutoSyncAt` from it, so the web switch can tell
+	 * on-and-working from on-but-never-fired. It rides beside the payloads for
+	 * the same reason `autoSync` does: the payload validator is closed.
+	 */
+	trigger?: SyncTrigger;
 };
+
+/** The two ways a sync can fire. Absent on an old CLI, and that reads as manual. */
+export type SyncTrigger = "manual" | "auto";
 
 /**
  * Union the per-harness kept-private lists into the one list the wire carries.
@@ -472,9 +484,12 @@ export function buildSyncBody(
 	built: readonly BuiltPayload[],
 	syncConfig: SyncConfig,
 	autoSync?: { enabled: boolean; frequencyHours: number },
+	trigger: SyncTrigger = "manual",
 ): SyncBody {
 	const payloads = built.map((b) => b.payload);
-	const base: SyncBody = autoSync ? { payloads, autoSync } : { payloads };
+	const base: SyncBody = autoSync
+		? { payloads, autoSync, trigger }
+		: { payloads, trigger };
 	if (!syncConfig.reviewKeptPrivate) return base;
 	return {
 		...base,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,7 +50,7 @@ program
 	.description("Scan, preview, and publish measured usage (rolling 30 days)")
 	.option(
 		"--auto [state]",
-		"silent background sync; 'on' enables the SessionStart hook, 'off' revokes it",
+		"silent background sync; 'on' asks your stack for the permission and installs the SessionStart hooks, 'off' revokes both",
 	)
 	.option(
 		"--every <hours>",

--- a/packages/cli/src/sync/server.test.ts
+++ b/packages/cli/src/sync/server.test.ts
@@ -43,6 +43,7 @@ function makeStaged(over: Partial<StagedSend> = {}): StagedSend {
 				slashCommands: [],
 			},
 			publishCost: true,
+			autoSync: null,
 			optIns: EMPTY_KEPT as never,
 			reviewKeptPrivate: false,
 			stack: { name: "S", slug: "s" },

--- a/packages/cli/src/sync/stage.test.ts
+++ b/packages/cli/src/sync/stage.test.ts
@@ -2,6 +2,7 @@
 // staged bodyJson IS the serialized body, the id is derived from it, and a
 // stage that cannot name its destination is blocked before any gate.
 
+import { PRICING_TABLE_VERSION } from "@aistack/pricing";
 import { describe, expect, test } from "vitest";
 import { createAggregate, ingestRecord } from "../harness/claude/analyzer.js";
 import { assistant } from "../harness/claude/fixtures.js";
@@ -14,7 +15,6 @@ import {
 	BUNDLED_SYNC_CONFIG,
 	EMPTY_OPT_INS,
 } from "../harness/shared/allowlist.js";
-import { PRICING_TABLE_VERSION } from "@aistack/pricing";
 import type { ScanStats } from "../harness/shared/window.js";
 import {
 	DEFAULT_WINDOW_DAYS,
@@ -31,6 +31,7 @@ const FETCHED: SyncConfig = {
 	optIns: EMPTY_OPT_INS,
 	reviewKeptPrivate: true,
 	stack: { name: "Alp's Daily Driver", slug: "alps-daily-driver" },
+	autoSync: null,
 };
 
 const STATS: ScanStats = {
@@ -97,6 +98,47 @@ describe("stageSync", () => {
 			}),
 		);
 		expect(off.body.keptPrivate).toBeUndefined();
+	});
+
+	// The seed (#102's acceptance, #103's send): the first sync from a machine
+	// whose local flag is ON, against a stack with no flag, sets the server
+	// flag. The server only seeds an ABSENT field, so the machine sends its own
+	// flag on every sync and lets the stack decide whether it means anything.
+	test("the machine's own opt-in rides on the body, so a first sync can seed the stack", async () => {
+		const staged = await stageSync(
+			deps({
+				getSettingsImpl: () => ({
+					autoSync: { enabled: true, frequencyHours: 12 },
+				}),
+			}),
+		);
+		expect(staged.body.autoSync).toEqual({
+			enabled: true,
+			frequencyHours: 12,
+		});
+		expect(JSON.parse(staged.bodyJson).autoSync).toEqual({
+			enabled: true,
+			frequencyHours: 12,
+		});
+	});
+
+	test("a machine that never opted in sends no flag, and seeds nothing", async () => {
+		const staged = await stageSync(deps({ getSettingsImpl: () => ({}) }));
+		expect(staged.body.autoSync).toBeUndefined();
+	});
+
+	// #102 put `trigger` on the wire; #103 sends it. The stamp rides in the
+	// STAGED bytes, so what the gate shows and what the server records agree.
+	test("a stage says the sync is manual unless the caller says otherwise", async () => {
+		const staged = await stageSync(deps({}));
+		expect(staged.body.trigger).toBe("manual");
+		expect(JSON.parse(staged.bodyJson).trigger).toBe("manual");
+	});
+
+	test("the background run stamps its stage auto", async () => {
+		const staged = await stageSync(deps({ trigger: "auto" }));
+		expect(staged.body.trigger).toBe("auto");
+		expect(JSON.parse(staged.bodyJson).trigger).toBe("auto");
 	});
 
 	test("summary and dialog derive from the staged content", async () => {

--- a/packages/cli/src/sync/stage.ts
+++ b/packages/cli/src/sync/stage.ts
@@ -30,6 +30,7 @@ import {
 	buildSyncBody,
 	mergeKeptPrivate,
 	type SyncBody,
+	type SyncTrigger,
 } from "../harness/shared/payload.js";
 import {
 	DEFAULT_WINDOW_DAYS,
@@ -71,6 +72,11 @@ export type StageDeps = {
 	adaptersImpl?: (sinceMs: number) => Promise<HarnessAdapter[]>;
 	getSettingsImpl?: () => Settings;
 	windowDays?: number;
+	/**
+	 * How this sync fired (#103). Defaults to `manual`, because every caller but
+	 * the background run has a human at the keyboard.
+	 */
+	trigger?: SyncTrigger;
 };
 
 export function stageId(bodyJson: string): string {
@@ -115,7 +121,7 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 	// bytes are the bytes sent (#78). Absent from the settings file means this
 	// machine has never answered, which the backend reads as "never told us".
 	const settings = (deps.getSettingsImpl ?? getSettings)();
-	const body = buildSyncBody(built, config, settings.autoSync);
+	const body = buildSyncBody(built, config, settings.autoSync, deps.trigger);
 	const bodyJson = JSON.stringify(body);
 	const keptPrivate = mergeKeptPrivate(built.map((b) => b.keptPrivate));
 

--- a/packages/cli/src/sync/summary.test.ts
+++ b/packages/cli/src/sync/summary.test.ts
@@ -108,6 +108,7 @@ function ctx(over: {
 				slashCommands: [],
 			},
 			publishCost: true,
+			autoSync: null,
 			optIns: EMPTY_OPT_INS,
 			reviewKeptPrivate: false,
 			stack: { name: "Alp's Daily Driver", slug: "alps-daily-driver" },


### PR DESCRIPTION
Ticket: alp82/aistack#103 — [Task: CLI — the server flag gates --auto, interactive sync reconciles hooks](https://github.com/alp82/aistack/issues/103)

Makes the CLI obey the server-side auto-sync permission from #102, per #100 decision 2 and 6.

**The gate.** `sync --auto` reads the stack's flag from `/api/sync-config` before it publishes, and before it scans. An explicit off exits silently and stamps the attempt, so a revoked machine asks once per frequency window instead of once per session start. A revoke is not a failure: the failure streak and the 3-failure escalation are untouched. An ABSENT flag still publishes, because that publish is what seeds the stack from this machine — #102's resolution named this and the ticket body's "flag off or absent" wording does not survive it.

**The setters.** `sync --auto on` grants the permission on the stack FIRST, then writes a trigger per detected harness. A refusal from aistack.to leaves the machine exactly as it was. `sync --auto off` revokes locally first (flag, then hooks), then tells the stack — a revoke is never blocked by the network, and a failed server call is reported rather than hidden. An unlinked machine cannot enable and is told to run `sync` first.

**The reconcile.** Every interactive sync settles auto-sync against the stack's own answer: flag on installs a trigger for every detected harness that lacks one and mirrors the flag locally, flag off touches nothing, and only "nobody has decided" reaches the post-sync ask. This completes a web-first enable in one sync, and gives a harness adopted months later its trigger. `--auto` never installs a hook.

**The wire.** The sync body carries `trigger: "manual" | "auto"`, staged inside the approved bytes.

**Fail-closed detail.** A permission value the machine cannot read reads as off, never as absent — absent is the one state a local flag may seed.

Version bumped to 0.7.0. 1577 tests pass, `tsc` shows no new errors, biome clean, the CLI builds.

---

Dispatched by the curia daemon — session `curia-103`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `b30df5c` feat(cli): the stack gates auto-sync, and one sync reconciles the hooks (#103)