### PR TITLE
Task: confirm the chart palette resolves in every browser (alp82/aistack#95)

### DIFF
--- a/src/features/charts/__tests__/ssr.test.tsx
+++ b/src/features/charts/__tests__/ssr.test.tsx
@@ -8,6 +8,7 @@
  * fails loudly instead of the site quietly shipping blank charts.
  */
 
+import { render } from "@testing-library/react";
 import { renderToString } from "react-dom/server";
 import { describe, expect, test } from "vitest";
 import { BarsChart } from "../BarsChart";
@@ -145,6 +146,46 @@ describe("house style", () => {
 			<StackedAreaChart series={two} ariaLabel="Tokens by harness" />,
 		);
 		expect(html).toContain("var(--chart-1, #69a621)");
+	});
+});
+
+describe("where the paint lives (#95)", () => {
+	// The paint is a `var()` inside an SVG *presentation attribute*, which is the
+	// library's documented theming path and the only way light and dark stay a
+	// pure CSS concern: the server cannot know the theme, so a baked hex would
+	// paint one of the two modes wrong on first paint.
+	//
+	// The DOM host repaints the scene after mount, so the attribute has to
+	// survive that. These tests pin both sides to the SAME place, because a fix
+	// that moved the paint into a `style` declaration would have to move it on
+	// both — a server attribute and a client style is a mark that changes color
+	// at hydration.
+
+	test("the server writes the paint into a fill attribute, not a style", () => {
+		const html = renderToString(
+			<StackedAreaChart series={two} ariaLabel="Tokens by harness" />,
+		);
+		expect(html).toMatch(/<path[^>]*\sfill="var\(--chart-1, #69a621\)"/);
+	});
+
+	test("the client repaint puts it in the same place the server did", () => {
+		const { container } = render(
+			<StackedAreaChart series={two} ariaLabel="Tokens by harness" />,
+		);
+		const marks = container.querySelectorAll("path[data-ts-key]");
+		expect(marks.length).toBeGreaterThanOrEqual(2);
+		const paints = Array.from(marks, (m) => m.getAttribute("fill"));
+		expect(paints).toContain("var(--chart-1, #69a621)");
+		expect(paints).toContain("var(--chart-2, #9e71fd)");
+		// No mark carries a competing paint in a style declaration.
+		for (const m of marks) expect(m.getAttribute("style")).toBeNull();
+	});
+
+	test("a line series travels by stroke, which is a separate attribute", () => {
+		const html = renderToString(
+			<TimeSeriesChart series={two} ariaLabel="Tokens by harness" />,
+		);
+		expect(html).toMatch(/<path[^>]*\sstroke="var\(--chart-1, #69a621\)"/);
 	});
 });
 

--- a/src/features/charts/prototype/PaletteCheck.tsx
+++ b/src/features/charts/prototype/PaletteCheck.tsx
@@ -1,0 +1,334 @@
+/**
+ * PROTOTYPE (#95) — the instrument for the browser check.
+ *
+ * The whole module hands paint to the marks as a `var()` inside an SVG
+ * **presentation attribute**:
+ *
+ *     <path fill="var(--chart-1, #69a621)" />
+ *
+ * Firefox and WebKit resolve that. Chromium's support for `var()` in
+ * presentation attributes is documented as incomplete, so this page exists to
+ * put the question in front of a pair of eyes in each browser.
+ *
+ * Two traps this page is shaped around:
+ *
+ * 1. **The fallback hides the failure in dark mode.** The hex inside `var()`
+ *    is the dark step, so `var(--chart-1, #69a621)` and a resolved
+ *    `--chart-1: #69a621` paint the *same color* in dark mode. A browser that
+ *    ignores the var looks correct there. The probe rows therefore carry a
+ *    fallback of **magenta**, which no slot ever is: magenta anywhere is a
+ *    browser that did not resolve the var. That reads the same in both themes
+ *    and needs no color memory.
+ *
+ * 2. **`fill` and `stroke` are separate attributes.** Areas and bars paint with
+ *    `fill`, lines and sparklines with `stroke`. Both get their own probe.
+ *
+ * The real charts sit underneath the probes. In **light** mode they must match
+ * the control row. If they look like the dark steps instead, the browser fell
+ * back to the baked hex — a pass on the probe and a fail here would mean the
+ * library, not the browser.
+ *
+ * Delete this file and its route when #95 is decided.
+ */
+
+import { useTheme } from "@/lib/theme";
+import { cn } from "@/lib/utils";
+import type { ChartSeries } from "../data";
+import { ACCENT_PAINT, CHART_SLOTS } from "../palette";
+import { Sparkline } from "../Sparkline";
+import { StackedAreaChart } from "../StackedAreaChart";
+import { TimeSeriesChart } from "../TimeSeriesChart";
+
+/** No slot is ever magenta, so magenta on screen is an unresolved `var()`. */
+const LOUD = "#ff00ff";
+
+const MONO = "font-mono text-xs uppercase tracking-[0.2em]";
+
+const DAY = 86_400_000;
+const START = Date.UTC(2026, 6, 20);
+
+function points(n: number, base: number, step: number) {
+	return Array.from({ length: n }, (_, i) => ({
+		at: START + i * DAY,
+		value: base + i * step + (i % 3) * (step / 2),
+	}));
+}
+
+/** Six series, so every slot in the palette is on screen at once. */
+const SIX: ChartSeries[] = CHART_SLOTS.map((slot, i) => ({
+	key: slot.hue,
+	label: `Slot ${i + 1} · ${slot.hue}`,
+	points: points(12, 90 - i * 12, 4 - i * 0.4),
+}));
+
+/** One series, which is what every public page ships today: the page accent. */
+const ONE: ChartSeries[] = [
+	{ key: "tokens", label: "Tokens", points: points(12, 100, 6) },
+];
+
+function PaletteCheck() {
+	const { theme, setTheme } = useTheme();
+
+	return (
+		<main className="mx-auto max-w-4xl px-6 py-12">
+			<h1 className="font-mono text-2xl font-black text-fg-primary">
+				Chart palette · browser check
+			</h1>
+			<p className="mt-3 max-w-prose text-sm leading-relaxed text-fg-secondary">
+				Every mark on this site takes its color from a CSS custom property
+				written into an SVG <code>fill</code> or <code>stroke</code> attribute.
+				This page asks one question: does this browser resolve it?
+			</p>
+
+			<ThemeSwitch theme={theme} setTheme={setTheme} />
+
+			<Step
+				n={1}
+				title="The probe"
+				note="Magenta anywhere below means this browser does not resolve var() in an SVG paint attribute. There is no other reason for magenta to appear."
+			>
+				<Row label="fill">
+					{CHART_SLOTS.map((slot, i) => (
+						<svg
+							key={slot.hue}
+							role="img"
+							aria-label={`fill probe, slot ${i + 1}`}
+							width="100%"
+							height="56"
+							viewBox="0 0 10 10"
+							preserveAspectRatio="none"
+						>
+							<rect
+								x="0"
+								y="0"
+								width="10"
+								height="10"
+								fill={`var(--chart-${i + 1}, ${LOUD})`}
+							/>
+						</svg>
+					))}
+				</Row>
+				<Row label="stroke">
+					{CHART_SLOTS.map((slot, i) => (
+						<svg
+							key={slot.hue}
+							role="img"
+							aria-label={`stroke probe, slot ${i + 1}`}
+							width="100%"
+							height="56"
+							viewBox="0 0 10 10"
+							preserveAspectRatio="none"
+						>
+							<line
+								x1="0"
+								y1="5"
+								x2="10"
+								y2="5"
+								strokeWidth="4"
+								stroke={`var(--chart-${i + 1}, ${LOUD})`}
+							/>
+						</svg>
+					))}
+				</Row>
+			</Step>
+
+			<Step
+				n={2}
+				title="The control"
+				note="Painted by a CSS declaration, which every browser resolves. The two probe rows above must match this row, slot for slot, in both themes."
+			>
+				<Row label="css">
+					{CHART_SLOTS.map((slot, i) => (
+						<div
+							key={slot.hue}
+							className="h-14"
+							style={{ background: `var(--chart-${i + 1})` }}
+						/>
+					))}
+				</Row>
+			</Step>
+
+			<Step
+				n={3}
+				title="The accent"
+				note="Single-series charts wear the page accent, not the palette. It travels the same way, so it gets the same probe. The left two boxes must match."
+			>
+				<div className="grid grid-cols-3 gap-3">
+					<svg
+						role="img"
+						aria-label="accent fill probe"
+						width="100%"
+						height="56"
+						viewBox="0 0 10 10"
+						preserveAspectRatio="none"
+					>
+						<rect
+							x="0"
+							y="0"
+							width="10"
+							height="10"
+							fill={`var(--accent-lime, ${LOUD})`}
+						/>
+					</svg>
+					<div className="h-14" style={{ background: "var(--accent-lime)" }} />
+					<div className="h-14 bg-[#ff00ff]" />
+				</div>
+				<p className={cn(MONO, "mt-2 text-fg-muted")}>
+					probe · css control · reference magenta
+				</p>
+			</Step>
+
+			<Step
+				n={4}
+				title="The real charts"
+				note="Drawn by the shared module, painted the way the app paints them: the fallback here is the dark step, not magenta. In LIGHT mode these must match the control row in step 2. If they look like the dark steps instead, the browser fell back to the baked hex."
+			>
+				<div className="space-y-8">
+					<Panel title="Six series · stacked areas · fill">
+						<StackedAreaChart
+							series={SIX}
+							ariaLabel="Six palette slots as stacked areas"
+						/>
+					</Panel>
+					<Panel title="Six series · lines and areas · stroke and fill">
+						<TimeSeriesChart
+							series={SIX}
+							ariaLabel="Six palette slots as lines"
+						/>
+					</Panel>
+					<Panel title="One series · the page accent">
+						<TimeSeriesChart
+							series={ONE}
+							caption="one series wears the accent"
+							ariaLabel="One series in the page accent"
+						/>
+					</Panel>
+					<Panel title="Sparkline · the mark every public page ships">
+						<div className="flex items-center gap-4">
+							<Sparkline
+								points={ONE[0].points}
+								ariaLabel="Sparkline in the page accent"
+							/>
+							<span className={cn(MONO, "text-fg-muted")}>
+								accent · {ACCENT_PAINT}
+							</span>
+						</div>
+					</Panel>
+				</div>
+			</Step>
+
+			<div className="mt-12 border-2 border-stroke-strong bg-bg-panel p-6">
+				<h2 className={cn(MONO, "font-bold text-fg-primary")}>
+					How to read it
+				</h2>
+				<ul className="mt-3 space-y-2 text-sm leading-relaxed text-fg-secondary">
+					<li>
+						<strong className="text-fg-primary">Pass.</strong> No magenta
+						anywhere, and in light mode the charts match the control row.
+					</li>
+					<li>
+						<strong className="text-fg-primary">Magenta boxes or lines.</strong>{" "}
+						This browser ignores the <code>var()</code> in the paint attribute.
+					</li>
+					<li>
+						<strong className="text-fg-primary">Black marks.</strong> The
+						browser resolves neither the property nor the fallback.
+					</li>
+					<li>
+						<strong className="text-fg-primary">
+							Light mode looks like dark mode.
+						</strong>{" "}
+						The charts fell back to the baked hex. Compare against the control
+						row, which is the truth.
+					</li>
+				</ul>
+			</div>
+		</main>
+	);
+}
+
+function ThemeSwitch({
+	theme,
+	setTheme,
+}: {
+	theme: "dark" | "light";
+	setTheme: (t: "dark" | "light") => void;
+}) {
+	return (
+		<div className="mt-6 flex items-center gap-3">
+			<span className={cn(MONO, "text-fg-muted")}>theme</span>
+			{(["dark", "light"] as const).map((t) => (
+				<button
+					key={t}
+					type="button"
+					onClick={() => setTheme(t)}
+					className={cn(
+						MONO,
+						"border-2 px-4 py-2 font-bold",
+						theme === t
+							? "border-accent bg-accent text-accent-contrast"
+							: "border-stroke-strong bg-bg-panel text-fg-secondary",
+					)}
+				>
+					{t}
+				</button>
+			))}
+		</div>
+	);
+}
+
+function Step({
+	n,
+	title,
+	note,
+	children,
+}: {
+	n: number;
+	title: string;
+	note: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<section className="mt-10">
+			<h2 className={cn(MONO, "font-bold text-fg-primary")}>
+				{n}. {title}
+			</h2>
+			<p className="mt-2 max-w-prose text-sm leading-relaxed text-fg-secondary">
+				{note}
+			</p>
+			<div className="mt-4">{children}</div>
+		</section>
+	);
+}
+
+function Row({
+	label,
+	children,
+}: {
+	label: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="mt-3">
+			<span className={cn(MONO, "text-fg-muted")}>{label}</span>
+			<div className="mt-1 grid grid-cols-6 gap-3">{children}</div>
+		</div>
+	);
+}
+
+function Panel({
+	title,
+	children,
+}: {
+	title: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="border-2 border-stroke-strong bg-bg-panel p-4">
+			<p className={cn(MONO, "text-fg-muted")}>{title}</p>
+			<div className="mt-3">{children}</div>
+		</div>
+	);
+}
+
+export { PaletteCheck };

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -31,6 +31,7 @@ import { Route as StacksSlugRouteImport } from './routes/stacks.$slug'
 import { Route as SettingsMachinesRouteImport } from './routes/settings.machines'
 import { Route as SettingsAnalyticsRouteImport } from './routes/settings.analytics'
 import { Route as PrototypeFreshnessRouteImport } from './routes/prototype.freshness'
+import { Route as PrototypeChartPaletteRouteImport } from './routes/prototype.chart-palette'
 import { Route as CliAuthRouteImport } from './routes/cli.auth'
 import { Route as ApiSyncConfigRouteImport } from './routes/api.sync-config'
 import { Route as AdminIconsRouteImport } from './routes/admin_.icons'
@@ -157,6 +158,11 @@ const PrototypeFreshnessRoute = PrototypeFreshnessRouteImport.update({
   path: '/prototype/freshness',
   getParentRoute: () => rootRouteImport,
 } as any)
+const PrototypeChartPaletteRoute = PrototypeChartPaletteRouteImport.update({
+  id: '/prototype/chart-palette',
+  path: '/prototype/chart-palette',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CliAuthRoute = CliAuthRouteImport.update({
   id: '/cli/auth',
   path: '/cli/auth',
@@ -251,6 +257,7 @@ export interface FileRoutesByFullPath {
   '/admin/icons': typeof AdminIconsRoute
   '/api/sync-config': typeof ApiSyncConfigRoute
   '/cli/auth': typeof CliAuthRoute
+  '/prototype/chart-palette': typeof PrototypeChartPaletteRoute
   '/prototype/freshness': typeof PrototypeFreshnessRoute
   '/settings/analytics': typeof SettingsAnalyticsRoute
   '/settings/machines': typeof SettingsMachinesRoute
@@ -290,6 +297,7 @@ export interface FileRoutesByTo {
   '/admin/icons': typeof AdminIconsRoute
   '/api/sync-config': typeof ApiSyncConfigRoute
   '/cli/auth': typeof CliAuthRoute
+  '/prototype/chart-palette': typeof PrototypeChartPaletteRoute
   '/prototype/freshness': typeof PrototypeFreshnessRoute
   '/settings/analytics': typeof SettingsAnalyticsRoute
   '/settings/machines': typeof SettingsMachinesRoute
@@ -330,6 +338,7 @@ export interface FileRoutesById {
   '/admin_/icons': typeof AdminIconsRoute
   '/api/sync-config': typeof ApiSyncConfigRoute
   '/cli/auth': typeof CliAuthRoute
+  '/prototype/chart-palette': typeof PrototypeChartPaletteRoute
   '/prototype/freshness': typeof PrototypeFreshnessRoute
   '/settings/analytics': typeof SettingsAnalyticsRoute
   '/settings/machines': typeof SettingsMachinesRoute
@@ -371,6 +380,7 @@ export interface FileRouteTypes {
     | '/admin/icons'
     | '/api/sync-config'
     | '/cli/auth'
+    | '/prototype/chart-palette'
     | '/prototype/freshness'
     | '/settings/analytics'
     | '/settings/machines'
@@ -410,6 +420,7 @@ export interface FileRouteTypes {
     | '/admin/icons'
     | '/api/sync-config'
     | '/cli/auth'
+    | '/prototype/chart-palette'
     | '/prototype/freshness'
     | '/settings/analytics'
     | '/settings/machines'
@@ -449,6 +460,7 @@ export interface FileRouteTypes {
     | '/admin_/icons'
     | '/api/sync-config'
     | '/cli/auth'
+    | '/prototype/chart-palette'
     | '/prototype/freshness'
     | '/settings/analytics'
     | '/settings/machines'
@@ -489,6 +501,7 @@ export interface RootRouteChildren {
   AdminIconsRoute: typeof AdminIconsRoute
   ApiSyncConfigRoute: typeof ApiSyncConfigRoute
   CliAuthRoute: typeof CliAuthRoute
+  PrototypeChartPaletteRoute: typeof PrototypeChartPaletteRoute
   PrototypeFreshnessRoute: typeof PrototypeFreshnessRoute
   SettingsAnalyticsRoute: typeof SettingsAnalyticsRoute
   SettingsMachinesRoute: typeof SettingsMachinesRoute
@@ -666,6 +679,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PrototypeFreshnessRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/prototype/chart-palette': {
+      id: '/prototype/chart-palette'
+      path: '/prototype/chart-palette'
+      fullPath: '/prototype/chart-palette'
+      preLoaderRoute: typeof PrototypeChartPaletteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/cli/auth': {
       id: '/cli/auth'
       path: '/cli/auth'
@@ -804,6 +824,7 @@ const rootRouteChildren: RootRouteChildren = {
   AdminIconsRoute: AdminIconsRoute,
   ApiSyncConfigRoute: ApiSyncConfigRoute,
   CliAuthRoute: CliAuthRoute,
+  PrototypeChartPaletteRoute: PrototypeChartPaletteRoute,
   PrototypeFreshnessRoute: PrototypeFreshnessRoute,
   SettingsAnalyticsRoute: SettingsAnalyticsRoute,
   SettingsMachinesRoute: SettingsMachinesRoute,

--- a/src/routes/prototype.chart-palette.tsx
+++ b/src/routes/prototype.chart-palette.tsx
@@ -1,0 +1,29 @@
+/**
+ * PROTOTYPE (#95) — `/prototype/chart-palette`.
+ *
+ * Throwaway route. It answers one question: does this browser resolve a
+ * `var()` written into an SVG paint attribute, which is how every mark on this
+ * site gets its color?
+ *
+ * The route server-renders on purpose. The first HTML has to carry the marks,
+ * because that is where the question bites: the server cannot know the theme,
+ * so the paint has to stay a property the CSS resolves after the fact.
+ *
+ * Public and unauthenticated, so the same URL opens in Chrome, Firefox and
+ * Safari with nothing to sign in to. Delete this file when #95 is decided.
+ */
+
+import { createFileRoute } from "@tanstack/react-router";
+import { PaletteCheck } from "@/features/charts/prototype/PaletteCheck";
+import { seoMeta } from "@/lib/seo";
+
+export const Route = createFileRoute("/prototype/chart-palette")({
+	component: PaletteCheck,
+	head: () => ({
+		meta: seoMeta({
+			title: "Chart palette check - AI Stack",
+			description: "Does this browser resolve var() in an SVG paint attribute?",
+			noindex: true,
+		}),
+	}),
+});


### PR DESCRIPTION
Ticket: alp82/aistack#95 — [Task: confirm the chart palette resolves in every browser](https://github.com/alp82/aistack/issues/95)

Ticket #95 asks whether every browser resolves a `var()` written into an SVG presentation attribute, which is how every mark on this site gets its color. That is an eyes-on question. This change builds the instrument that asks it and pins what the code does on both sides.

**The page.** `/prototype/chart-palette` is public, unauthenticated and server-rendered, so one URL opens in Chrome, Firefox and Safari with nothing to sign in to. Four steps:

1. **The probe** — bare `<rect fill>` and `<line stroke>`, six slots each, no library involved.
2. **The control** — the same six painted by a CSS declaration, which every browser resolves.
3. **The accent** — the same probe for `--accent-lime`, because every public page today ships a single-series mark, not the palette.
4. **The real charts** — the module's own components at all six slots, plus a single-series chart and a sparkline.

**Why magenta.** The probe rows use `var(--chart-N, #ff00ff)`. The real fallback is the dark step, so `var(--chart-1, #69a621)` and a resolved `--chart-1: #69a621` paint the same color in dark mode — a browser that ignores the var looks correct there. Magenta cannot be mistaken for a slot in either theme, so the probe reads pass or fail without color memory.

**The tests.** Three new cases in `ssr.test.tsx` pin where the paint lives: the server writes it into a `fill` attribute, the client repaint puts it in the same place and adds no competing `style`, and a line series travels by `stroke`, a separate attribute. The ticket asks for the fix to hold on both sides — these fail if the two sides ever disagree.

Throwaway. The route and its component are deleted when #95 is decided.

---

Dispatched by the curia daemon — session `curia-95`, model `opus`.

Commits (read out of git by the daemon, not reported by the agent):

- `72a53fd` Task: the instrument for the chart palette browser check (alp82/aistack#95)