### PR TITLE
Task: fix the two live defects on the public surfaces (alp82/aistack#129)

### DIFF
--- a/convex/activityFeed.test.ts
+++ b/convex/activityFeed.test.ts
@@ -71,6 +71,14 @@ function syncEvent(over: {
   }
 }
 
+/** The watermark bucket holding `at`, keyed the way the query keys it: UTC day. */
+function valueOn(
+  points: { at: number; value: number }[],
+  at: number
+): number | undefined {
+  return points.find((p) => p.at === Math.floor(at / DAY) * DAY)?.value
+}
+
 async function emit(
   t: Ctx,
   stackId: Id<'stacks'>,
@@ -293,11 +301,90 @@ describe('movement', () => {
   test('the first sync a stack ever published has no movement to claim', async () => {
     const t = convexTest(schema, modules)
     const stackId = await seedStack(t)
-    await emit(t, stackId, Date.now() - HOUR, syncEvent({ totalTokens: 1_000 }))
+    const now = Date.now()
+    await snapshot(t, stackId, { capturedAt: now - HOUR, totalTokens: 1_000 })
+    await emit(t, stackId, now - HOUR, syncEvent({ totalTokens: 1_000 }))
 
     const feed = await t.query(api.activityFeed.stream, {})
     expect(feed.rows[0].deltaTokens).toBeNull()
     expect(feed.rows[0].firstReading).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // "first reading" rests on the SNAPSHOTS, not on the events (#129).
+  // `activityEvents` starts where #78 turned instrumentation on, so every
+  // stack older than that had its first post-instrumentation sync called its
+  // first reading. On prod the feed said so about OrcDev while its stack page
+  // showed nine readings over six days.
+  // -------------------------------------------------------------------------
+
+  test('a sync with readings older than the events table is not a first reading', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t)
+    const now = Date.now()
+    // Three syncs the events table never saw.
+    await snapshot(t, stackId, { capturedAt: now - 4 * DAY, totalTokens: 400 })
+    await snapshot(t, stackId, { capturedAt: now - 3 * DAY, totalTokens: 700 })
+    await snapshot(t, stackId, { capturedAt: now - 2 * DAY, totalTokens: 900 })
+    await snapshot(t, stackId, { capturedAt: now - HOUR, totalTokens: 1_000 })
+    await emit(t, stackId, now - HOUR, syncEvent({ totalTokens: 1_000 }))
+
+    const feed = await t.query(api.activityFeed.stream, {})
+    expect(feed.rows[0].firstReading).toBe(false)
+    // And it carries the real movement against the newest of those readings.
+    expect(feed.rows[0].deltaTokens).toBe(100)
+  })
+
+  test('a movement recovered from the snapshots may fall', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t)
+    const now = Date.now()
+    await snapshot(t, stackId, { capturedAt: now - 2 * DAY, totalTokens: 2_000 })
+    await snapshot(t, stackId, { capturedAt: now - HOUR, totalTokens: 1_800 })
+    await emit(t, stackId, now - HOUR, syncEvent({ totalTokens: 1_800 }))
+
+    const feed = await t.query(api.activityFeed.stream, {})
+    expect(feed.rows[0].deltaTokens).toBe(-200)
+    expect(feed.rows[0].firstReading).toBe(false)
+  })
+
+  test('the prior reading is the newest per harness, summed', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t)
+    const now = Date.now()
+    await snapshot(t, stackId, {
+      capturedAt: now - 3 * DAY,
+      harness: 'claude-code',
+      totalTokens: 600,
+    })
+    await snapshot(t, stackId, {
+      capturedAt: now - 2 * DAY,
+      harness: 'codex',
+      totalTokens: 400,
+    })
+    await snapshot(t, stackId, {
+      capturedAt: now - HOUR,
+      harness: 'claude-code',
+      totalTokens: 900,
+    })
+    await emit(t, stackId, now - HOUR, syncEvent({ totalTokens: 1_300 }))
+
+    const feed = await t.query(api.activityFeed.stream, {})
+    // 600 + 400 stood before this sync, so a 1,300 reading moved +300.
+    expect(feed.rows[0].deltaTokens).toBe(300)
+  })
+
+  test('a sync that has an earlier EVENT never reads the snapshots', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t)
+    const now = Date.now()
+    // A snapshot that disagrees with the events, to prove which one is used.
+    await snapshot(t, stackId, { capturedAt: now - 3 * HOUR, totalTokens: 99 })
+    await emit(t, stackId, now - 2 * HOUR, syncEvent({ totalTokens: 1_000 }))
+    await emit(t, stackId, now - HOUR, syncEvent({ totalTokens: 1_285 }))
+
+    const feed = await t.query(api.activityFeed.stream, {})
+    expect(feed.rows[0].deltaTokens).toBe(285)
   })
 
   test('movement can fall — a 30-day window forgets its far end', async () => {
@@ -360,7 +447,7 @@ describe('the band', () => {
     expect(band.totals.updates).toBe(1)
   })
 
-  test('tokens measured is the movement the whole site gained, floored at zero', async () => {
+  test('tokens measured is a LEVEL — the total the window carries, fallers and all', async () => {
     const t = convexTest(schema, modules)
     const a = await seedStack(t, { name: 'Up' })
     const b = await seedStack(t, { name: 'Down' })
@@ -371,8 +458,20 @@ describe('the band', () => {
     await emit(t, b, now - 2 * HOUR, syncEvent({ totalTokens: 4_000 }))
 
     const band = await t.query(api.activityFeed.band, {})
-    // 300 gained, and the stack that fell contributes nothing rather than -1000.
-    expect(band.totals.movedTokens).toBe(300)
+    // The latest reading of each stack, summed. The stack that FELL is in it at
+    // its 4,000 — it is not deleted, and neither is it counted at -1,000 (#128).
+    expect(band.usage.tokens).toBe(5_300)
+  })
+
+  test('a stack that synced twice in the window counts once, at its latest', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await seedStack(t)
+    const now = Date.now()
+    await emit(t, stackId, now - 4 * HOUR, syncEvent({ totalTokens: 1_000 }))
+    await emit(t, stackId, now - 2 * HOUR, syncEvent({ totalTokens: 1_300 }))
+
+    const band = await t.query(api.activityFeed.band, {})
+    expect(band.usage.tokens).toBe(1_300)
   })
 
   test('sessions and projects SUM, models and tools UNION', async () => {
@@ -428,7 +527,7 @@ describe('the band', () => {
     const band = await t.query(api.activityFeed.band, {})
     expect(band.usage.stacks).toBe(0)
     expect(band.usage.sessions).toBe(0)
-    expect(band.totals.movedTokens).toBe(0)
+    expect(band.usage.tokens).toBe(0)
     // The rows themselves still show: the band is quiet, not empty.
     expect(band.rows).toHaveLength(1)
   })
@@ -446,7 +545,7 @@ describe('the band', () => {
     expect(band.rows[0].at).toBe(now)
   })
 
-  test('the watermark is one daily bucket of gained tokens per day', async () => {
+  test('the watermark plots the level measured each day, so its last point is the tile', async () => {
     const t = convexTest(schema, modules)
     const stackId = await seedStack(t)
     const now = Date.now()
@@ -459,9 +558,29 @@ describe('the band', () => {
     expect(band.points[band.points.length - 1].at).toBeGreaterThan(
       band.points[0].at
     )
-    const gained = band.points.reduce((sum, p) => sum + p.value, 0)
-    // The first sync has nothing to compare against, so it gains nothing.
-    expect(gained).toBe(1_000)
+    // Each day carries what it measured, not what it gained — so the first sync
+    // is 1,000 rather than nothing, and the newest day equals the tile.
+    expect(band.points.map((p) => p.value).filter((v) => v > 0)).toEqual([
+      1_000, 1_500, 2_000,
+    ])
+    expect(valueOn(band.points, now - HOUR)).toBe(band.usage.tokens)
+  })
+
+  test('a day two stacks synced sums their levels, each at its latest', async () => {
+    const t = convexTest(schema, modules)
+    const a = await seedStack(t, { name: 'A' })
+    const b = await seedStack(t, { name: 'B' })
+    // Yesterday noon UTC: always in the past, always inside the watermark, and
+    // far enough from a bucket boundary that the three events land together
+    // whatever time of day the test runs.
+    const noon = Math.floor(Date.now() / DAY) * DAY - 12 * HOUR
+    await emit(t, a, noon - 3 * HOUR, syncEvent({ totalTokens: 1_000 }))
+    await emit(t, a, noon - 2 * HOUR, syncEvent({ totalTokens: 1_200 }))
+    await emit(t, b, noon - HOUR, syncEvent({ totalTokens: 500 }))
+
+    const band = await t.query(api.activityFeed.band, {})
+    // A's older 1,000 is dropped for its own 1,200; B adds its 500.
+    expect(valueOn(band.points, noon)).toBe(1_700)
   })
 
   test('counts the stacks it measured across', async () => {

--- a/convex/activityFeed.ts
+++ b/convex/activityFeed.ts
@@ -32,6 +32,12 @@ import { ActivityEvent } from './schema'
  * people running Opus is one model and two people running Bash is one tool.
  * Each stack contributes only its LATEST sync in the window, or a stack that
  * synced twice would report its sessions twice.
+ *
+ * A LEVEL OR A MOVEMENT, NEVER A THIRD THING (#128, built in #129). The band's
+ * five tiles and the watermark behind them are LEVELS — they take no sign and
+ * they may fall. The rows under them are MOVEMENTS, and a movement always
+ * carries its sign. Nothing floors, and nothing drops the fallers before
+ * summing.
  */
 
 const HOUR_MS = 60 * 60 * 1000
@@ -90,8 +96,6 @@ const Band = v.object({
     syncs: v.number(),
     /** Stacks published plus compositions changed — one number on the surface. */
     updates: v.number(),
-    /** Movement the whole site gained in the window; a fall contributes zero. */
-    movedTokens: v.number(),
     /** Distinct stacks with any activity in the watermark window. */
     stacksSeen: v.number(),
   }),
@@ -100,10 +104,17 @@ const Band = v.object({
     projects: v.number(),
     models: v.number(),
     tools: v.number(),
+    /**
+     * The total the stacks that synced in the window are carrying — a LEVEL,
+     * like its three neighbors, so it takes no sign and may fall (#128). It is
+     * NOT a movement: the tile used to sum the risers and delete the fallers,
+     * which no true sentence described.
+     */
+    tokens: v.number(),
     /** Stacks that synced in the window. Zero means quiet, and quiet is not 0. */
     stacks: v.number(),
   }),
-  /** One point per UTC day, oldest first. Tokens gained that day. */
+  /** One point per UTC day, oldest first. The level measured that day. */
   points: v.array(v.object({ at: v.number(), value: v.number() })),
   rows: v.array(FeedRow),
 })
@@ -178,17 +189,13 @@ async function scanFeed(
   /** Set once nothing below can be wanted. The walk then only settles deltas. */
   let closed = false
   let scanned = 0
-  let exhausted = true
 
   for await (const event of ctx.db
     .query('activityEvents')
     .withIndex('by_createdAt')
     .order('desc')) {
     scanned += 1
-    if (scanned > SCAN_CAP) {
-      exhausted = false
-      break
-    }
+    if (scanned > SCAN_CAP) break
 
     const stack = await visibleStack(ctx, cache, event.stackId)
     if (!stack) continue
@@ -228,20 +235,56 @@ async function scanFeed(
       }
     }
 
-    if (closed && pending.size === 0) {
-      exhausted = false
-      break
-    }
+    if (closed && pending.size === 0) break
   }
 
-  // A row still parked when the TABLE ran out has no earlier sync at all, which
-  // is what makes "first reading" true. A row still parked because the walk hit
-  // its bound knows nothing, and says nothing.
-  if (exhausted) {
-    for (const { index } of pending.values()) rows[index].firstReading = true
+  // A row still parked found no earlier sync EVENT, which is not the same as no
+  // earlier sync (#129). The events table starts where #78 turned
+  // instrumentation on, and the walk is bounded, so neither the end of the
+  // table nor the end of the walk can settle the claim. The snapshots can, so
+  // the claim rests on them.
+  for (const parked of pending.values()) {
+    const row = rows[parked.index]
+    const prior = await priorTotal(ctx, row.stackId, row.at)
+    if (prior === null) row.firstReading = true
+    else row.deltaTokens = parked.tokens - prior
   }
 
   return { rows, hasMore }
+}
+
+/**
+ * The rolling total this stack carried BEFORE the sync stamped `before`, read
+ * from `measuredSnapshots` — or null when no earlier reading exists at all.
+ *
+ * This is what makes "first reading" a fact (#129). `activityEvents` only
+ * reaches back to #78, so a stack that synced nine times before that had every
+ * one of those readings claimed as its first. The snapshots hold one immutable
+ * row per approved sync since the stack began, and nothing prunes them.
+ *
+ * `receivedAt` is the server clock the event is stamped with, and every
+ * snapshot of one batch shares it — so a strict `<` drops this sync's own rows
+ * and keeps every earlier one. `capturedAt` is the client clock and cannot be
+ * compared to an event timestamp at all.
+ *
+ * One indexed read per parked row, which is at most one per distinct stack in
+ * the walk — the same bound `usageFor` already pays for the band.
+ */
+async function priorTotal(
+  ctx: QueryCtx,
+  stackId: Id<'stacks'>,
+  before: number
+): Promise<number | null> {
+  const snapshots = await ctx.db
+    .query('measuredSnapshots')
+    .withIndex('by_stack_capturedAt', (q) => q.eq('stackId', stackId))
+    .collect()
+  const earlier = snapshots.filter((row) => row.receivedAt < before)
+  if (earlier.length === 0) return null
+  return newestPerHarness(earlier).reduce(
+    (sum, row) => sum + row.payload.activity.totalTokens,
+    0
+  )
 }
 
 function toPublic(row: ScanRow) {
@@ -261,10 +304,17 @@ function dayStart(at: number): number {
 }
 
 /**
- * One bucket per UTC day, oldest first, holding the tokens the site GAINED that
- * day. A fall contributes zero rather than a negative: the watermark is a shape
- * behind a headline, and a line that dips below its own baseline reads as a
- * second series.
+ * One bucket per UTC day, oldest first, holding the LEVEL the stacks that
+ * synced that day were carrying (#128, built in #129). The line therefore draws
+ * the same quantity the tile above it states, and its last point IS the tile.
+ *
+ * It used to plot the tokens the site GAINED, floored at zero — a movement
+ * under a tile that is a level, so the two were unrelated numbers stacked on
+ * each other. Nothing floors anything now: a level cannot go negative, so the
+ * old fear of a line dipping below its own baseline does not arise.
+ *
+ * A stack that synced twice in one day counts once, at that day's newest
+ * reading — the same rule `usageFor` applies to the window.
  */
 function pointsFor(
   rows: ScanRow[],
@@ -275,10 +325,18 @@ function pointsFor(
   for (let back = WATERMARK_DAYS - 1; back >= 0; back -= 1) {
     buckets.set(today - back * DAY_MS, 0)
   }
+  // Rows arrive newest-first, so the first sync seen per stack per day is that
+  // day's latest reading.
+  const counted = new Set<string>()
   for (const row of rows) {
+    const tokens = syncTokens(row.event)
+    if (tokens === null) continue
     const key = dayStart(row.at)
     if (!buckets.has(key)) continue
-    buckets.set(key, (buckets.get(key) ?? 0) + Math.max(row.deltaTokens ?? 0, 0))
+    const mark = `${key}:${row.stackId}`
+    if (counted.has(mark)) continue
+    counted.add(mark)
+    buckets.set(key, (buckets.get(key) ?? 0) + tokens)
   }
   return [...buckets.entries()]
     .sort((a, b) => a[0] - b[0])
@@ -298,7 +356,8 @@ function newestPerHarness(
 }
 
 /**
- * The four measured numbers, joined from `measuredSnapshots`.
+ * The five measured numbers. Four are joined from `measuredSnapshots`; the
+ * token level comes off the sync events, which already carry it.
  *
  * The join is paid ONCE, here, for the whole band — which is exactly why the
  * rows below it stay on event-only facts (#84, #96). One indexed read per stack
@@ -313,6 +372,7 @@ async function usageFor(
   projects: number
   models: number
   tools: number
+  tokens: number
   stacks: number
 }> {
   // Rows arrive newest-first, so the first sync seen per stack is its latest.
@@ -325,11 +385,13 @@ async function usageFor(
 
   let sessions = 0
   let projects = 0
+  let tokens = 0
   const models = new Set<string>()
   const tools = new Set<string>()
 
   for (const row of latest.values()) {
     if (row.event.type !== 'sync.landed') continue
+    tokens += syncTokens(row.event) ?? 0
     for (const harness of row.event.harnesses) {
       sessions += harness.sessions
       projects += harness.projects
@@ -355,6 +417,7 @@ async function usageFor(
     projects,
     models: models.size,
     tools: tools.size,
+    tokens,
     stacks: latest.size,
   }
 }
@@ -388,10 +451,6 @@ export const band = query({
       totals: {
         syncs: inWindow.filter((r) => r.event.type === 'sync.landed').length,
         updates: inWindow.filter((r) => r.event.type !== 'sync.landed').length,
-        movedTokens: inWindow.reduce(
-          (sum, r) => sum + Math.max(r.deltaTokens ?? 0, 0),
-          0
-        ),
         stacksSeen: new Set(rows.map((r) => r.stackId as string)).size,
       },
       usage: await usageFor(ctx, rows, windowStart),

--- a/src/features/activity/PulseBand.tsx
+++ b/src/features/activity/PulseBand.tsx
@@ -12,7 +12,7 @@ import { fmtCount, fmtTokens, liveDays, MONO_LABEL } from "./feed";
  *
  *   // the last 24 hours              2 syncs · 1 stack update · 8 models
  *
- *   +285M            596              41               22
+ *   4.99B            596              41               22
  *   TOKENS MEASURED  SESSIONS         PROJECTS         TOOLS
  *
  *   as it lands
@@ -29,7 +29,14 @@ import { fmtCount, fmtTokens, liveDays, MONO_LABEL } from "./feed";
  * rows keep their left border.
  *
  * QUIET IS NOT ZERO. With no sync in the window every measured tile renders an
- * em dash. A row of zeroes reads as a broken site rather than a quiet one.
+ * em dash. A row of zeroes reads as a broken site rather than a quiet one. All
+ * four tiles take the SAME guard — the token tile once tested its own value,
+ * so it read as quiet whenever the number happened to be zero.
+ *
+ * ALL FOUR TILES ARE LEVELS (#128, built in #129). The token tile carries no
+ * sign and may fall. It used to print a movement with a `+`, summed over the
+ * risers only, which no true sentence described — and it sat above rows that
+ * are movements and could point the other way.
  *
  * The two `page` trims (#96): a tighter header, and no footer row — the page
  * does not repeat the landing band's footnote, and the button that led there
@@ -151,11 +158,7 @@ export function PulseBand({
 
 				<div className="grid grid-cols-2 gap-x-8 gap-y-12 md:grid-cols-4">
 					<Stat
-						value={
-							totals.movedTokens === 0
-								? "—"
-								: `+${fmtTokens(totals.movedTokens)}`
-						}
+						value={quiet ? "—" : fmtTokens(usage.tokens)}
 						label="tokens measured"
 						accent
 					/>

--- a/src/features/activity/__tests__/activity-page.test.tsx
+++ b/src/features/activity/__tests__/activity-page.test.tsx
@@ -53,7 +53,7 @@ describe("the page", () => {
 		expect(
 			screen.getByRole("heading", { name: "ACTIVITY" }),
 		).toBeInTheDocument();
-		expect(screen.getByText("+512M")).toBeInTheDocument();
+		expect(screen.getByText("512M")).toBeInTheDocument();
 		expect(screen.getByText("tokens measured")).toBeInTheDocument();
 	});
 

--- a/src/features/activity/__tests__/fixture.ts
+++ b/src/features/activity/__tests__/fixture.ts
@@ -81,9 +81,6 @@ export function band(over: Partial<Band> = {}): Band {
 		totals: {
 			syncs: 2,
 			updates: 1,
-			// Deliberately NOT one row's delta: the tile is the whole site's
-			// movement, and a test that shares a number cannot tell them apart.
-			movedTokens: 512_000_000,
 			stacksSeen: 4,
 		},
 		usage: {
@@ -91,6 +88,10 @@ export function band(over: Partial<Band> = {}): Band {
 			projects: 41,
 			models: 8,
 			tools: 22,
+			// Deliberately NOT one row's delta: the tile is the level the whole
+			// site carries, and a test that shares a number cannot tell them
+			// apart.
+			tokens: 512_000_000,
 			stacks: 2,
 		},
 		points: points([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1e8, 2e8, 0, 3e8]),

--- a/src/features/activity/__tests__/pulse-band.test.tsx
+++ b/src/features/activity/__tests__/pulse-band.test.tsx
@@ -14,7 +14,7 @@ afterEach(cleanup);
 describe("the band", () => {
 	it("leads with what the site measured, tokens on the accent", () => {
 		render(<PulseBand band={band()} variant="landing" />);
-		const tokens = screen.getByText("+512M");
+		const tokens = screen.getByText("512M");
 		expect(tokens).toHaveClass("text-accent-lime");
 		expect(screen.getByText("tokens measured")).toBeInTheDocument();
 		expect(screen.getByText("596")).toBeInTheDocument();
@@ -37,7 +37,6 @@ describe("the band", () => {
 					totals: {
 						syncs: 0,
 						updates: 0,
-						movedTokens: 0,
 						stacksSeen: 4,
 					},
 					usage: {
@@ -45,6 +44,7 @@ describe("the band", () => {
 						projects: 0,
 						models: 0,
 						tools: 0,
+						tokens: 0,
 						stacks: 0,
 					},
 				})}
@@ -55,6 +55,31 @@ describe("the band", () => {
 		// numeric: "0 syncs" counts what happened, it does not measure anything.
 		expect(screen.getAllByText("—")).toHaveLength(5);
 		expect(screen.getAllByText("0")).toHaveLength(2);
+	});
+
+	it("states the token tile as a level, so it carries no sign (#129)", () => {
+		render(<PulseBand band={band()} variant="landing" />);
+		expect(screen.queryByText("+512M")).not.toBeInTheDocument();
+	});
+
+	it("takes the same quiet guard as its neighbors, not its own value", () => {
+		// A window with syncs in it says what it measured, even at zero tokens.
+		render(
+			<PulseBand
+				band={band({
+					usage: {
+						sessions: 596,
+						projects: 41,
+						models: 8,
+						tools: 22,
+						tokens: 0,
+						stacks: 2,
+					},
+				})}
+				variant="landing"
+			/>,
+		);
+		expect(screen.getByText("0")).toBeInTheDocument();
 	});
 
 	it("drops the watermark below three days with a reading", () => {

--- a/src/features/activity/__tests__/ssr.test.tsx
+++ b/src/features/activity/__tests__/ssr.test.tsx
@@ -24,7 +24,7 @@ describe("server rendering", () => {
 			<PulseBand band={band({ rows: [syncRow()] })} variant="landing" />,
 		);
 
-		expect(html).toContain("+512M");
+		expect(html).toContain("512M");
 		// Uppercased by CSS, so the markup carries the words as written.
 		expect(html).toContain("tokens measured");
 		expect(html).toContain("596");

--- a/src/features/leaderboard/LeaderboardPage.tsx
+++ b/src/features/leaderboard/LeaderboardPage.tsx
@@ -167,6 +167,11 @@ function Row({
 /**
  * The sparkline cell. One reading is not a trend, and the row says so rather
  * than drawing a flat stroke that would claim days nobody measured.
+ *
+ * A RISE AND A FALL WEAR THE SAME COLOR (#128, built in #129). The sign carries
+ * the direction. Grey is this page's muted color, so a grey fall read as "this
+ * row is fading" rather than as "down" — and the feed already treats a fall as
+ * a fact, not as a demotion.
  */
 function Trend({ row }: { readonly row: BoardRow }) {
 	const trend = trendOf(row.points);
@@ -187,7 +192,7 @@ function Trend({ row }: { readonly row: BoardRow }) {
 				{drawable ? (
 					<Sparkline
 						points={row.points.map((p) => ({ at: p.at, value: p.tokens }))}
-						ariaLabel={`${row.name} measured tokens across ${row.syncCount} syncs`}
+						ariaLabel={`${row.name} measured tokens across ${row.points.length} syncs`}
 						width={SPARK_WIDTH}
 						height={SPARK_HEIGHT}
 					/>
@@ -203,11 +208,11 @@ function Trend({ row }: { readonly row: BoardRow }) {
 			<span className="mt-1 block whitespace-nowrap font-mono text-[10px] leading-none text-fg-muted">
 				{drawable ? (
 					<>
-						<span className={up ? "text-accent-lime" : "text-fg-secondary"}>
+						<span className="text-accent-lime">
 							{up ? "+" : "−"}
 							{f.pct(Math.abs(trend ?? 0))}
 						</span>{" "}
-						· {row.syncCount} syncs
+						· {row.points.length} syncs
 					</>
 				) : (
 					`${row.syncCount === 1 ? "1 sync" : `${row.syncCount} syncs`} · no trend`

--- a/src/features/leaderboard/__tests__/leaderboard-page.test.tsx
+++ b/src/features/leaderboard/__tests__/leaderboard-page.test.tsx
@@ -43,6 +43,16 @@ describe("the trend", () => {
 		).toBe("−21% over 2 syncs");
 		expect(trendWords([{ at: 1, tokens: 100 }])).toBe("1 sync");
 	});
+
+	it("labels the percentage with the span it covers, not the sync count", () => {
+		// The server caps `points` at 60 while reporting the true count, so a
+		// stack past the cap used to print a span it never measured (#129).
+		const points = Array.from({ length: 60 }, (_, i) => ({
+			at: i,
+			tokens: 100 - i,
+		}));
+		expect(trendWords(points, 84)).toBe("−59% over 60 syncs");
+	});
 });
 
 describe("the board", () => {
@@ -74,6 +84,14 @@ describe("the board", () => {
 		setup();
 		// Alper's trail goes 10M -> 8M: −20% over 2 syncs.
 		expect(screen.getAllByText(/−20%/).length).toBeGreaterThan(0);
+	});
+
+	it("colors a fall like a rise — the sign carries the direction (#129)", () => {
+		setup();
+		// Anchored: the drawn cell states the percentage alone, the narrow
+		// layout states it inside a sentence.
+		expect(screen.getByText(/^−20%$/)).toHaveClass("text-accent-lime");
+		expect(screen.getByText(/^\+17%$/)).toHaveClass("text-accent-lime");
 	});
 
 	it("prints spend as a lower bound with its coverage, or exactly", () => {

--- a/src/features/leaderboard/board.ts
+++ b/src/features/leaderboard/board.ts
@@ -25,7 +25,12 @@ export function trendOf(points: readonly SeriesPoint[]): number | null {
 
 /**
  * The trend in words, for the narrow layout that has no room to draw it.
- * `syncCount` is the row's full reading count — `points` may be capped.
+ *
+ * The percentage is labelled with the span it actually covers, `points.length`,
+ * NOT with `syncCount` (#129). The server caps `points` at 60 while reporting
+ * the row's true reading count, so a stack past 60 syncs printed
+ * `−7% over 84 syncs` for a percentage that spanned 60. `syncCount` still
+ * carries the one-reading case, where nothing is capped.
  */
 export function trendWords(
 	points: readonly SeriesPoint[],
@@ -34,7 +39,7 @@ export function trendWords(
 	const trend = trendOf(points);
 	if (trend === null) return syncCount === 1 ? "1 sync" : "no trend";
 	const sign = trend >= 0 ? "+" : "−";
-	return `${sign}${Math.abs(Math.round(trend * 100))}% over ${syncCount} syncs`;
+	return `${sign}${Math.abs(Math.round(trend * 100))}% over ${points.length} syncs`;
 }
 
 /** Wire names in words. An unknown harness keeps its wire spelling. */


### PR DESCRIPTION
Closes #129.

## Defect 1 — "first reading" was claimed wrongly

`activityEvents` starts where #78 turned instrumentation on, so a walk that found no earlier sync had **not** established that none happened. Every stack older than the table had its first post-instrumentation sync called its first reading. On prod the feed said so about OrcDev while `/stacks/orcdev` showed nine readings over six days.

The claim now rests on `measuredSnapshots` — one immutable row per approved sync since the stack began, and nothing prunes them.

The ticket left one thing open: does the row then carry a real movement, or simply drop the claim? **It carries the movement.** The snapshots answer both questions in the same read, so dropping the claim would pay the read and throw the answer away.

- One indexed read per parked row, which is at most one per distinct stack in the walk — the bound `usageFor` already pays for the band.
- The filter is on `receivedAt`, the server clock the event is stamped with. Every snapshot of one batch shares it, so a strict `<` drops this sync's own rows and keeps every earlier one. `capturedAt` is the client clock and cannot be compared to an event timestamp at all.
- The prior level is the newest snapshot per harness, summed — the same rule every other surface reads.
- The walk's own bound stops mattering, because the snapshots settle the claim either way. `exhausted` is gone.

## Defect 2 — the falling-total rule from #128

> Every surface draws either a level or a movement between two real readings, and never a third thing. A level takes no sign and may fall. A movement always carries its sign, in the same color as a rise. Nothing floors, and nothing drops the fallers before summing.

All five items from the #128 resolution:

1. **`activityFeed.ts` — the band's token tile becomes a LEVEL.** It summed the risers and **deleted** the fallers, so a day where one stack gained 10M and another lost 200M read `+10M`. No true sentence described that figure. It is now the total the stacks that synced in the window carry — the same quantity as its three neighbors. `totals.movedTokens` moves to `usage.tokens`.
2. **`PulseBand.tsx` — no `+`, and the same `quiet` guard as its neighbors.** The tile used to test its own value, so it read as quiet whenever the number happened to be zero.
3. **`pointsFor` — the watermark plots the daily level**, so the line's last point IS the tile. The two were unrelated quantities stacked on each other. A stack that synced twice in a day counts once, at its newest reading. Nothing floors: a level cannot go negative, so the old comment's fear of a line dipping below its own baseline does not arise.
4. **`LeaderboardPage.tsx` — a fall wears the accent, like a rise.** The sign carries the direction. Grey is this page's muted color, so a grey fall read as "this row is fading".
5. **`board.ts` — `trendWords` labels the percentage with the span it covers.** The server caps `points` at 60 while reporting the true count, so a stack past 60 syncs printed `−7% over 84 syncs` for a percentage spanning 60. The sparkline cell and its aria-label had the same mismatch and take the same fix.

`FeedRows.tsx` and `fmtDelta` are untouched — the feed row was already compliant.

## Tests

Claims, not rendering. New in `convex/activityFeed.test.ts`: a sync with readings older than the events table is not a first reading and carries the real movement; a recovered movement may fall; the prior reading is newest-per-harness summed; a sync with an earlier event never reads the snapshots. The band tests now pin the level (fallers included, one reading per stack) and the watermark's last point equals the tile. UI tests pin the missing sign, the shared quiet guard, the shared fall color, and the capped span.

Full suite green: 1765 passed, 6 skipped. `tsc` error count unchanged from `main` (42, all pre-existing in `stack-view` tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192Tv61Qb1pUyniYLLHP1va