### PR TITLE
Task: a mixed-vendor payload cites the right price table per model (alp82/aistack#136)

### DIFF
--- a/convex/lib/reprice.test.ts
+++ b/convex/lib/reprice.test.ts
@@ -243,6 +243,106 @@ describe('repriceSnapshot — the gap filler (#93)', () => {
   })
 })
 
+describe('per-model citations from a mixed-vendor payload (#136)', () => {
+  it('cites each published figure by the table the model carries', () => {
+    // One opencode payload prices OpenAI and Google rows from two tables. The
+    // old shape stamped one id over both — a false citation. The new shape
+    // carries the table on the model, and the top-level field is null.
+    const out = repriceSnapshot({
+      models: [
+        {
+          id: 'openai:gpt-5.4',
+          tokens: tokens({ input: MTOK }),
+          apiEquivalentUSD: 2.5,
+          pricingTable: OPENAI_PRICING_TABLE_VERSION,
+        },
+        {
+          id: 'google:gemini-3.6-flash',
+          tokens: tokens({ input: MTOK }),
+          apiEquivalentUSD: 1.5,
+          pricingTable: GOOGLE_PRICING_TABLE_VERSION,
+        },
+      ],
+      window: JULY,
+      publishedTable: null,
+      publishCost: true,
+    })
+    expect(out.cost?.publishedUSD).toBe(4)
+    expect(out.cost?.pricingTables).toEqual([
+      OPENAI_PRICING_TABLE_VERSION,
+      GOOGLE_PRICING_TABLE_VERSION,
+    ])
+  })
+
+  it('falls back to the payload table for a model with no citation of its own', () => {
+    // The old wire shape: dollars on the model, one table on the payload.
+    const out = repriceSnapshot({
+      models: [
+        {
+          id: 'claude-opus-5',
+          tokens: tokens({ output: MTOK }),
+          apiEquivalentUSD: 25,
+        },
+      ],
+      window: JULY,
+      publishedTable: PRICING_TABLE_VERSION,
+      publishCost: true,
+    })
+    expect(out.cost?.pricingTables).toEqual([PRICING_TABLE_VERSION])
+  })
+
+  it('does not repeat a table cited by both a published and an estimated row', () => {
+    const out = repriceSnapshot({
+      models: [
+        {
+          id: 'openai:gpt-5.4',
+          tokens: tokens({ input: MTOK }),
+          apiEquivalentUSD: 2.5,
+          pricingTable: OPENAI_PRICING_TABLE_VERSION,
+        },
+        { id: 'gpt-5.6-luna', tokens: tokens({ output: MTOK }) },
+      ],
+      window: JULY,
+      publishedTable: null,
+      publishCost: true,
+    })
+    expect(out.cost?.pricingTables).toEqual([OPENAI_PRICING_TABLE_VERSION])
+  })
+
+  it('strips the citation with the dollars when cost is off', () => {
+    // Cost is absent, not zeroed — and a citation with nothing to cite would
+    // leak that a figure existed.
+    const out = repriceSnapshot({
+      models: [
+        {
+          id: 'openai:gpt-5.4',
+          tokens: tokens({ input: MTOK }),
+          apiEquivalentUSD: 2.5,
+          pricingTable: OPENAI_PRICING_TABLE_VERSION,
+        },
+      ],
+      window: JULY,
+      publishedTable: null,
+      publishCost: false,
+    })
+    expect(out.models[0].apiEquivalentUSD).toBeUndefined()
+    expect(out.models[0].pricingTable).toBeUndefined()
+  })
+
+  it('stamps the citing table onto a row it estimates', () => {
+    // An estimated figure is cited by OUR table, per model, the same way a
+    // published figure is cited by the CLI's.
+    const out = repriceSnapshot({
+      models: [{ id: 'gpt-5.6-sol', tokens: tokens({ input: MTOK }) }],
+      window: JULY,
+      publishedTable: null,
+      publishCost: true,
+    })
+    expect(out.models[0].costEstimated).toBe(true)
+    expect(out.models[0].pricingTable).toBe(OPENAI_PRICING_TABLE_VERSION)
+  })
+})
+
 describe('provider-qualified ids from a multi-provider harness (#123)', () => {
   it('estimates a Google row at the Google list rate', () => {
     const out = repriceSnapshot({

--- a/convex/lib/reprice.ts
+++ b/convex/lib/reprice.ts
@@ -56,6 +56,12 @@ export type WireModel = {
   id: string
   tokens: WireTokens
   apiEquivalentUSD?: number
+  /**
+   * The table that produced `apiEquivalentUSD`, riding on the model (#136).
+   * Absent on payloads from before the mixed-vendor wire change — those cite
+   * every published figure with the payload-level `pricingTable` instead.
+   */
+  pricingTable?: string
 }
 
 /** The reported window, as the two UTC date strings the payload carries. */
@@ -63,6 +69,8 @@ export type SnapshotWindow = { from: string; to: string }
 
 export type RepricedModel<T> = T & {
   apiEquivalentUSD?: number
+  /** The table citing the dollars above, whether published or estimated. */
+  pricingTable?: string
   /** True when the dollars above came from this module, not from the CLI. */
   costEstimated: boolean
 }
@@ -162,7 +170,9 @@ export function repriceSnapshot<T extends WireModel>(input: {
   if (!publishCost) {
     return {
       models: models.map((m) => {
-        const { apiEquivalentUSD: _dropped, ...rest } = m
+        // The citation strips with the dollars: cost is absent, not zeroed,
+        // and a table with nothing to cite would leak that a figure existed.
+        const { apiEquivalentUSD: _dropped, pricingTable: _table, ...rest } = m
         return { ...(rest as T), costEstimated: false }
       }),
       cost: null,
@@ -175,6 +185,11 @@ export function repriceSnapshot<T extends WireModel>(input: {
   let pricedTokens = 0
   let repricedTokens = 0
   let totalTokens = 0
+  // The published citations lead, in model order: they date the exact dollars,
+  // and the estimates are the addition. A model with no citation of its own is
+  // from before the mixed-vendor wire change (#136) and cites the payload's
+  // one table.
+  const publishedTables = new Set<string>()
   const estimateTables = new Set<string>()
 
   const out = models.map((m): RepricedModel<T> => {
@@ -184,6 +199,8 @@ export function repriceSnapshot<T extends WireModel>(input: {
     if (m.apiEquivalentUSD !== undefined) {
       publishedUSD += m.apiEquivalentUSD
       pricedTokens += size
+      const table = m.pricingTable ?? publishedTable
+      if (table) publishedTables.add(table)
       return { ...m, costEstimated: false }
     }
 
@@ -195,18 +212,20 @@ export function repriceSnapshot<T extends WireModel>(input: {
     repricedTokens += size
     const table = pricingTableFor(m.id)
     if (table) estimateTables.add(table)
-    return { ...m, apiEquivalentUSD: usd, costEstimated: true }
+    return {
+      ...m,
+      apiEquivalentUSD: usd,
+      costEstimated: true,
+      // The estimate is cited per model exactly the way a published figure is.
+      ...(table ? { pricingTable: table } : {}),
+    }
   })
 
   if (pricedTokens === 0) return { models: out, cost: null, repricedTokens: 0 }
 
-  // The payload's own table leads: it cites the exact dollars, and the estimate
-  // is the addition. A table already named by the payload is not repeated.
   const pricingTables = [
-    ...(publishedUSD > 0 && publishedTable ? [publishedTable] : []),
-    ...[...estimateTables].filter(
-      (t) => !(publishedUSD > 0 && t === publishedTable)
-    ),
+    ...publishedTables,
+    ...[...estimateTables].filter((t) => !publishedTables.has(t)),
   ]
 
   return {

--- a/convex/measured.test.ts
+++ b/convex/measured.test.ts
@@ -340,6 +340,36 @@ describe('publishSnapshot — string bounds on the payload', () => {
     ).resolves.toBeDefined()
   })
 
+  test('accepts and bounds a per-model pricingTable (#136)', async () => {
+    // A mixed-vendor payload cites the table on the model, not on the payload.
+    // The string renders on the same public page as the rest, so it clears the
+    // same bar.
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    const model = (pricingTable: string) => [
+      {
+        id: 'openai:gpt-5.4',
+        tokenShare: 1,
+        tokens: { input: 1, output: 1, cacheWrite: 0, cacheRead: 0 },
+        apiEquivalentUSD: 2.5,
+        pricingTable,
+      },
+    ]
+
+    await expect(
+      publish(t, stackId, {
+        pricingTable: null,
+        models: model('openai-list-2026-08-02'),
+      }),
+    ).resolves.toBeDefined()
+    await expect(
+      publish(t, stackId, { models: model('z'.repeat(65)) }),
+    ).rejects.toThrow(/models\[0\]\.pricingTable/)
+    await expect(
+      publish(t, stackId, { models: model(`x${BIDI_OVERRIDE}`) }),
+    ).rejects.toThrow(/models\[0\]\.pricingTable/)
+  })
+
   test('window bounds are dates, so the rendered window cannot be arbitrary text', async () => {
     const t = convexTest(schema, modules)
     const { stackId } = await seedStack(t)
@@ -556,6 +586,48 @@ describe('getCurrentByStackSlug', () => {
       slug: `my-stack-${shortId}`,
     })
     expect(current?.models[0].catalogSlug).toBe('claude-haiku-4-5-20251001')
+  })
+
+  test('cites every per-model table in the cost reading (#136)', async () => {
+    // One opencode snapshot prices OpenAI and Google rows from two tables and
+    // its top-level pricingTable is null. Both citations must survive to the
+    // surface — the old shape stamped one string over both.
+    const t = convexTest(schema, modules)
+    const { stackId, shortId } = await seedStack(t)
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payload({
+        pricingTable: null,
+        models: [
+          {
+            id: 'openai:gpt-5.4',
+            tokenShare: 0.5,
+            tokens: { input: 10, output: 10, cacheWrite: 0, cacheRead: 0 },
+            apiEquivalentUSD: 2.5,
+            pricingTable: 'openai-list-2026-08-02',
+          },
+          {
+            id: 'google:gemini-3.6-flash',
+            tokenShare: 0.5,
+            tokens: { input: 10, output: 10, cacheWrite: 0, cacheRead: 0 },
+            apiEquivalentUSD: 1.5,
+            pricingTable: 'google-list-2026-08-09',
+          },
+        ],
+      }) as never,
+    })
+
+    const current = await t.query(api.measured.getCurrentByStackSlug, {
+      slug: `my-stack-${shortId}`,
+    })
+    expect(current?.cost?.pricingTables).toEqual([
+      'openai-list-2026-08-02',
+      'google-list-2026-08-09',
+    ])
+    expect(current?.pricingTable).toBe(
+      'openai-list-2026-08-02 + google-list-2026-08-09',
+    )
+    expect(current?.cost?.publishedUSD).toBe(4)
   })
 
   test('reports isFresh from the SERVER clock', async () => {

--- a/convex/measured.ts
+++ b/convex/measured.ts
@@ -124,6 +124,11 @@ function checkPayloadStrings(
         `models[${i}].id must be 1-${MODEL_ID_MAX} characters of A-Z a-z 0-9 . _ : -`
       )
     }
+    // The per-model citation (#136) renders on the same public page as the
+    // payload-level one, so it clears the same bar.
+    if (model.pricingTable !== undefined) {
+      requireName(model.pricingTable, `models[${i}].pricingTable`)
+    }
   })
 
   for (const category of NAME_CATEGORIES) {
@@ -214,6 +219,11 @@ const ResolvedModel = v.object({
     cacheRead: v.number(),
   }),
   apiEquivalentUSD: v.optional(v.number()),
+  /**
+   * The table citing the dollars above, per model (#136) — the payload's own
+   * for a published figure, ours for an estimated one. Absent with the dollars.
+   */
+  pricingTable: v.optional(v.string()),
   /**
    * True when the dollars above were priced server-side from the shared table
    * rather than by the syncing CLI (#93). An estimate is a lower bound: the
@@ -488,9 +498,14 @@ function mergeModels(lists: Priced[][]): Priced[] {
       if (held.apiEquivalentUSD !== undefined && m.apiEquivalentUSD !== undefined) {
         held.apiEquivalentUSD += m.apiEquivalentUSD
         held.costEstimated = held.costEstimated || m.costEstimated
+        // A merged figure keeps its citation only while every contributor
+        // cites the same table (#136); the headline's `pricingTables` still
+        // names them all either way.
+        if (held.pricingTable !== m.pricingTable) held.pricingTable = undefined
       } else {
         held.apiEquivalentUSD = undefined
         held.costEstimated = false
+        held.pricingTable = undefined
       }
       if (held.catalogSlug === null) {
         held.catalogSlug = m.catalogSlug

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -89,6 +89,11 @@ const MeasuredModel = v.object({
   // Absent when publishCost is off, or when the model was not fully priced —
   // never zeroed (#33 decision 11).
   apiEquivalentUSD: v.optional(v.number()),
+  // The table that produced the dollars above, riding on the model (#136): one
+  // opencode payload mixes vendors, so the payload-level `pricingTable` cannot
+  // cite every figure. Present exactly when the dollars are. Absent on
+  // payloads from before the mixed-vendor wire change.
+  pricingTable: v.optional(v.string()),
 })
 
 export const MeasuredPayload = v.object({

--- a/packages/cli/src/harness/claude/adapter.ts
+++ b/packages/cli/src/harness/claude/adapter.ts
@@ -3,7 +3,6 @@
 // gives it the adapter shape.
 
 import { BUILTIN_TOOLS } from "../shared/allowlist.js";
-import { PRICING_TABLE_VERSION } from "@aistack/pricing";
 import { hasRecentFile } from "../shared/recency.js";
 import type {
 	HarnessAdapter,
@@ -19,7 +18,6 @@ export const CLAUDE_HARNESS_NAME = "claude-code";
 export const claudeAdapter: HarnessAdapter = {
 	name: CLAUDE_HARNESS_NAME,
 	builtinTools: BUILTIN_TOOLS,
-	pricingTableVersion: PRICING_TABLE_VERSION,
 
 	async detect(opts: HarnessDetectOptions): Promise<boolean> {
 		return hasRecentFile(

--- a/packages/cli/src/harness/claude/analyzer.test.ts
+++ b/packages/cli/src/harness/claude/analyzer.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import { SONNET_5_INTRO_ENDS_MS } from "@aistack/pricing";
+import { describe, expect, it } from "vitest";
 import {
 	type Aggregate,
 	cleanName,

--- a/packages/cli/src/harness/claude/analyzer.ts
+++ b/packages/cli/src/harness/claude/analyzer.ts
@@ -31,6 +31,11 @@
 // cost is computed as it is ingested and un-applied on replace.
 
 import {
+	apiEquivalentCost,
+	normalizeModel,
+	type TokenCounts,
+} from "@aistack/pricing";
+import {
 	asArr,
 	asName,
 	asNum,
@@ -44,11 +49,6 @@ import {
 	type Obj,
 	type Aggregate as SharedAggregate,
 } from "../shared/aggregate.js";
-import {
-	apiEquivalentCost,
-	normalizeModel,
-	type TokenCounts,
-} from "@aistack/pricing";
 
 // Re-exported for the existing import sites (tests, stage, summary); the
 // definitions moved to ../shared/aggregate.ts in #67.

--- a/packages/cli/src/harness/codex/adapter.ts
+++ b/packages/cli/src/harness/codex/adapter.ts
@@ -1,6 +1,5 @@
 // The Codex CLI harness behind the seam (#66 decision 6, built in #67).
 
-import { OPENAI_PRICING_TABLE_VERSION } from "@aistack/pricing";
 import { hasRecentFile } from "../shared/recency.js";
 import type {
 	HarnessAdapter,
@@ -47,7 +46,6 @@ export const CODEX_BUILTIN_TOOLS: ReadonlySet<string> = new Set([
 export const codexAdapter: HarnessAdapter = {
 	name: CODEX_HARNESS_NAME,
 	builtinTools: CODEX_BUILTIN_TOOLS,
-	pricingTableVersion: OPENAI_PRICING_TABLE_VERSION,
 
 	async detect(opts: HarnessDetectOptions): Promise<boolean> {
 		return hasRecentFile(

--- a/packages/cli/src/harness/codex/analyzer.ts
+++ b/packages/cli/src/harness/codex/analyzer.ts
@@ -23,6 +23,11 @@
 // zero write prices correctly with zero pricing-code changes.
 
 import {
+	apiEquivalentCost,
+	normalizeModel,
+	type TokenCounts,
+} from "@aistack/pricing";
+import {
 	addModelUsage,
 	asName,
 	asNum,
@@ -35,11 +40,6 @@ import {
 	type Obj,
 	type Aggregate as SharedAggregate,
 } from "../shared/aggregate.js";
-import {
-	apiEquivalentCost,
-	normalizeModel,
-	type TokenCounts,
-} from "@aistack/pricing";
 
 /** Codex needs no response dedup bookkeeping — deltas count once by construction. */
 export type Aggregate = SharedAggregate<never>;

--- a/packages/cli/src/harness/index.ts
+++ b/packages/cli/src/harness/index.ts
@@ -17,7 +17,6 @@
 //       windowDays: DEFAULT_WINDOW_DAYS,
 //       harnessName: adapter.name,
 //       builtinTools: adapter.builtinTools,
-//       pricingTableVersion: adapter.pricingTableVersion,
 //     });
 //   }
 

--- a/packages/cli/src/harness/shared/payload.test.ts
+++ b/packages/cli/src/harness/shared/payload.test.ts
@@ -1,5 +1,8 @@
 import {
 	apiEquivalentCost,
+	GOOGLE_PRICING_TABLE_VERSION,
+	LOCAL_PRICING_TABLE_VERSION,
+	OPENAI_PRICING_TABLE_VERSION,
 	PRICING_TABLE_VERSION,
 	type TokenCounts,
 } from "@aistack/pricing";
@@ -47,7 +50,6 @@ const CLEAN_STATS: ScanStats = {
 const HARNESS_PARAMS = {
 	harnessName: "claude-code",
 	builtinTools: BUILTIN_TOOLS,
-	pricingTableVersion: PRICING_TABLE_VERSION,
 } as const;
 
 const config = (over: Partial<SyncConfig> = {}): SyncConfig => ({
@@ -550,6 +552,107 @@ describe("a multi-provider harness prices at ingest (#123)", () => {
 		]);
 		expect(payload.models[0].apiEquivalentUSD).toBe(0);
 		expect(payload.excludedTokens.unpriced).toBe(0);
+	});
+});
+
+describe("the citation rides on the rate (#136)", () => {
+	// One opencode payload mixes vendors. A single top-level table id cannot
+	// cite dollars drawn from two tables, so each priced model carries the table
+	// that produced its own figure.
+	function buildProvided(
+		rows: ReadonlyArray<{ key: string; input: number; output: number }>,
+		syncConfig: SyncConfig = config(),
+	): MeasuredPayload {
+		const agg = sharedAggregate();
+		for (const r of rows) {
+			const counts: TokenCounts = {
+				input: r.input,
+				output: r.output,
+				cacheWrite5m: 0,
+				cacheWrite1h: 0,
+				cacheWriteUnsplit: 0,
+				cacheRead: 0,
+			};
+			addModelUsage(agg, r.key, counts, apiEquivalentCost(r.key, counts, NOW));
+		}
+		return buildPayload({
+			aggregate: agg,
+			stats: CLEAN_STATS,
+			syncConfig,
+			now: NOW,
+			windowDays: 30,
+			...HARNESS_PARAMS,
+		}).payload;
+	}
+
+	it("cites each priced model's own table in a mixed-vendor payload", () => {
+		const payload = buildProvided([
+			{ key: "openai:gpt-5.4", input: 1_000_000, output: 0 },
+			{ key: "google:gemini-3.6-flash", input: 1_000_000, output: 0 },
+		]);
+		const byId = new Map(payload.models.map((m) => [m.id, m]));
+		expect(byId.get("openai:gpt-5.4")?.pricingTable).toBe(
+			OPENAI_PRICING_TABLE_VERSION,
+		);
+		expect(byId.get("google:gemini-3.6-flash")?.pricingTable).toBe(
+			GOOGLE_PRICING_TABLE_VERSION,
+		);
+	});
+
+	it("nulls the top-level table when the models cite more than one", () => {
+		// A single string over a mixed payload is a false citation — the defect
+		// this ticket exists to remove. The per-model fields carry the truth.
+		const payload = buildProvided([
+			{ key: "openai:gpt-5.4", input: 1_000_000, output: 0 },
+			{ key: "google:gemini-3.6-flash", input: 1_000_000, output: 0 },
+		]);
+		expect(payload.pricingTable).toBeNull();
+	});
+
+	it("keeps the single table id top-level when only one is cited", () => {
+		// A Claude Code payload reads exactly as it always did.
+		const payload = build([
+			assistant({
+				model: "claude-opus-5",
+				usage: { output_tokens: 1_000_000 },
+			}),
+		]);
+		expect(payload.pricingTable).toBe(PRICING_TABLE_VERSION);
+		expect(payload.models[0].pricingTable).toBe(PRICING_TABLE_VERSION);
+	});
+
+	it("pairs the citation with the dollars — an unpriced model carries neither", () => {
+		const payload = buildProvided([
+			{ key: "google:gemini-3.6-flash", input: 1_000_000, output: 0 },
+			{ key: "github-copilot:gemini-3-pro-preview", input: 500_000, output: 0 },
+		]);
+		const byId = new Map(payload.models.map((m) => [m.id, m]));
+		expect(byId.get("github-copilot:gemini-3-pro-preview")).not.toHaveProperty(
+			"pricingTable",
+		);
+		expect(byId.get("google:gemini-3.6-flash")?.pricingTable).toBe(
+			GOOGLE_PRICING_TABLE_VERSION,
+		);
+	});
+
+	it("cites local-no-charge for a $0 local row", () => {
+		// Free is a fact about the machine, and it has a citation like any other
+		// figure — that is what separates it from unpriced.
+		const payload = buildProvided([
+			{ key: "ollama:qwen3-coder", input: 1_000_000, output: 0 },
+		]);
+		expect(payload.models[0].apiEquivalentUSD).toBe(0);
+		expect(payload.models[0].pricingTable).toBe(LOCAL_PRICING_TABLE_VERSION);
+	});
+
+	it("omits every citation when publishCost is off", () => {
+		const payload = buildProvided(
+			[{ key: "openai:gpt-5.4", input: 1_000_000, output: 0 }],
+			config({ publishCost: false }),
+		);
+		expect(payload.pricingTable).toBeNull();
+		expect(payload.models[0]).not.toHaveProperty("pricingTable");
+		expect(JSON.stringify(payload)).not.toContain(OPENAI_PRICING_TABLE_VERSION);
 	});
 });
 

--- a/packages/cli/src/harness/shared/payload.ts
+++ b/packages/cli/src/harness/shared/payload.ts
@@ -13,7 +13,7 @@
 //      not in the payload at all (#33 decision 11) — there is nothing to
 //      "reveal" server-side, because nothing was transmitted.
 
-import { baseModelId } from "@aistack/pricing";
+import { baseModelId, pricingTableFor } from "@aistack/pricing";
 import {
 	type Aggregate,
 	cleanName,
@@ -44,6 +44,13 @@ export type PayloadModel = {
 		cacheRead: number;
 	};
 	apiEquivalentUSD?: number;
+	/**
+	 * The table that produced `apiEquivalentUSD` — present exactly when the
+	 * dollars are (#136). Per model, not per payload: one opencode payload mixes
+	 * vendors, so a single top-level id would cite one table for dollars drawn
+	 * from two.
+	 */
+	pricingTable?: string;
 };
 
 export type PayloadAtom = { name: string; callShare: number };
@@ -70,7 +77,12 @@ export type MeasuredPayload = {
 	capturedAt: number;
 	window: { days: number; from: string; to: string };
 	harness: { name: string; version: string | null };
-	/** `null` when `publishCost` is off — no cost was computed into the payload. */
+	/**
+	 * The one table the models' citations agree on, or `null` — when
+	 * `publishCost` is off, when nothing priced, and when a mixed-vendor payload
+	 * cites several tables (the per-model `pricingTable` fields carry the truth,
+	 * and joining them here would blow the server's 64-character name bound).
+	 */
 	pricingTable: string | null;
 	activity: {
 		sessions: number;
@@ -181,6 +193,8 @@ type ModelGroup = {
 	costUSD: number;
 	unpricedTokens: number;
 	anyUnpriceable: boolean;
+	/** The table citing this group's rates; every row shares it (one base model). */
+	table: string | null;
 };
 
 /**
@@ -211,9 +225,11 @@ function groupModels(rows: readonly ModelRow[]): ModelGroup[] {
 				costUSD: 0,
 				unpricedTokens: 0,
 				anyUnpriceable: false,
+				table: null,
 			};
 			groups.set(id, g);
 		}
+		g.table ??= pricingTableFor(r.modelKey);
 		g.totalTokens += r.totalTokens;
 		g.input += r.tokens.input;
 		g.output += r.tokens.output;
@@ -249,9 +265,16 @@ function buildModels(
 		};
 		// Absent, not zero: a partially-priced model reporting a dollar figure
 		// would understate without saying so. `excludedTokens.unpriced` carries
-		// the tokens that were left out.
-		if (publishCost && !g.anyUnpriceable && g.unpricedTokens === 0) {
+		// the tokens that were left out. Dollars and their citation travel
+		// together (#136) — a figure without its table may not render anywhere.
+		if (
+			publishCost &&
+			!g.anyUnpriceable &&
+			g.unpricedTokens === 0 &&
+			g.table !== null
+		) {
 			model.apiEquivalentUSD = round2(g.costUSD);
+			model.pricingTable = g.table;
 		}
 		return model;
 	});
@@ -272,8 +295,6 @@ export type BuildPayloadInput = {
 	harnessName: string;
 	/** The adapter's fail-closed vendor tool set (#66 decision 3). */
 	builtinTools: ReadonlySet<string>;
-	/** The adapter's pinned price-table id, stamped only when cost publishes. */
-	pricingTableVersion: string;
 };
 
 export type BuiltPayload = {
@@ -300,7 +321,6 @@ export function buildPayload(input: BuildPayloadInput): BuiltPayload {
 		windowDays,
 		harnessName,
 		builtinTools,
-		pricingTableVersion,
 	} = input;
 	const finalized = finalize(agg);
 	const { publishCost, allowlist, optIns } = syncConfig;
@@ -348,6 +368,18 @@ export function buildPayload(input: BuildPayloadInput): BuiltPayload {
 		sumCounts(finalized.slashCommands),
 	);
 
+	const models = buildModels(
+		finalized.models,
+		finalized.totalTokens,
+		publishCost,
+	);
+	// The citation lives on each model (#136). The top-level field survives for
+	// readers of the old shape and states the one table everything agrees on —
+	// never a false single citation over a mixed payload.
+	const citedTables = [
+		...new Set(models.flatMap((m) => (m.pricingTable ? [m.pricingTable] : []))),
+	];
+
 	const payload: MeasuredPayload = {
 		schemaVersion: SCHEMA_VERSION,
 		capturedAt: now,
@@ -359,7 +391,7 @@ export function buildPayload(input: BuildPayloadInput): BuiltPayload {
 					? null
 					: sanitizeModelId(finalized.harnessVersion),
 		},
-		pricingTable: publishCost ? pricingTableVersion : null,
+		pricingTable: citedTables.length === 1 ? citedTables[0] : null,
 		activity: {
 			sessions: finalized.sessions,
 			activeDays,
@@ -368,7 +400,7 @@ export function buildPayload(input: BuildPayloadInput): BuiltPayload {
 			cacheHitShare: round4(finalized.cacheHitShare),
 			subagentShare: round4(finalized.sidechainShare),
 		},
-		models: buildModels(finalized.models, finalized.totalTokens, publishCost),
+		models,
 		inventory: {
 			builtinTools: builtins.atoms,
 			mcpServers: mcp.atoms,

--- a/packages/cli/src/harness/types.ts
+++ b/packages/cli/src/harness/types.ts
@@ -41,11 +41,6 @@ export interface HarnessAdapter {
 	 */
 	readonly builtinTools: ReadonlySet<string>;
 	/**
-	 * The pinned price-table id stamped into this harness's payloads. Per
-	 * harness because the vendors publish their lists separately.
-	 */
-	readonly pricingTableVersion: string;
-	/**
 	 * True when this harness wrote a transcript inside the sync window. A log
 	 * root that merely exists is NOT detection (#101): a months-old install
 	 * leaves one behind forever, and it used to scan, publish, ask and hook.

--- a/packages/cli/src/sync/stage.test.ts
+++ b/packages/cli/src/sync/stage.test.ts
@@ -2,7 +2,6 @@
 // staged bodyJson IS the serialized body, the id is derived from it, and a
 // stage that cannot name its destination is blocked before any gate.
 
-import { PRICING_TABLE_VERSION } from "@aistack/pricing";
 import { describe, expect, test } from "vitest";
 import { createAggregate, ingestRecord } from "../harness/claude/analyzer.js";
 import { assistant } from "../harness/claude/fixtures.js";
@@ -64,7 +63,6 @@ function deps(
 const FAKE_CLAUDE_ADAPTER: HarnessAdapter = {
 	name: "claude-code",
 	builtinTools: BUILTIN_TOOLS,
-	pricingTableVersion: PRICING_TABLE_VERSION,
 	detect: async () => true,
 	scan: async () => {
 		const aggregate = createAggregate();

--- a/packages/cli/src/sync/stage.ts
+++ b/packages/cli/src/sync/stage.ts
@@ -112,7 +112,6 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 				windowDays,
 				harnessName: adapter.name,
 				builtinTools: adapter.builtinTools,
-				pricingTableVersion: adapter.pricingTableVersion,
 			}),
 		);
 	}

--- a/packages/cli/src/sync/summary.ts
+++ b/packages/cli/src/sync/summary.ts
@@ -71,14 +71,15 @@ const fmtPct = (share: number): string => `${(share * 100).toFixed(1)}%`;
  * dollars.
  */
 export function totalUSD(payload: MeasuredPayload): number | null {
-	if (payload.pricingTable === null) return null;
 	let sum = 0;
 	let any = false;
 	for (const m of payload.models) {
-		if (m.apiEquivalentUSD !== undefined) {
-			sum += m.apiEquivalentUSD;
-			any = true;
-		}
+		if (m.apiEquivalentUSD === undefined) continue;
+		// The citation may sit on the model (#136) or, in the old single-vendor
+		// shape, on the payload. A figure neither cites stays unrendered.
+		if (m.pricingTable === undefined && payload.pricingTable === null) continue;
+		sum += m.apiEquivalentUSD;
+		any = true;
 	}
 	return any ? sum : null;
 }


### PR DESCRIPTION
Closes #136.

## The defect

One opencode payload mixes vendors. The wire stamped one `pricingTable` id over dollars drawn from two tables. That is a false citation, not missing dollars.

## The fix

The citation rides on the rate. Each priced model now carries `pricingTable` beside `apiEquivalentUSD` — present exactly when the dollars are. The top-level `pricingTable` stays on the wire and holds the one table all models agree on, or `null`. A joined string cannot hold two ids, because the server bounds the field to 64 characters.

- **CLI** (`packages/cli`): `buildModels` takes each group's table from `pricingTableFor(modelKey)`. `HarnessAdapter.pricingTableVersion` is removed — the table comes from the rate, not from the harness. The gate's `totalUSD` accepts a citation on the model or on the payload.
- **Backend** (`convex`): the closed validator accepts the new optional field and holds it to the same display-safe bound as the payload-level one. `repriceSnapshot` cites `m.pricingTable ?? publishedTable`, so the old shape keeps its citation. An estimated row also gets a per-model citation from our table. `mergeModels` keeps a merged citation only when every contributor cites the same table.

## Wire compatibility

This is an additive wire change. Old clients send no per-model field and keep working — the backend falls back to the payload-level table. **Deploy the backend before the CLI release (#127)**, as `AGENTS.md` requires: an old backend's closed validator rejects the new field.

## Tests

- `packages/cli/src/harness/shared/payload.test.ts`: mixed payload cites per model, top-level nulls on a mix, single-vendor payloads unchanged, citation pairs with the dollars, `local-no-charge` cited, publishCost off omits everything.
- `convex/lib/reprice.test.ts`: per-model citations surface in `pricingTables`, old-shape fallback, no duplicate tables, citation strips with the dollars, estimates stamped.
- `convex/measured.test.ts`: validator accepts and bounds the field; a mixed snapshot's cost reading names both tables.

Full suite: 1778 passed. The 69 pre-existing `tsc` errors in `stack-view` test files are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TuPYyH6JxiDRSnJa6sCvK