### PR TITLE
Task: the opencode adapter (alp82/aistack#124)

### DIFF
--- a/packages/cli/src/harness/detect.test.ts
+++ b/packages/cli/src/harness/detect.test.ts
@@ -14,6 +14,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { enableAutoSync } from "../autosync/optin.js";
 import { claudeRecentlyActive } from "../commands/connect.js";
@@ -29,11 +30,46 @@ let dir: string;
 const savedEnv = {
 	CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
 	CODEX_HOME: process.env.CODEX_HOME,
+	XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+	OPENCODE_DB: process.env.OPENCODE_DB,
 };
 
 beforeEach(() => {
 	dir = mkdtempSync(join(tmpdir(), "aistack-detect-"));
+	// Point every harness at the temp dir so the machine running the tests
+	// never leaks its own installs into `detectedAdapters`.
+	process.env.XDG_DATA_HOME = join(dir, "xdg-data");
+	delete process.env.OPENCODE_DB;
 });
+
+/** A minimal real opencode store with one message at `tsMs`. */
+function writeOpencodeDb(tsMs: number): void {
+	const dataDir = join(dir, "xdg-data", "opencode");
+	mkdirSync(dataDir, { recursive: true });
+	const db = new DatabaseSync(join(dataDir, "opencode.db"));
+	db.exec(`
+		create table migration (id text primary key, time_completed integer);
+		create table session (id text primary key, parent_id text, version text);
+		create table message (id text primary key, session_id text,
+			time_created integer, time_updated integer, data text);
+		create table part (id text primary key, message_id text, session_id text,
+			time_created integer, time_updated integer, data text);
+		create table session_message (id text primary key, session_id text,
+			type text, time_created integer, time_updated integer, data text, seq integer);
+	`);
+	db.prepare("insert into migration values (?, ?)").run(
+		"20260622202450_simplify_session_input",
+		tsMs,
+	);
+	db.prepare("insert into message values (?, ?, ?, ?, ?)").run(
+		"msg_1",
+		"ses_1",
+		tsMs,
+		tsMs,
+		JSON.stringify({ role: "assistant", time: { created: tsMs } }),
+	);
+	db.close();
+}
 
 afterEach(() => {
 	rmSync(dir, { recursive: true, force: true });
@@ -141,6 +177,24 @@ describe("detectedAdapters", () => {
 
 		const names = (await detectedAdapters(SINCE)).map((a) => a.name);
 		expect(names).toEqual(["claude-code", "codex"]);
+	});
+
+	it("an in-window opencode store detects, after the other two", async () => {
+		process.env.CLAUDE_CONFIG_DIR = join(dir, "claude-home");
+		process.env.CODEX_HOME = join(dir, "codex-home");
+		write("claude-home/projects/proj-a/sess-1.jsonl", NOW - DAY);
+		writeOpencodeDb(NOW - DAY);
+
+		const names = (await detectedAdapters(SINCE)).map((a) => a.name);
+		expect(names).toEqual(["claude-code", "opencode"]);
+	});
+
+	it("an opencode store with only stale rows stays undetected", async () => {
+		process.env.CLAUDE_CONFIG_DIR = join(dir, "claude-home");
+		process.env.CODEX_HOME = join(dir, "codex-home");
+		writeOpencodeDb(NOW - 90 * DAY);
+
+		expect(await detectedAdapters(SINCE)).toEqual([]);
 	});
 
 	it("returns nothing when every harness is stale", async () => {

--- a/packages/cli/src/harness/index.ts
+++ b/packages/cli/src/harness/index.ts
@@ -22,6 +22,7 @@
 
 import { CLAUDE_HARNESS_NAME, claudeAdapter } from "./claude/adapter.js";
 import { CODEX_HARNESS_NAME, codexAdapter } from "./codex/adapter.js";
+import { OPENCODE_HARNESS_NAME, opencodeAdapter } from "./opencode/adapter.js";
 import { DEFAULT_WINDOW_DAYS, windowStartMs } from "./shared/window.js";
 import type { HarnessAdapter } from "./types.js";
 
@@ -58,6 +59,11 @@ export {
 } from "./claude/analyzer.js";
 export { type ScanOptions, scan, transcriptRoots } from "./claude/scan.js";
 export { CODEX_HARNESS_NAME, codexAdapter } from "./codex/adapter.js";
+export {
+	OPENCODE_BUILTIN_TOOLS,
+	OPENCODE_HARNESS_NAME,
+	opencodeAdapter,
+} from "./opencode/adapter.js";
 export {
 	type Aggregate,
 	cleanName,
@@ -124,12 +130,15 @@ export type {
 export const HARNESS_ADAPTERS: readonly HarnessAdapter[] = [
 	claudeAdapter,
 	codexAdapter,
+	opencodeAdapter,
 ];
 
 /** Display name for a harness discriminator. One name per harness, defined here. */
 export function harnessLabel(name: string): string {
 	if (name === CLAUDE_HARNESS_NAME) return "Claude Code";
 	if (name === CODEX_HARNESS_NAME) return "Codex";
+	// The brand spells itself lowercase, so the discriminator IS the label.
+	if (name === OPENCODE_HARNESS_NAME) return "opencode";
 	return name;
 }
 

--- a/packages/cli/src/harness/opencode/adapter.ts
+++ b/packages/cli/src/harness/opencode/adapter.ts
@@ -1,0 +1,36 @@
+// The opencode harness behind the seam (#66 decision 6) — wayfinder ticket
+// #124 (map #121).
+
+import type {
+	HarnessAdapter,
+	HarnessDetectOptions,
+	HarnessScan,
+	HarnessScanOptions,
+} from "../types.js";
+import { createAggregate, OPENCODE_BUILTIN_TOOLS } from "./analyzer.js";
+import { detectOpencode, scan } from "./scan.js";
+
+export const OPENCODE_HARNESS_NAME = "opencode";
+
+export { OPENCODE_BUILTIN_TOOLS } from "./analyzer.js";
+
+export const opencodeAdapter: HarnessAdapter = {
+	name: OPENCODE_HARNESS_NAME,
+	builtinTools: OPENCODE_BUILTIN_TOOLS,
+
+	async detect(opts: HarnessDetectOptions): Promise<boolean> {
+		return detectOpencode({
+			sinceMs: opts.sinceMs,
+			...(opts.roots ? { roots: opts.roots } : {}),
+		});
+	},
+
+	async scan(opts: HarnessScanOptions): Promise<HarnessScan> {
+		const aggregate = createAggregate();
+		const stats = await scan(aggregate, {
+			sinceMs: opts.sinceMs,
+			...(opts.onProgress ? { onProgress: opts.onProgress } : {}),
+		});
+		return { aggregate, stats };
+	},
+};

--- a/packages/cli/src/harness/opencode/analyzer.test.ts
+++ b/packages/cli/src/harness/opencode/analyzer.test.ts
@@ -1,0 +1,273 @@
+// The opencode fold — wayfinder ticket #124 (map #121). The properties that
+// matter most, from docs/research/harness-adapters-2026-08.md:
+//   - every model key carries the harness's own provider id (#123): a gateway
+//     re-serving a vendor's model must NOT price at that vendor's list rate;
+//   - the four token counters are disjoint deltas — map straight through,
+//     never read `tokens.total`, never add `reasoning`;
+//   - opencode's own `cost` field is 0.0 on every record and never publishes.
+
+import { describe, expect, it } from "vitest";
+import { finalize } from "../shared/aggregate.js";
+import {
+	createAggregate,
+	createDbFoldState,
+	ingestMessageRow,
+	ingestToolPart,
+	type MessageRow,
+	noteConfiguredMcpServers,
+	noteSessions,
+	type ToolPartRow,
+} from "./analyzer.js";
+
+// 2026-07-20T12:00:00Z — inside every rate period the table cites today.
+const TS = Date.UTC(2026, 6, 20, 12, 0, 0);
+
+function row(over: Partial<MessageRow> = {}): MessageRow {
+	return {
+		id: "msg_0001",
+		sessionId: "ses_0001",
+		role: "assistant",
+		providerId: "anthropic",
+		modelId: "claude-opus-4-6",
+		tsMs: TS,
+		input: 100,
+		output: 10,
+		cacheRead: 1000,
+		cacheWrite: 200,
+		cwd: "/home/u/secret-project",
+		...over,
+	};
+}
+
+describe("ingestMessageRow", () => {
+	it("folds one assistant row under its provider-keyed model, priced at its own timestamp", () => {
+		const agg = createAggregate();
+		const state = createDbFoldState();
+		noteSessions(state, [
+			{ id: "ses_0001", parentId: null, version: "1.18.11" },
+		]);
+
+		ingestMessageRow(agg, state, row());
+
+		const m = agg.byModel.get("anthropic:claude-opus-4-6");
+		expect(m).toBeDefined();
+		expect(m).toMatchObject({
+			input: 100,
+			output: 10,
+			cacheRead: 1000,
+			cacheWriteUnsplit: 200,
+			cacheWrite5m: 0,
+			cacheWrite1h: 0,
+			messages: 1,
+			unpricedTokens: 0,
+		});
+		// Hand-computed at Anthropic list (5/25, write5m ×1.25, read ×0.1):
+		// (100·5 + 10·25 + 200·5·1.25 + 1000·5·0.1) / 1e6
+		expect(m?.costUSD).toBeCloseTo(0.0025, 10);
+		expect(agg.distinctResponses).toBe(1);
+		expect(agg.sessions).toEqual(new Set(["ses_0001"]));
+		expect(agg.activeDays).toEqual(new Set(["2026-07-20"]));
+		expect(agg.ccVersions).toEqual(new Set(["1.18.11"]));
+		expect(agg.projectDirs.size).toBe(1);
+	});
+
+	it("a gateway re-serving a vendor's model stays unpriced — never the vendor's list rate", () => {
+		const agg = createAggregate();
+		const state = createDbFoldState();
+
+		ingestMessageRow(
+			agg,
+			state,
+			row({ providerId: "github-copilot", modelId: "gemini-3-pro-preview" }),
+		);
+
+		const m = agg.byModel.get("github-copilot:gemini-3-pro-preview");
+		expect(m?.costUSD).toBe(0);
+		expect(m?.unpricedTokens).toBe(1310);
+		const f = finalize(agg);
+		expect(f.models[0]?.costUSD).toBeNull();
+		expect(f.unpricedTokens).toBe(1310);
+	});
+
+	it("a local provider prices at a real zero, not as unpriced", () => {
+		const agg = createAggregate();
+		const state = createDbFoldState();
+
+		ingestMessageRow(
+			agg,
+			state,
+			row({ providerId: "ollama", modelId: "llama3.2:3b" }),
+		);
+
+		const m = agg.byModel.get("ollama:llama3.2:3b");
+		expect(m?.costUSD).toBe(0);
+		expect(m?.unpricedTokens).toBe(0);
+		expect(finalize(agg).models[0]?.costUSD).toBe(0);
+	});
+
+	it("splits main and subagent tokens by the session's parent", () => {
+		const agg = createAggregate();
+		const state = createDbFoldState();
+		noteSessions(state, [
+			{ id: "ses_main", parentId: null, version: "1.18.11" },
+			{ id: "ses_child", parentId: "ses_main", version: "1.18.11" },
+		]);
+
+		ingestMessageRow(agg, state, row({ id: "m1", sessionId: "ses_main" }));
+		ingestMessageRow(agg, state, row({ id: "m2", sessionId: "ses_child" }));
+
+		expect(agg.mainTokens).toBe(1310);
+		expect(agg.sidechainTokens).toBe(1310);
+		expect(finalize(agg).sidechainShare).toBeCloseTo(0.5, 10);
+	});
+
+	it("counts a message id once even when it appears in both table generations", () => {
+		const agg = createAggregate();
+		const state = createDbFoldState();
+
+		ingestMessageRow(agg, state, row({ id: "m1" }));
+		ingestMessageRow(agg, state, row({ id: "m1" }));
+
+		expect(agg.distinctResponses).toBe(1);
+		expect(agg.byModel.get("anthropic:claude-opus-4-6")?.messages).toBe(1);
+	});
+
+	it("a row missing its provider folds under (unknown), never a bare vendor key", () => {
+		const agg = createAggregate();
+		const state = createDbFoldState();
+
+		ingestMessageRow(agg, state, row({ providerId: null }));
+
+		expect([...agg.byModel.keys()]).toEqual(["(unknown)"]);
+		expect(agg.byModel.get("(unknown)")?.unpricedTokens).toBe(1310);
+	});
+
+	it("a dated model suffix normalizes inside the provider key", () => {
+		const agg = createAggregate();
+		const state = createDbFoldState();
+
+		ingestMessageRow(agg, state, row({ modelId: "claude-opus-4-5-20251101" }));
+
+		expect([...agg.byModel.keys()]).toEqual(["anthropic:claude-opus-4-5"]);
+	});
+
+	it("a row with no timestamp cannot be priced time-awarely", () => {
+		const agg = createAggregate();
+		const state = createDbFoldState();
+
+		ingestMessageRow(agg, state, row({ tsMs: null }));
+
+		expect(agg.untimestampedResponses).toBe(1);
+		expect(agg.byModel.get("anthropic:claude-opus-4-6")?.unpricedTokens).toBe(
+			1310,
+		);
+	});
+
+	it("a non-assistant row counts activity but no tokens", () => {
+		const agg = createAggregate();
+		const state = createDbFoldState();
+
+		ingestMessageRow(agg, state, row({ role: "user", id: "u1" }));
+
+		expect(agg.sessions.size).toBe(1);
+		expect(agg.distinctResponses).toBe(0);
+		expect(agg.byModel.size).toBe(0);
+	});
+});
+
+function part(over: Partial<ToolPartRow> = {}): ToolPartRow {
+	return {
+		id: "prt_0001",
+		partType: "tool",
+		tool: "bash",
+		callId: null,
+		inputName: null,
+		subagentType: null,
+		...over,
+	};
+}
+
+describe("ingestToolPart", () => {
+	it("a built-in name containing an underscore never invents an MCP server", () => {
+		// Splitting `apply_patch` on the first `_` would publish a fake server
+		// named `apply` (research §inventory) — the literal built-in set wins.
+		const agg = createAggregate();
+		const state = createDbFoldState();
+
+		ingestToolPart(agg, state, part({ tool: "apply_patch" }));
+
+		expect(agg.toolCalls.get("apply_patch")).toBe(1);
+		expect(agg.mcpServerCalls.size).toBe(0);
+	});
+
+	it("a configured MCP server's prefix recovers the server and the tool", () => {
+		const agg = createAggregate();
+		const state = createDbFoldState();
+		noteConfiguredMcpServers(agg, state, ["chrome-devtools"]);
+
+		ingestToolPart(agg, state, part({ tool: "chrome-devtools_click" }));
+
+		expect(agg.mcpServerCalls.get("chrome-devtools")).toBe(1);
+		expect(agg.mcpToolCalls.get("chrome-devtools_click")).toBe(1);
+		expect(agg.toolCalls.size).toBe(0);
+	});
+
+	it("a configured server the window never called still inventories at zero", () => {
+		const agg = createAggregate();
+		const state = createDbFoldState();
+
+		noteConfiguredMcpServers(agg, state, ["idle-server"]);
+
+		expect(agg.mcpServerCalls.get("idle-server")).toBe(0);
+	});
+
+	it("an unknown underscored name buckets as a plain tool count, not a split", () => {
+		const agg = createAggregate();
+		const state = createDbFoldState();
+
+		ingestToolPart(agg, state, part({ tool: "mystery_helper_run" }));
+
+		expect(agg.toolCalls.get("mystery_helper_run")).toBe(1);
+		expect(agg.mcpServerCalls.size).toBe(0);
+	});
+
+	it("the skill tool records the skill name", () => {
+		const agg = createAggregate();
+		const state = createDbFoldState();
+
+		ingestToolPart(agg, state, part({ tool: "skill", inputName: "tdd" }));
+
+		expect(agg.toolCalls.get("skill")).toBe(1);
+		expect(agg.skillCalls.get("tdd")).toBe(1);
+	});
+
+	it("the task tool records the subagent type", () => {
+		const agg = createAggregate();
+		const state = createDbFoldState();
+
+		ingestToolPart(agg, state, part({ tool: "task", subagentType: "explore" }));
+
+		expect(agg.toolCalls.get("task")).toBe(1);
+		expect(agg.subagentCalls.get("explore")).toBe(1);
+	});
+
+	it("a repeated callID counts once", () => {
+		const agg = createAggregate();
+		const state = createDbFoldState();
+
+		ingestToolPart(agg, state, part({ id: "p1", callId: "call_1" }));
+		ingestToolPart(agg, state, part({ id: "p2", callId: "call_1" }));
+
+		expect(agg.toolCalls.get("bash")).toBe(1);
+	});
+
+	it("a step-finish part never counts — its tokens repeat the message's", () => {
+		const agg = createAggregate();
+		const state = createDbFoldState();
+
+		ingestToolPart(agg, state, part({ partType: "step-finish", tool: null }));
+
+		expect(agg.toolCalls.size).toBe(0);
+		expect(agg.records).toBe(0);
+	});
+});

--- a/packages/cli/src/harness/opencode/analyzer.ts
+++ b/packages/cli/src/harness/opencode/analyzer.ts
@@ -1,0 +1,281 @@
+// Pure fold over rows projected out of opencode's SQLite store. No I/O, no
+// console — the scanner owns the database and hands this module plain values.
+//
+// Wayfinder ticket #124 (map #121). Field semantics come from
+// docs/research/harness-adapters-2026-08.md (§opencode), keyed by #123's
+// binding rule: every pricing key carries the harness's own provider id
+// (`modelKeyFor(providerID, modelID)`), because one opencode install routes
+// several providers and a gateway re-serving a vendor's model must not price
+// at that vendor's list rate.
+//
+// THE LOAD-BEARING FACTS (research §2):
+//   - the four token counters are DISJOINT deltas: input, output, cache.read,
+//     cache.write map straight onto TokenCounts with no arithmetic;
+//   - `tokens.total` is absent on some rows and wrong on Google rows — never
+//     read it; `reasoning` is a subset of `output` for two vendors and
+//     additive for one — never add it;
+//   - opencode's own `cost` is 0.0 on every record (subscription/OAuth auth);
+//     a zero is not a measurement, so cost comes from @aistack/pricing only.
+
+import {
+	apiEquivalentCost,
+	modelKeyFor,
+	normalizeModel,
+	type TokenCounts,
+} from "@aistack/pricing";
+import {
+	addModelUsage,
+	asNum,
+	asStr,
+	bump,
+	cleanName,
+	createAggregate as createSharedAggregate,
+	type Aggregate as SharedAggregate,
+} from "../shared/aggregate.js";
+
+/**
+ * opencode's vendor-assigned tool surface, as observed in the probe DB and
+ * pinned against the opencode source. Same fail-closed mechanism as the other
+ * adapters: a literal set, never a pattern. It doubles as the MCP guard —
+ * MCP tool names are `sanitize(server) + "_" + sanitize(tool)` and built-in
+ * names contain `_` too, so a name must miss this set AND carry a configured
+ * server's prefix before any split is attempted.
+ */
+export const OPENCODE_BUILTIN_TOOLS: ReadonlySet<string> = new Set([
+	"apply_patch",
+	"bash",
+	"edit",
+	"glob",
+	"grep",
+	"list",
+	"patch",
+	"question",
+	"read",
+	"skill",
+	"task",
+	"todoread",
+	"todowrite",
+	"webfetch",
+	"websearch",
+	"write",
+]);
+
+/** Message-id dedup lives in DbFoldState, not the aggregate's `seen`. */
+export type Aggregate = SharedAggregate<never>;
+
+export function createAggregate(): Aggregate {
+	return createSharedAggregate<never>();
+}
+
+/** What the scanner knows about one session row, named columns only. */
+export type SessionInfo = {
+	id: unknown;
+	parentId: unknown;
+	version: unknown;
+};
+
+/**
+ * Per-database fold state. Sessions are loaded up front (a message's session
+ * may predate the window); message ids are deduped across the v1 and v2
+ * tables because v2 is described in the opencode source as a projection —
+ * reading a row from both would double count.
+ */
+export type DbFoldState = {
+	sessions: Map<string, { parentId: string | null; version: string | null }>;
+	seenMessageIds: Set<string>;
+	/** Configured MCP server names, sanitized the way opencode builds tool names. */
+	mcpServers: string[];
+};
+
+export function createDbFoldState(): DbFoldState {
+	return { sessions: new Map(), seenMessageIds: new Set(), mcpServers: [] };
+}
+
+export function noteSessions(
+	state: DbFoldState,
+	rows: Iterable<SessionInfo>,
+): void {
+	for (const row of rows) {
+		const id = asStr(row.id);
+		if (!id) continue;
+		state.sessions.set(id, {
+			parentId: asStr(row.parentId),
+			version: asStr(row.version),
+		});
+	}
+}
+
+/**
+ * One projected message row. Every value is untrusted — `json_extract` returns
+ * whatever the blob holds — so the fold narrows each field itself.
+ */
+export type MessageRow = {
+	id: unknown;
+	sessionId: unknown;
+	role: unknown;
+	providerId: unknown;
+	modelId: unknown;
+	/** `data.time.created`, epoch ms. */
+	tsMs: unknown;
+	input: unknown;
+	output: unknown;
+	cacheRead: unknown;
+	cacheWrite: unknown;
+	cwd: unknown;
+};
+
+export function ingestMessageRow(
+	agg: Aggregate,
+	state: DbFoldState,
+	row: MessageRow,
+): void {
+	agg.records++;
+
+	const id = asStr(row.id);
+	if (id) {
+		if (state.seenMessageIds.has(id)) return;
+		state.seenMessageIds.add(id);
+	}
+
+	const tsMs =
+		typeof row.tsMs === "number" && Number.isFinite(row.tsMs) ? row.tsMs : null;
+	if (tsMs !== null) {
+		agg.activeDays.add(new Date(tsMs).toISOString().slice(0, 10));
+		agg.firstTs = agg.firstTs === null ? tsMs : Math.min(agg.firstTs, tsMs);
+		agg.lastTs = agg.lastTs === null ? tsMs : Math.max(agg.lastTs, tsMs);
+	}
+
+	const sessionId = asStr(row.sessionId);
+	const session = sessionId ? state.sessions.get(sessionId) : undefined;
+	if (sessionId) {
+		agg.sessions.add(sessionId);
+		if (session?.version) agg.ccVersions.add(cleanName(session.version));
+	}
+	// Counted, never published — same standing non-goal as Claude project dirs.
+	const cwd = asStr(row.cwd);
+	if (cwd) agg.projectDirs.add(cwd);
+
+	if (asStr(row.role) !== "assistant") return;
+	agg.assistantRecords++;
+	agg.distinctResponses++;
+	if (tsMs === null) agg.untimestampedResponses++;
+
+	const counts: TokenCounts = {
+		input: asNum(row.input),
+		output: asNum(row.output),
+		cacheWrite5m: 0,
+		cacheWrite1h: 0,
+		cacheWriteUnsplit: asNum(row.cacheWrite),
+		cacheRead: asNum(row.cacheRead),
+	};
+
+	// A session with a parent is a subagent's — an honest measurement here,
+	// unlike Codex's structural 0 (research §inventory: 21.4% on the probe DB).
+	const total =
+		counts.input + counts.output + counts.cacheWriteUnsplit + counts.cacheRead;
+	if (session?.parentId) agg.sidechainTokens += total;
+	else agg.mainTokens += total;
+
+	const provider = asStr(row.providerId);
+	const model = asStr(row.modelId);
+	const modelKey =
+		provider && model
+			? normalizeModel(modelKeyFor(provider, cleanName(model)))
+			: "(unknown)";
+	addModelUsage(
+		agg,
+		modelKey,
+		counts,
+		apiEquivalentCost(modelKey, counts, tsMs),
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Inventory — `part` rows of type "tool"
+// ---------------------------------------------------------------------------
+
+/**
+ * opencode's own `sanitize` as applied when composing MCP tool names: the
+ * observed names (`chrome-devtools_click`) show `-` surviving, so everything
+ * outside the tool-name charset collapses to `_`.
+ */
+const sanitizeMcpName = (name: string): string =>
+	name.replace(/[^A-Za-z0-9_-]/g, "_");
+
+/**
+ * One projected `part` row. The scanner extracts these named paths and
+ * nothing else — `part.data.state.output` holds full command output and never
+ * materializes in JS.
+ */
+export type ToolPartRow = {
+	id: unknown;
+	partType: unknown;
+	tool: unknown;
+	callId: unknown;
+	/** `$.state.input.name` — the skill tool's skill. */
+	inputName: unknown;
+	/** `$.state.input.subagent_type` — the task tool's agent. */
+	subagentType: unknown;
+};
+
+export function ingestToolPart(
+	agg: Aggregate,
+	state: DbFoldState,
+	row: ToolPartRow,
+): void {
+	// step-finish parts repeat the message's tokens and text parts carry prose;
+	// only tool executions count (research §2).
+	if (asStr(row.partType) !== "tool") return;
+	const rawName = asStr(row.tool);
+	if (!rawName) return;
+	const name = cleanName(rawName);
+
+	const dedupKey = asStr(row.callId) ?? asStr(row.id);
+	if (dedupKey) {
+		if (agg.toolCallDedup.has(dedupKey)) return;
+		agg.toolCallDedup.add(dedupKey);
+	}
+
+	// Fail-closed order (research §inventory): the literal built-in set first,
+	// then configured MCP server prefixes, then a plain count the shared
+	// payload filter withholds — never a split that invents a server name.
+	if (OPENCODE_BUILTIN_TOOLS.has(name)) {
+		bump(agg.toolCalls, name);
+		if (name === "skill") {
+			const skill = asStr(row.inputName);
+			if (skill) bump(agg.skillCalls, cleanName(skill));
+		} else if (name === "task") {
+			const agent = asStr(row.subagentType);
+			if (agent) bump(agg.subagentCalls, cleanName(agent));
+		}
+		return;
+	}
+	for (const server of state.mcpServers) {
+		if (name.startsWith(`${server}_`)) {
+			bump(agg.mcpServerCalls, server);
+			bump(agg.mcpToolCalls, name);
+			return;
+		}
+	}
+	bump(agg.toolCalls, name);
+}
+
+/**
+ * Static MCP inventory from `~/.config/opencode/opencode.json` (JSONC — the
+ * scanner owns the tolerant parse). A configured server the window never
+ * called still exists: zero-count entries ride into the inventory. The
+ * sanitized form is what tool-name prefixes are matched against, longest
+ * first so `foo-bar` wins over `foo` for `foo-bar_tool`.
+ */
+export function noteConfiguredMcpServers(
+	agg: Aggregate,
+	state: DbFoldState,
+	serverNames: Iterable<string>,
+): void {
+	for (const raw of serverNames) {
+		const name = cleanName(sanitizeMcpName(raw));
+		if (!agg.mcpServerCalls.has(name)) agg.mcpServerCalls.set(name, 0);
+		if (!state.mcpServers.includes(name)) state.mcpServers.push(name);
+	}
+	state.mcpServers.sort((a, b) => b.length - a.length);
+}

--- a/packages/cli/src/harness/opencode/scan.test.ts
+++ b/packages/cli/src/harness/opencode/scan.test.ts
@@ -1,0 +1,358 @@
+// The opencode I/O shell against REAL temp SQLite files — wayfinder #124
+// (map #121). The store is `opencode*.db` under the data dir (the JSON tree
+// is dead storage, research §1); a locked, corrupt, or newer-schema DB counts
+// as UNREADABLE, never as zero.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createAggregate } from "./analyzer.js";
+import { detectOpencode, scan } from "./scan.js";
+
+const NOW = Date.UTC(2026, 7, 5, 12, 0, 0);
+const DAY = 86_400_000;
+const SINCE = NOW - 29 * DAY;
+
+let dir: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "aistack-opencode-"));
+});
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+const MIGRATION_OK = "20260622202450_simplify_session_input";
+
+type Db = InstanceType<typeof DatabaseSync>;
+
+function createDb(name = "opencode.db"): { db: Db; file: string } {
+	const file = join(dir, name);
+	const db = new DatabaseSync(file);
+	db.exec(`
+		create table migration (id text primary key, time_completed integer);
+		create table session (id text primary key, parent_id text, version text,
+			title text, summary_diffs text);
+		create table message (id text primary key, session_id text,
+			time_created integer, time_updated integer, data text);
+		create table part (id text primary key, message_id text, session_id text,
+			time_created integer, time_updated integer, data text);
+		create table session_message (id text primary key, session_id text,
+			type text, time_created integer, time_updated integer, data text, seq integer);
+	`);
+	db.prepare("insert into migration values (?, ?)").run(MIGRATION_OK, NOW);
+	return { db, file };
+}
+
+function insertAssistant(
+	db: Db,
+	over: {
+		id?: string;
+		sessionId?: string;
+		ts?: number;
+		provider?: string;
+		model?: string;
+		input?: number;
+		output?: number;
+		cacheRead?: number;
+		cacheWrite?: number;
+	} = {},
+): void {
+	const ts = over.ts ?? NOW - DAY;
+	db.prepare("insert into message values (?, ?, ?, ?, ?)").run(
+		over.id ?? "msg_1",
+		over.sessionId ?? "ses_1",
+		ts,
+		ts,
+		JSON.stringify({
+			role: "assistant",
+			time: { created: ts, completed: ts + 1000 },
+			modelID: over.model ?? "claude-opus-4-6",
+			providerID: over.provider ?? "anthropic",
+			path: { cwd: "/home/u/secret-project" },
+			cost: 0,
+			tokens: {
+				total: 999_999_999, // poison: reading `total` is a bug
+				input: over.input ?? 100,
+				output: over.output ?? 10,
+				reasoning: 5_000_000, // poison: adding `reasoning` is a bug
+				cache: {
+					read: over.cacheRead ?? 1000,
+					write: over.cacheWrite ?? 200,
+				},
+			},
+		}),
+	);
+}
+
+function insertToolPart(
+	db: Db,
+	over: { id?: string; ts?: number; tool?: string; callId?: string } = {},
+): void {
+	const ts = over.ts ?? NOW - DAY;
+	db.prepare("insert into part values (?, ?, ?, ?, ?, ?)").run(
+		over.id ?? "prt_1",
+		"msg_1",
+		"ses_1",
+		ts,
+		ts,
+		JSON.stringify({
+			type: "tool",
+			tool: over.tool ?? "bash",
+			callID: over.callId ?? `call_${over.id ?? "prt_1"}`,
+			state: {
+				input: { name: "tdd" },
+				output: "SECRET COMMAND OUTPUT", // must never materialize
+			},
+		}),
+	);
+}
+
+function insertSession(db: Db, id: string, parentId: string | null): void {
+	db.prepare("insert into session values (?, ?, ?, ?, ?)").run(
+		id,
+		parentId,
+		"1.18.11",
+		"a secret title",
+		"full file contents",
+	);
+}
+
+describe("scan", () => {
+	it("folds an in-window assistant message and its tool part from a real DB", async () => {
+		const { db } = createDb();
+		insertSession(db, "ses_1", null);
+		insertAssistant(db);
+		insertToolPart(db);
+		db.close();
+
+		const agg = createAggregate();
+		const stats = await scan(agg, { sinceMs: SINCE, roots: [dir] });
+
+		expect(stats.filesFound).toBe(1);
+		expect(stats.filesRead).toBe(1);
+		expect(stats.filesUnreadable).toBe(0);
+		const m = agg.byModel.get("anthropic:claude-opus-4-6");
+		expect(m).toMatchObject({
+			input: 100,
+			output: 10,
+			cacheRead: 1000,
+			cacheWriteUnsplit: 200,
+			messages: 1,
+		});
+		expect(agg.toolCalls.get("bash")).toBe(1);
+		expect(agg.ccVersions).toEqual(new Set(["1.18.11"]));
+	});
+
+	it("the window filter runs in SQL — an out-of-window row never reaches the fold", async () => {
+		const { db } = createDb();
+		insertSession(db, "ses_1", null);
+		insertAssistant(db, { id: "msg_old", ts: NOW - 90 * DAY });
+		insertToolPart(db, { id: "prt_old", ts: NOW - 90 * DAY });
+		db.close();
+
+		const agg = createAggregate();
+		await scan(agg, { sinceMs: SINCE, roots: [dir] });
+
+		expect(agg.byModel.size).toBe(0);
+		expect(agg.toolCalls.size).toBe(0);
+		expect(agg.sessions.size).toBe(0);
+	});
+
+	it("reads a v2 session_message row and dedups an id present in both generations", async () => {
+		const ts = NOW - DAY;
+		const { db } = createDb();
+		insertSession(db, "ses_1", null);
+		insertAssistant(db, { id: "msg_both" });
+		db.prepare("insert into session_message values (?, ?, ?, ?, ?, ?, ?)").run(
+			"msg_both",
+			"ses_1",
+			"assistant",
+			ts,
+			ts,
+			JSON.stringify({
+				role: "assistant",
+				model: { id: "claude-opus-4-6", providerID: "anthropic" },
+				time: { created: ts },
+				tokens: {
+					input: 7,
+					output: 3,
+					reasoning: 0,
+					cache: { read: 0, write: 0 },
+				},
+				content: [],
+			}),
+			1,
+		);
+		db.prepare("insert into session_message values (?, ?, ?, ?, ?, ?, ?)").run(
+			"msg_v2only",
+			"ses_1",
+			"assistant",
+			ts,
+			ts,
+			JSON.stringify({
+				role: "assistant",
+				model: { id: "gpt-5.4", providerID: "openai" },
+				time: { created: ts },
+				tokens: {
+					input: 7,
+					output: 3,
+					reasoning: 0,
+					cache: { read: 0, write: 0 },
+				},
+				content: [],
+			}),
+			1,
+		);
+		db.close();
+
+		const agg = createAggregate();
+		await scan(agg, { sinceMs: SINCE, roots: [dir] });
+
+		// msg_both counted once (from v1), msg_v2only from the v2 table.
+		expect(agg.distinctResponses).toBe(2);
+		expect(agg.byModel.get("anthropic:claude-opus-4-6")?.messages).toBe(1);
+		expect(agg.byModel.get("openai:gpt-5.4")?.messages).toBe(1);
+	});
+
+	it("a corrupt DB counts as unreadable and leaks no path", async () => {
+		writeFileSync(join(dir, "opencode.db"), "this is not sqlite at all");
+
+		const agg = createAggregate();
+		const stats = await scan(agg, { sinceMs: SINCE, roots: [dir] });
+
+		expect(stats.filesFound).toBe(1);
+		expect(stats.filesRead).toBe(0);
+		expect(stats.filesUnreadable).toBe(1);
+		for (const f of stats.unreadableFiles) {
+			expect(f.path).not.toContain(dir);
+			expect(f.reason).not.toContain(dir);
+		}
+	});
+
+	it("a DB whose newest migration is past the pinned ceiling is unreadable, not misread", async () => {
+		const { db } = createDb();
+		db.prepare("insert into migration values (?, ?)").run(
+			"20990101000000_from_the_future",
+			NOW,
+		);
+		insertSession(db, "ses_1", null);
+		insertAssistant(db);
+		db.close();
+
+		const agg = createAggregate();
+		const stats = await scan(agg, { sinceMs: SINCE, roots: [dir] });
+
+		expect(stats.filesUnreadable).toBe(1);
+		expect(stats.unreadableFiles[0]?.reason).toBe("schema-too-new");
+		expect(agg.byModel.size).toBe(0);
+	});
+
+	it("a missing data dir is silence", async () => {
+		const agg = createAggregate();
+		const stats = await scan(agg, {
+			sinceMs: SINCE,
+			roots: [join(dir, "does-not-exist")],
+		});
+		expect(stats.filesFound).toBe(0);
+		expect(stats.filesUnreadable).toBe(0);
+	});
+
+	it("globs channel DBs but never WAL siblings", async () => {
+		const { db } = createDb("opencode-nightly.db");
+		insertSession(db, "ses_1", null);
+		insertAssistant(db);
+		db.close();
+		writeFileSync(join(dir, "opencode.db-wal"), "not a db");
+		writeFileSync(join(dir, "auth.json"), "{}");
+
+		const agg = createAggregate();
+		const stats = await scan(agg, { sinceMs: SINCE, roots: [dir] });
+
+		expect(stats.filesFound).toBe(1);
+		expect(stats.filesRead).toBe(1);
+		expect(agg.distinctResponses).toBe(1);
+	});
+
+	it("reads MCP server names from a JSONC config with comments, trailing commas, and URLs", async () => {
+		const { db } = createDb();
+		insertSession(db, "ses_1", null);
+		insertAssistant(db);
+		db.close();
+		const configFile = join(dir, "opencode.json");
+		writeFileSync(
+			configFile,
+			`{
+	// a comment with a URL: https://example.com/path
+	"mcp": {
+		"chrome-devtools": {
+			"type": "local",
+			"command": ["npx", "-y", "chrome-devtools-mcp@latest"], /* block */
+		},
+	},
+}`,
+		);
+
+		const agg = createAggregate();
+		await scan(agg, { sinceMs: SINCE, roots: [dir], configFile });
+
+		expect(agg.mcpServerCalls.get("chrome-devtools")).toBe(0);
+	});
+
+	it("an unparseable config is silence, not an error", async () => {
+		const { db } = createDb();
+		insertSession(db, "ses_1", null);
+		insertAssistant(db);
+		db.close();
+		const configFile = join(dir, "opencode.json");
+		writeFileSync(configFile, "{ definitely broken");
+
+		const agg = createAggregate();
+		const stats = await scan(agg, { sinceMs: SINCE, roots: [dir], configFile });
+
+		expect(stats.filesRead).toBe(1);
+		expect(agg.mcpServerCalls.size).toBe(0);
+	});
+});
+
+describe("detectOpencode", () => {
+	it("a DB with only stale messages is not detected", async () => {
+		const { db } = createDb();
+		insertSession(db, "ses_1", null);
+		insertAssistant(db, { ts: NOW - 90 * DAY });
+		db.close();
+
+		expect(await detectOpencode({ sinceMs: SINCE, roots: [dir] })).toBe(false);
+	});
+
+	it("one in-window message detects the harness", async () => {
+		const { db } = createDb();
+		insertSession(db, "ses_1", null);
+		insertAssistant(db, { ts: NOW - 90 * DAY, id: "msg_old" });
+		insertAssistant(db, { ts: NOW - DAY, id: "msg_new" });
+		db.close();
+
+		expect(await detectOpencode({ sinceMs: SINCE, roots: [dir] })).toBe(true);
+	});
+
+	it("an empty data dir, a missing dir, and a corrupt DB all read as absent", async () => {
+		expect(await detectOpencode({ sinceMs: SINCE, roots: [dir] })).toBe(false);
+		expect(
+			await detectOpencode({ sinceMs: SINCE, roots: [join(dir, "nope")] }),
+		).toBe(false);
+		writeFileSync(join(dir, "opencode.db"), "junk");
+		expect(await detectOpencode({ sinceMs: SINCE, roots: [dir] })).toBe(false);
+	});
+
+	it("a fresh DB mtime with no in-window rows is NOT detection — the probe is a query", async () => {
+		// The #101 failure mode: `opencode --version` touches the DB file.
+		const { db } = createDb();
+		insertSession(db, "ses_1", null);
+		insertAssistant(db, { ts: NOW - 120 * DAY });
+		db.close();
+		// The file's mtime is "now" (we just wrote it) yet nothing is in-window.
+		expect(await detectOpencode({ sinceMs: SINCE, roots: [dir] })).toBe(false);
+	});
+});

--- a/packages/cli/src/harness/opencode/scan.ts
+++ b/packages/cli/src/harness/opencode/scan.ts
@@ -1,0 +1,451 @@
+// I/O shell around the pure opencode analyzer: find `opencode*.db`, open it
+// read-only with node:sqlite, project NAMED COLUMNS through json_extract, and
+// hand plain values to the fold. Nothing leaves this machine.
+//
+// Wayfinder ticket #124 (map #121), semantics from
+// docs/research/harness-adapters-2026-08.md (§opencode).
+//
+// STANDING NON-GOAL (locked in #13): raw transcripts, prompts, absolute paths
+// and repo names never leave the machine. The SAME FILE this module opens
+// also holds `account.refresh_token`, `credential.value`,
+// `session_input.prompt` and full file contents in `session.summary_diffs`
+// and `part.data.state.output`. The rule that keeps them out: never
+// `SELECT *` — every query names its columns, and `part.data` reaches JS only
+// as four json_extract'ed scalars. Errors are swallowed, not thrown, because
+// a node:sqlite error message carries the DB path.
+
+import { readFileSync } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import { emptyScanStats, type ScanStats } from "../shared/window.js";
+import {
+	type Aggregate,
+	createDbFoldState,
+	type DbFoldState,
+	ingestMessageRow,
+	ingestToolPart,
+	noteConfiguredMcpServers,
+	noteSessions,
+} from "./analyzer.js";
+
+/**
+ * Newest migration id this build understands, from the probe DB (research
+ * §1). A DB migrated past it may hold the same table names with different
+ * semantics, so it counts as UNREADABLE — a visible coverage figure — rather
+ * than being read on the guess that nothing moved.
+ */
+export const OPENCODE_MIGRATION_CEILING = 20260622202450;
+
+/** `$XDG_DATA_HOME/opencode` or `~/.local/share/opencode` — opencode's own rule. */
+export function opencodeDataDirs(): string[] {
+	const xdg = process.env.XDG_DATA_HOME;
+	const base = xdg || path.join(homedir(), ".local", "share");
+	return [path.join(base, "opencode")];
+}
+
+/**
+ * The store is `opencode.db` on release channels, `opencode-<channel>.db`
+ * otherwise, and `$OPENCODE_DB` overrides both. WAL siblings (`-wal`,
+ * `-shm`) are opened by SQLite itself, never listed as stores.
+ */
+function isStoreFile(basename: string): boolean {
+	return basename === "opencode.db" || /^opencode-[^/]+\.db$/.test(basename);
+}
+
+async function dbFilesIn(root: string): Promise<string[]> {
+	const override = process.env.OPENCODE_DB;
+	if (override) return [override];
+	try {
+		const entries = await readdir(root, { withFileTypes: true });
+		return entries
+			.filter((e) => e.isFile() && isStoreFile(e.name))
+			.map((e) => path.join(root, e.name))
+			.sort();
+	} catch {
+		return [];
+	}
+}
+
+// ---------------------------------------------------------------------------
+// node:sqlite, feature-detected
+// ---------------------------------------------------------------------------
+
+type SqliteDb = {
+	prepare(sql: string): {
+		all(...params: unknown[]): Record<string, unknown>[];
+		get(...params: unknown[]): Record<string, unknown> | undefined;
+	};
+	close(): void;
+};
+
+/**
+ * `node:sqlite` landed in Node 22.5 while this CLI's floor is 18, so it is
+ * feature-detected in the shape of the codex scanner's zstd check. On a
+ * runtime without it, a found DB counts as unreadable — a visible coverage
+ * figure, never a silent skip.
+ */
+async function loadSqlite(): Promise<((file: string) => SqliteDb) | null> {
+	try {
+		const mod = (await import("node:sqlite")) as {
+			DatabaseSync: new (file: string, opts: { readOnly: boolean }) => SqliteDb;
+		};
+		if (typeof mod.DatabaseSync !== "function") return null;
+		return (file) => new mod.DatabaseSync(file, { readOnly: true });
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * A read failure classified WITHOUT the error object's message or stack —
+ * both can carry the absolute DB path, which never leaves this module.
+ */
+function errorClass(e: unknown): string {
+	const code = (e as { code?: unknown } | null)?.code;
+	if (typeof code === "string" && code.length > 0) return code;
+	return e instanceof Error ? e.constructor.name : "unknown";
+}
+
+const readError = (reason: string): Error =>
+	Object.assign(new Error(reason), { code: reason });
+
+// ---------------------------------------------------------------------------
+// Scan
+// ---------------------------------------------------------------------------
+
+export type ScanOptions = {
+	/** Only count records with a timestamp at or after this epoch ms. */
+	sinceMs?: number;
+	onProgress?: (files: number) => void;
+	/** Override the discovered data dirs. Tests only. */
+	roots?: string[];
+	/** Override the opencode.json path. Tests only. */
+	configFile?: string;
+};
+
+export async function scan(
+	agg: Aggregate,
+	opts: ScanOptions = {},
+): Promise<ScanStats> {
+	const stats: ScanStats = emptyScanStats();
+	const open = await loadSqlite();
+	const sinceMs = opts.sinceMs ?? 0;
+
+	const state = createDbFoldState();
+	readConfiguredMcpServers(agg, state, opts.configFile);
+
+	for (const root of opts.roots ?? opencodeDataDirs()) {
+		for (const file of await dbFilesIn(root)) {
+			stats.filesFound++;
+			agg.files++;
+			try {
+				if (open === null) throw readError("sqlite-unsupported");
+				readDb(agg, state, open, file, sinceMs);
+				stats.filesRead++;
+			} catch (e) {
+				stats.filesUnreadable++;
+				stats.unreadableFiles.push({
+					path: path.basename(file),
+					reason: errorClass(e),
+				});
+			}
+			if (opts.onProgress) opts.onProgress(stats.filesFound);
+		}
+	}
+	return stats;
+}
+
+/** Refuse a DB whose newest migration this build has never seen. */
+function checkMigrationCeiling(db: SqliteDb): void {
+	let newest: unknown;
+	try {
+		newest = db.prepare("select max(id) as id from migration").get()?.id;
+	} catch {
+		throw readError("schema-unversioned");
+	}
+	const prefix = Number.parseInt(String(newest ?? ""), 10);
+	if (!Number.isFinite(prefix)) throw readError("schema-unversioned");
+	if (prefix > OPENCODE_MIGRATION_CEILING) throw readError("schema-too-new");
+}
+
+function readDb(
+	agg: Aggregate,
+	state: DbFoldState,
+	open: (file: string) => SqliteDb,
+	file: string,
+	sinceMs: number,
+): void {
+	const db = open(file);
+	try {
+		checkMigrationCeiling(db);
+
+		noteSessions(
+			state,
+			db
+				.prepare("select id, parent_id, version from session")
+				.all()
+				.map((r) => ({ id: r.id, parentId: r.parent_id, version: r.version })),
+		);
+
+		// v1 messages. `time.created` (epoch ms, in the blob) prices the
+		// response; the indexed integer column runs the window filter and backs
+		// a blob whose clock field is missing or malformed.
+		const v1 = db.prepare(
+			`select id, session_id, time_created,
+				json_extract(data, '$.role') as role,
+				json_extract(data, '$.providerID') as provider_id,
+				json_extract(data, '$.modelID') as model_id,
+				json_extract(data, '$.time.created') as ts_ms,
+				json_extract(data, '$.tokens.input') as tok_input,
+				json_extract(data, '$.tokens.output') as tok_output,
+				json_extract(data, '$.tokens.cache.read') as tok_cache_read,
+				json_extract(data, '$.tokens.cache.write') as tok_cache_write,
+				json_extract(data, '$.path.cwd') as cwd
+			from message where time_created >= ?`,
+		);
+		for (const r of v1.all(sinceMs)) {
+			agg.lines++;
+			ingestMessageRow(agg, state, {
+				id: r.id,
+				sessionId: r.session_id,
+				role: r.role,
+				providerId: r.provider_id,
+				modelId: r.model_id,
+				tsMs: pickTs(r.ts_ms, r.time_created),
+				input: r.tok_input,
+				output: r.tok_output,
+				cacheRead: r.tok_cache_read,
+				cacheWrite: r.tok_cache_write,
+				cwd: r.cwd,
+			});
+		}
+
+		// v2 (`session_message`) — the other live generation (research §1: which
+		// one current opencode writes is unproven, so both are read and message
+		// ids dedup across them). The assistant shape differs: `model: {id,
+		// providerID}`, role in the `type` column.
+		const v2 = db.prepare(
+			`select id, session_id, type, time_created,
+				json_extract(data, '$.model.providerID') as provider_id,
+				json_extract(data, '$.model.id') as model_id,
+				json_extract(data, '$.time.created') as ts_ms,
+				json_extract(data, '$.tokens.input') as tok_input,
+				json_extract(data, '$.tokens.output') as tok_output,
+				json_extract(data, '$.tokens.cache.read') as tok_cache_read,
+				json_extract(data, '$.tokens.cache.write') as tok_cache_write,
+				json_extract(data, '$.path.cwd') as cwd
+			from session_message where time_created >= ?`,
+		);
+		for (const r of v2.all(sinceMs)) {
+			agg.lines++;
+			ingestMessageRow(agg, state, {
+				id: r.id,
+				sessionId: r.session_id,
+				role: r.type,
+				providerId: r.provider_id,
+				modelId: r.model_id,
+				tsMs: pickTs(r.ts_ms, r.time_created),
+				input: r.tok_input,
+				output: r.tok_output,
+				cacheRead: r.tok_cache_read,
+				cacheWrite: r.tok_cache_write,
+				cwd: r.cwd,
+			});
+		}
+
+		// v1 tool parts. Only these four scalar paths of `part.data` ever reach
+		// JS — `$.state.output` holds full command output and stays in SQLite.
+		const parts = db.prepare(
+			`select id,
+				json_extract(data, '$.type') as part_type,
+				json_extract(data, '$.tool') as tool,
+				json_extract(data, '$.callID') as call_id,
+				json_extract(data, '$.state.input.name') as input_name,
+				json_extract(data, '$.state.input.subagent_type') as subagent_type
+			from part
+			where time_created >= ? and json_extract(data, '$.type') = 'tool'`,
+		);
+		for (const r of parts.all(sinceMs)) {
+			agg.lines++;
+			ingestToolPart(agg, state, {
+				id: r.id,
+				partType: r.part_type,
+				tool: r.tool,
+				callId: r.call_id,
+				inputName: r.input_name,
+				subagentType: r.subagent_type,
+			});
+		}
+
+		// v2 inline tool content, same named-scalar rule via json_each. The v2
+		// content shape is unverified on any real machine, so a query error here
+		// is tolerated — the tokens above are the load-bearing read.
+		try {
+			const v2parts = db.prepare(
+				`select sm.id || ':' || je.key as id,
+					json_extract(je.value, '$.type') as part_type,
+					json_extract(je.value, '$.tool') as tool,
+					json_extract(je.value, '$.callID') as call_id,
+					json_extract(je.value, '$.state.input.name') as input_name,
+					json_extract(je.value, '$.state.input.subagent_type') as subagent_type
+				from session_message sm, json_each(sm.data, '$.content') je
+				where sm.time_created >= ? and sm.type = 'assistant'`,
+			);
+			for (const r of v2parts.all(sinceMs)) {
+				ingestToolPart(agg, state, {
+					id: r.id,
+					partType: r.part_type,
+					tool: r.tool,
+					callId: r.call_id,
+					inputName: r.input_name,
+					subagentType: r.subagent_type,
+				});
+			}
+		} catch {
+			/* v2 content unreadable — the message tokens already counted */
+		}
+	} finally {
+		try {
+			db.close();
+		} catch {
+			/* already closed or never opened fully */
+		}
+	}
+}
+
+/** The blob's own clock when it is a finite number, else the indexed column. */
+function pickTs(jsonTs: unknown, columnTs: unknown): number | null {
+	if (typeof jsonTs === "number" && Number.isFinite(jsonTs)) return jsonTs;
+	if (typeof columnTs === "number" && Number.isFinite(columnTs))
+		return columnTs;
+	// node:sqlite may hand integers back as bigint depending on flags.
+	if (typeof columnTs === "bigint") return Number(columnTs);
+	if (typeof jsonTs === "bigint") return Number(jsonTs);
+	return null;
+}
+
+// ---------------------------------------------------------------------------
+// Config — the static MCP inventory
+// ---------------------------------------------------------------------------
+
+/** `$XDG_CONFIG_HOME/opencode/opencode.json` or `~/.config/opencode/opencode.json`. */
+export function opencodeConfigFile(): string {
+	const xdg = process.env.XDG_CONFIG_HOME;
+	const base = xdg || path.join(homedir(), ".config");
+	return path.join(base, "opencode", "opencode.json");
+}
+
+/**
+ * The real config is JSONC — comments and trailing commas (research
+ * §inventory) — so `JSON.parse` alone throws on it. The strip below is
+ * string-aware: a `//` inside a quoted URL survives. Any remaining parse
+ * failure is silence, not an error: the observed half of the MCP inventory
+ * stands on its own.
+ */
+function readConfiguredMcpServers(
+	agg: Aggregate,
+	state: DbFoldState,
+	configFile?: string,
+): void {
+	const file = configFile ?? opencodeConfigFile();
+	try {
+		const parsed: unknown = JSON.parse(stripJsonc(readFileSync(file, "utf8")));
+		const mcp = (parsed as { mcp?: unknown } | null)?.mcp;
+		if (mcp && typeof mcp === "object" && !Array.isArray(mcp)) {
+			noteConfiguredMcpServers(agg, state, Object.keys(mcp));
+		}
+	} catch {
+		return;
+	}
+}
+
+export function stripJsonc(text: string): string {
+	let out = "";
+	let i = 0;
+	let inString = false;
+	while (i < text.length) {
+		const ch = text[i];
+		const next = text[i + 1];
+		if (inString) {
+			out += ch;
+			if (ch === "\\") {
+				out += next ?? "";
+				i += 2;
+				continue;
+			}
+			if (ch === '"') inString = false;
+			i++;
+		} else if (ch === '"') {
+			inString = true;
+			out += ch;
+			i++;
+		} else if (ch === "/" && next === "/") {
+			while (i < text.length && text[i] !== "\n") i++;
+		} else if (ch === "/" && next === "*") {
+			i += 2;
+			while (i < text.length && !(text[i] === "*" && text[i + 1] === "/")) i++;
+			i += 2;
+		} else {
+			out += ch;
+			i++;
+		}
+	}
+	// Trailing commas: `, }` and `, ]` with any whitespace between.
+	return out.replace(/,(\s*[}\]])/g, "$1");
+}
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Detection is a QUERY, not a stat walk (#101, research §6): every opencode
+ * start — including `opencode --version` — touches the DB file, and the probe
+ * machine showed a four-month gap between the file's mtime and the newest
+ * real message. The indexed probe costs 0.02 ms.
+ */
+export async function detectOpencode(opts: {
+	sinceMs: number;
+	roots?: string[];
+}): Promise<boolean> {
+	const open = await loadSqlite();
+	if (open === null) return false;
+
+	for (const root of opts.roots ?? opencodeDataDirs()) {
+		for (const file of await dbFilesIn(root)) {
+			if (!(await exists(file))) continue;
+			let db: SqliteDb | null = null;
+			try {
+				db = open(file);
+				checkMigrationCeiling(db);
+				const probe = (table: string) =>
+					db
+						?.prepare(
+							`select 1 as hit from ${table} where time_created >= ? limit 1`,
+						)
+						.get(opts.sinceMs) !== undefined;
+				if (probe("message") || probe("session_message")) return true;
+			} catch {
+				/* unreadable or foreign DB — not detection */
+			} finally {
+				try {
+					db?.close();
+				} catch {
+					/* ignore */
+				}
+			}
+		}
+	}
+	return false;
+}
+
+async function exists(p: string): Promise<boolean> {
+	try {
+		await stat(p);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/src/features/measured/copy.ts
+++ b/src/features/measured/copy.ts
@@ -226,6 +226,8 @@ export function coverageCaveat(s: HarnessSnapshot): string | null {
 export function harnessLabel(name: string): string {
 	if (name === "claude-code") return HARNESS;
 	if (name === "codex") return "Codex";
+	// The brand spells itself lowercase, so the discriminator is the label.
+	if (name === "opencode") return "opencode";
 	return name;
 }
 


### PR DESCRIPTION
Closes #124.

## What this adds

The **opencode** adapter behind the existing harness seam: `packages/cli/src/harness/opencode/` (`scan.ts` I/O shell, `analyzer.ts` pure fold, `adapter.ts`), registered third in `HARNESS_ADAPTERS`. The server takes any display-safe harness name, so no backend change is needed.

## The load-bearing choices (from the #122 research)

- **The store is SQLite** (`opencode*.db`), not the dead JSON tree. `node:sqlite` is feature-detected in the shape of the codex zstd check. On a runtime without it, a found DB counts as **unreadable**, never as zero.
- **Named columns only.** The same file holds refresh tokens, raw prompts, and full file diffs. No query says `SELECT *`, and `part.data` reaches JS as four `json_extract` scalars.
- **Provider-keyed pricing (#123).** Every row keys `modelKeyFor(providerID, modelID)`. On the probe DB the gateway models stay unpriced and `github-copilot:gemini-3-pro-preview` never touches Google's rate.
- **Never `tokens.total`, never `reasoning`, never opencode's own `cost`** (it is 0.0 on all 925 records). The four disjoint counters map straight onto `TokenCounts`; `cache.write` lands in `cacheWriteUnsplit`.
- **Detection is an indexed query, not a stat** (#101): `opencode --version` touches the DB file, and the probe machine showed a four-month mtime false positive.
- **Fail-closed MCP naming.** Built-in set first, then configured server prefixes from the JSONC config, then a plain count the payload filter withholds. `apply_patch` never invents a server named `apply`.
- **Both message generations** (`message`, `session_message`) are read with id dedup, plus a migration-id ceiling: a DB migrated past `20260622202450` reads as `schema-too-new`, not as data.
- **`subagentShare` is a real measurement** via `session.parent_id`.

## Verification against the real install

Full-history scan of `~/.local/share/opencode/opencode.db` reproduces the research figures exactly: 925 assistant responses, 53,495,960 tokens, subagent share 21.4%, and the model table row for row. With the #123 Google rows the priced share is **98.6%** (was 78.2% at research time); the remainder is the opencode-zen gateway, honestly unpriced. The built payload cites a price table per model with a null top-level table, and a leak grep over the JSON finds no path, no title, no secret.

Tests: 30 new (analyzer 17, scan/detect 13) plus 2 new `detectedAdapters` cases; 553 pass across `packages/cli` and `src/features/measured`. CLI typecheck clean; web `tsc` failures are pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TuPYyH6JxiDRSnJa6sCvK