### PR TITLE
Task: the pi-mono adapter (alp82/aistack#126)

### DIFF
--- a/packages/cli/src/harness/detect.test.ts
+++ b/packages/cli/src/harness/detect.test.ts
@@ -21,6 +21,7 @@ import { claudeRecentlyActive } from "../commands/connect.js";
 import { claudeAdapter } from "./claude/adapter.js";
 import { codexAdapter } from "./codex/adapter.js";
 import { detectedAdapters, detectionSinceMs } from "./index.js";
+import { piAdapter } from "./pi/adapter.js";
 
 const NOW = Date.UTC(2026, 7, 5, 12, 0, 0);
 const DAY = 86_400_000;
@@ -32,6 +33,8 @@ const savedEnv = {
 	CODEX_HOME: process.env.CODEX_HOME,
 	XDG_DATA_HOME: process.env.XDG_DATA_HOME,
 	OPENCODE_DB: process.env.OPENCODE_DB,
+	PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
+	PI_CODING_AGENT_SESSION_DIR: process.env.PI_CODING_AGENT_SESSION_DIR,
 };
 
 beforeEach(() => {
@@ -40,6 +43,8 @@ beforeEach(() => {
 	// never leaks its own installs into `detectedAdapters`.
 	process.env.XDG_DATA_HOME = join(dir, "xdg-data");
 	delete process.env.OPENCODE_DB;
+	process.env.PI_CODING_AGENT_SESSION_DIR = join(dir, "pi-sessions");
+	delete process.env.PI_CODING_AGENT_DIR;
 });
 
 /** A minimal real opencode store with one message at `tsMs`. */
@@ -158,6 +163,32 @@ describe("codexAdapter.detect", () => {
 	});
 });
 
+describe("piAdapter.detect", () => {
+	const PI_FILE =
+		"2026-08-04T09-00-00-000Z_019f8fe5-f4d5-744d-9b02-4a9bad77279d.jsonl";
+
+	it("an existing root with only stale sessions is not detected", async () => {
+		write(`pi/--home-u-proj--/${PI_FILE}`, NOW - 90 * DAY);
+		expect(
+			await piAdapter.detect({ sinceMs: SINCE, roots: [join(dir, "pi")] }),
+		).toBe(false);
+	});
+
+	it("one in-window session detects the harness", async () => {
+		write(`pi/--home-u-proj--/${PI_FILE}`, NOW - DAY);
+		expect(
+			await piAdapter.detect({ sinceMs: SINCE, roots: [join(dir, "pi")] }),
+		).toBe(true);
+	});
+
+	it("a recent file that is not a pi session does not detect the harness", async () => {
+		write("pi/--home-u-proj--/notes.jsonl", NOW);
+		expect(
+			await piAdapter.detect({ sinceMs: SINCE, roots: [join(dir, "pi")] }),
+		).toBe(false);
+	});
+});
+
 describe("detectedAdapters", () => {
 	it("skips the stale harness and keeps the live one", async () => {
 		process.env.CLAUDE_CONFIG_DIR = join(dir, "claude-home");
@@ -187,6 +218,19 @@ describe("detectedAdapters", () => {
 
 		const names = (await detectedAdapters(SINCE)).map((a) => a.name);
 		expect(names).toEqual(["claude-code", "opencode"]);
+	});
+
+	it("an in-window pi session detects, last in gate order", async () => {
+		process.env.CLAUDE_CONFIG_DIR = join(dir, "claude-home");
+		process.env.CODEX_HOME = join(dir, "codex-home");
+		write("claude-home/projects/proj-a/sess-1.jsonl", NOW - DAY);
+		write(
+			"pi-sessions/--home-u-proj--/2026-08-04T09-00-00-000Z_019f8fe5-f4d5-744d-9b02-4a9bad77279d.jsonl",
+			NOW - DAY,
+		);
+
+		const names = (await detectedAdapters(SINCE)).map((a) => a.name);
+		expect(names).toEqual(["claude-code", "pi-mono"]);
 	});
 
 	it("an opencode store with only stale rows stays undetected", async () => {

--- a/packages/cli/src/harness/index.ts
+++ b/packages/cli/src/harness/index.ts
@@ -23,6 +23,7 @@
 import { CLAUDE_HARNESS_NAME, claudeAdapter } from "./claude/adapter.js";
 import { CODEX_HARNESS_NAME, codexAdapter } from "./codex/adapter.js";
 import { OPENCODE_HARNESS_NAME, opencodeAdapter } from "./opencode/adapter.js";
+import { PI_HARNESS_NAME, piAdapter } from "./pi/adapter.js";
 import { DEFAULT_WINDOW_DAYS, windowStartMs } from "./shared/window.js";
 import type { HarnessAdapter } from "./types.js";
 
@@ -64,6 +65,11 @@ export {
 	OPENCODE_HARNESS_NAME,
 	opencodeAdapter,
 } from "./opencode/adapter.js";
+export {
+	PI_BUILTIN_TOOLS,
+	PI_HARNESS_NAME,
+	piAdapter,
+} from "./pi/adapter.js";
 export {
 	type Aggregate,
 	cleanName,
@@ -131,14 +137,17 @@ export const HARNESS_ADAPTERS: readonly HarnessAdapter[] = [
 	claudeAdapter,
 	codexAdapter,
 	opencodeAdapter,
+	piAdapter,
 ];
 
 /** Display name for a harness discriminator. One name per harness, defined here. */
 export function harnessLabel(name: string): string {
 	if (name === CLAUDE_HARNESS_NAME) return "Claude Code";
 	if (name === CODEX_HARNESS_NAME) return "Codex";
-	// The brand spells itself lowercase, so the discriminator IS the label.
+	// These brands spell themselves lowercase, so the discriminator IS the
+	// label — but each is an explicit row, so a rename cannot leak a raw slug.
 	if (name === OPENCODE_HARNESS_NAME) return "opencode";
+	if (name === PI_HARNESS_NAME) return "pi-mono";
 	return name;
 }
 

--- a/packages/cli/src/harness/pi/adapter.ts
+++ b/packages/cli/src/harness/pi/adapter.ts
@@ -1,0 +1,55 @@
+// The pi coding agent behind the harness seam (#66 decision 6) — wayfinder
+// ticket #126 (map #121). The payload discriminator is the catalog slug,
+// `pi-mono` (the repo is earendil-works/pi-mono; the binary is `pi`).
+
+import { hasRecentFile } from "../shared/recency.js";
+import type {
+	HarnessAdapter,
+	HarnessDetectOptions,
+	HarnessScan,
+	HarnessScanOptions,
+} from "../types.js";
+import { createAggregate } from "./analyzer.js";
+import { isSessionFile, scan, sessionRoots } from "./scan.js";
+
+export const PI_HARNESS_NAME = "pi-mono";
+
+/**
+ * pi's vendor-assigned tool surface — seven names, published in the vendor's
+ * own docs (usage.md §tools). Same fail-closed mechanism as the other
+ * adapters: a literal set, never a pattern. Everything outside it comes from
+ * a user extension and publishes only as a per-category count. pi has no MCP,
+ * no subagents and no skill tool by explicit vendor design, so those
+ * categories stay absent rather than zero (#40).
+ */
+export const PI_BUILTIN_TOOLS: ReadonlySet<string> = new Set([
+	"read",
+	"bash",
+	"edit",
+	"write",
+	"grep",
+	"find",
+	"ls",
+]);
+
+export const piAdapter: HarnessAdapter = {
+	name: PI_HARNESS_NAME,
+	builtinTools: PI_BUILTIN_TOOLS,
+
+	async detect(opts: HarnessDetectOptions): Promise<boolean> {
+		return hasRecentFile(
+			opts.roots ?? sessionRoots(),
+			isSessionFile,
+			opts.sinceMs,
+		);
+	},
+
+	async scan(opts: HarnessScanOptions): Promise<HarnessScan> {
+		const aggregate = createAggregate();
+		const stats = await scan(aggregate, {
+			sinceMs: opts.sinceMs,
+			...(opts.onProgress ? { onProgress: opts.onProgress } : {}),
+		});
+		return { aggregate, stats };
+	},
+};

--- a/packages/cli/src/harness/pi/analyzer.test.ts
+++ b/packages/cli/src/harness/pi/analyzer.test.ts
@@ -1,0 +1,486 @@
+// The pi fold — wayfinder ticket #126 (map #121). The properties that matter
+// most, from docs/research/harness-adapters-2026-08.md (§pi-mono):
+//   - `usage.input` already EXCLUDES cache traffic — no subtraction (the
+//     opposite of Codex);
+//   - `cacheWrite1h` is a SUBSET of `cacheWrite`, so pi carries the exact TTL
+//     split the re-pricer normally has to guess;
+//   - /fork and /clone copy entries into a second file KEEPING ids, so usage
+//     dedup is cross-file and the 8-hex id alone is not enough;
+//   - `retainedTail` embeds already-counted assistant messages — never descend.
+
+import { describe, expect, it } from "vitest";
+import {
+	createAggregate,
+	createFileState,
+	createFoldState,
+	ingestEntry,
+} from "./analyzer.js";
+
+const TS = "2026-07-20T12:00:00.000Z";
+const TS_MS = Date.parse(TS);
+
+function header(over: Record<string, unknown> = {}) {
+	return {
+		type: "session",
+		version: 3,
+		id: "019f8fe5-f4d5-744d-9b02-4a9bad77279d",
+		timestamp: TS,
+		cwd: "/home/u/secret-project",
+		...over,
+	};
+}
+
+type UsageOver = {
+	input?: number;
+	output?: number;
+	cacheRead?: number;
+	cacheWrite?: number;
+	cacheWrite1h?: number;
+};
+
+function usage(u: UsageOver = {}) {
+	const base = {
+		input: u.input ?? 0,
+		output: u.output ?? 0,
+		cacheRead: u.cacheRead ?? 0,
+		cacheWrite: u.cacheWrite ?? 0,
+		totalTokens:
+			(u.input ?? 0) +
+			(u.output ?? 0) +
+			(u.cacheRead ?? 0) +
+			(u.cacheWrite ?? 0),
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+	return u.cacheWrite1h === undefined
+		? base
+		: { ...base, cacheWrite1h: u.cacheWrite1h };
+}
+
+function assistant(
+	id: string,
+	u: UsageOver = {},
+	msgOver: Record<string, unknown> = {},
+	entryOver: Record<string, unknown> = {},
+) {
+	return {
+		type: "message",
+		id,
+		parentId: null,
+		timestamp: TS,
+		message: {
+			role: "assistant",
+			content: [],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-fable-5",
+			usage: usage(u),
+			stopReason: "stop",
+			timestamp: TS_MS,
+			...msgOver,
+		},
+		...entryOver,
+	};
+}
+
+function ingestAll(entries: unknown[]) {
+	const agg = createAggregate();
+	const fold = createFoldState();
+	const state = createFileState();
+	for (const e of entries) ingestEntry(agg, e, state, fold);
+	return { agg, fold, state };
+}
+
+describe("usage", () => {
+	it("prices one assistant response under a provider-carrying key with the exact TTL split", () => {
+		const { agg } = ingestAll([
+			header(),
+			assistant("acf8635a", {
+				input: 100,
+				output: 200,
+				cacheRead: 1000,
+				cacheWrite: 500,
+				cacheWrite1h: 300,
+			}),
+		]);
+
+		const row = agg.byModel.get("anthropic:claude-fable-5");
+		expect(row).toBeDefined();
+		// input is already exclusive of cache traffic — no subtraction.
+		expect(row?.input).toBe(100);
+		expect(row?.output).toBe(200);
+		expect(row?.cacheRead).toBe(1000);
+		// cacheWrite1h is a subset of cacheWrite: 300 long, 200 short, 0 unsplit.
+		expect(row?.cacheWrite1h).toBe(300);
+		expect(row?.cacheWrite5m).toBe(200);
+		expect(row?.cacheWriteUnsplit).toBe(0);
+		// claude-fable-5 at $10/$50 per M: 100*10 + 200*50 + 1000*10*0.1
+		// + 200*10*1.25 + 300*10*2.0 = 20,500 micro-dollars.
+		expect(row?.costUSD).toBeCloseTo(0.0205, 10);
+		expect(row?.unpricedTokens).toBe(0);
+		expect(agg.distinctResponses).toBe(1);
+		expect(agg.mainTokens).toBe(1800);
+	});
+
+	it("counts a /fork-duplicated response once across files, keyed by id+timestamp+total", () => {
+		const agg = createAggregate();
+		const fold = createFoldState();
+		const entry = assistant("acf8635a", { input: 100, output: 50 });
+
+		const original = createFileState();
+		ingestEntry(agg, header(), original, fold);
+		ingestEntry(agg, entry, original, fold);
+
+		// /fork copied the entry into a second file, id and timestamps intact.
+		const forked = createFileState();
+		ingestEntry(agg, header({ parentSession: "/orig.jsonl" }), forked, fold);
+		ingestEntry(agg, entry, forked, fold);
+
+		expect(agg.distinctResponses).toBe(1);
+		expect(agg.byModel.get("anthropic:claude-fable-5")?.input).toBe(100);
+		expect(agg.continuationsFolded).toBe(1);
+	});
+
+	it("counts equal ids with different timestamps or totals as distinct responses", () => {
+		// 8-hex ids collide at corpus scale — the composite key must not fold
+		// two genuinely different responses that happen to share an id.
+		const { agg } = ingestAll([
+			header(),
+			assistant("acf8635a", { input: 100, output: 50 }),
+			assistant(
+				"acf8635a",
+				{ input: 100, output: 50 },
+				{},
+				{ timestamp: "2026-07-20T13:00:00.000Z" },
+			),
+			assistant("acf8635a", { input: 7, output: 3 }),
+		]);
+		expect(agg.distinctResponses).toBe(3);
+	});
+
+	it("counts toolResult and summary usage, attributed to the last-known model", () => {
+		// pi's own footer counts these three: "Totals include assistant
+		// responses, usage reported by tools, and summary generation".
+		const { agg } = ingestAll([
+			header(),
+			assistant("acf8635a", { input: 100, output: 50 }),
+			{
+				type: "message",
+				id: "b1b1b1b1",
+				parentId: "acf8635a",
+				timestamp: TS,
+				message: {
+					role: "toolResult",
+					toolCallId: "call_1",
+					toolName: "bash",
+					content: [],
+					usage: usage({ input: 10, output: 5 }),
+					isError: false,
+					timestamp: TS_MS,
+				},
+			},
+			{
+				type: "compaction",
+				id: "c2c2c2c2",
+				parentId: "b1b1b1b1",
+				timestamp: TS,
+				summary: "secret prose",
+				tokensBefore: 50_000,
+				usage: usage({ input: 20, output: 8 }),
+			},
+			{
+				type: "branch_summary",
+				id: "d3d3d3d3",
+				parentId: "acf8635a",
+				timestamp: TS,
+				fromId: "c2c2c2c2",
+				summary: "more prose",
+				usage: usage({ input: 4, output: 2 }),
+			},
+		]);
+		const row = agg.byModel.get("anthropic:claude-fable-5");
+		expect(row?.input).toBe(100 + 10 + 20 + 4);
+		expect(row?.output).toBe(50 + 5 + 8 + 2);
+		expect(agg.mainTokens).toBe(150 + 15 + 28 + 6);
+	});
+
+	it("never descends into retainedTail — its assistant messages are already counted", () => {
+		const inner = assistant("acf8635a", { input: 100, output: 50 });
+		const { agg } = ingestAll([
+			header(),
+			inner,
+			{
+				type: "compaction",
+				id: "c2c2c2c2",
+				parentId: "acf8635a",
+				timestamp: TS,
+				summary: "s",
+				tokensBefore: 1,
+				retainedTail: [
+					{ role: "user", content: "latest request" },
+					(inner as { message: unknown }).message,
+				],
+			},
+		]);
+		expect(agg.byModel.get("anthropic:claude-fable-5")?.input).toBe(100);
+		expect(agg.distinctResponses).toBe(1);
+	});
+
+	it("attributes model-less usage after a model_change to the changed model", () => {
+		const { agg } = ingestAll([
+			header(),
+			{
+				type: "model_change",
+				id: "e4e4e4e4",
+				parentId: null,
+				timestamp: TS,
+				provider: "anthropic",
+				modelId: "claude-haiku-4-5",
+			},
+			{
+				type: "compaction",
+				id: "c2c2c2c2",
+				parentId: "e4e4e4e4",
+				timestamp: TS,
+				summary: "s",
+				tokensBefore: 1,
+				usage: usage({ input: 30 }),
+			},
+		]);
+		expect(agg.byModel.get("anthropic:claude-haiku-4-5")?.input).toBe(30);
+	});
+
+	it("counts an id-less response without dedup protection and says so", () => {
+		const { agg } = ingestAll([
+			header(),
+			assistant("x", { input: 10 }, {}, { id: undefined }),
+		]);
+		expect(agg.distinctResponses).toBe(1);
+		expect(agg.unkeyedResponses).toBe(1);
+	});
+
+	it("prices from the message timestamp when the entry timestamp is unparseable", () => {
+		const { agg } = ingestAll([
+			header(),
+			assistant("a1", { input: 100 }, {}, { timestamp: "not-a-date" }),
+		]);
+		const row = agg.byModel.get("anthropic:claude-fable-5");
+		expect(row?.costUSD).toBeCloseTo(0.001, 10);
+		expect(agg.untimestampedResponses).toBe(0);
+	});
+
+	it("surfaces a response with no timestamp at all as unpriced, never today's rate", () => {
+		const { agg } = ingestAll([
+			header(),
+			assistant(
+				"a1",
+				{ input: 100 },
+				{ timestamp: undefined },
+				{ timestamp: undefined },
+			),
+		]);
+		const row = agg.byModel.get("anthropic:claude-fable-5");
+		expect(row?.costUSD).toBe(0);
+		expect(row?.unpricedTokens).toBe(100);
+		expect(agg.untimestampedResponses).toBe(1);
+	});
+});
+
+describe("pricing hazards", () => {
+	it("translates pi's -fast id suffix into the table's #fast key", () => {
+		const { agg } = ingestAll([
+			header(),
+			assistant("a1", { input: 100 }, { model: "claude-opus-5-fast" }),
+		]);
+		const row = agg.byModel.get("anthropic:claude-opus-5#fast");
+		expect(row?.input).toBe(100);
+		// fast Opus 5 is $10/M input
+		expect(row?.costUSD).toBeCloseTo(0.001, 10);
+	});
+
+	it("leaves a router-billed response unpriced rather than at vendor list rates", () => {
+		const { agg } = ingestAll([
+			header(),
+			assistant(
+				"a1",
+				{ input: 100 },
+				{ provider: "openrouter", model: "anthropic/claude-opus-4.6" },
+			),
+		]);
+		const row = agg.byModel.get("openrouter:anthropic/claude-opus-4.6");
+		expect(row?.unpricedTokens).toBe(100);
+		expect(row?.costUSD).toBe(0);
+	});
+
+	it("prices a local provider at a real zero", () => {
+		const { agg } = ingestAll([
+			header(),
+			assistant(
+				"a1",
+				{ input: 100 },
+				{ provider: "ollama", model: "llama3.2:3b" },
+			),
+		]);
+		const row = agg.byModel.get("ollama:llama3.2:3b");
+		expect(row?.costUSD).toBe(0);
+		expect(row?.unpricedTokens).toBe(0);
+	});
+
+	it("treats a response served by a different model than asked as unpriced", () => {
+		// `model` is what pi asked for, `responseModel` what the API says it
+		// served. A disagreement means the rate for `model` cannot be cited.
+		const { agg } = ingestAll([
+			header(),
+			assistant("a1", { input: 100 }, { responseModel: "some-other-model" }),
+		]);
+		const row = agg.byModel.get("anthropic:claude-fable-5");
+		expect(row?.unpricedTokens).toBe(100);
+		expect(row?.costUSD).toBe(0);
+	});
+
+	it("prices normally when responseModel agrees", () => {
+		const { agg } = ingestAll([
+			header(),
+			assistant("a1", { input: 100 }, { responseModel: "claude-fable-5" }),
+		]);
+		expect(agg.byModel.get("anthropic:claude-fable-5")?.costUSD).toBeCloseTo(
+			0.001,
+			10,
+		);
+	});
+});
+
+describe("window and activity", () => {
+	const OLD = "2026-06-01T08:00:00.000Z";
+	const SINCE = Date.parse("2026-07-01T00:00:00.000Z");
+
+	it("skips out-of-window usage but keeps pre-window context for in-window entries", () => {
+		const agg = createAggregate();
+		const fold = createFoldState();
+		const state = createFileState();
+		const entries = [
+			header({ timestamp: OLD }),
+			assistant(
+				"a1",
+				{ input: 999 },
+				{ timestamp: Date.parse(OLD) },
+				{ timestamp: OLD },
+			),
+			{
+				type: "model_change",
+				id: "e4e4e4e4",
+				parentId: null,
+				timestamp: OLD,
+				provider: "anthropic",
+				modelId: "claude-haiku-4-5",
+			},
+			// resumed today: usage bills to the model named before the window
+			{
+				type: "compaction",
+				id: "c2c2c2c2",
+				parentId: "e4e4e4e4",
+				timestamp: TS,
+				summary: "s",
+				tokensBefore: 1,
+				usage: usage({ input: 30 }),
+			},
+		];
+		for (const e of entries) ingestEntry(agg, e, state, fold, SINCE);
+
+		expect(agg.byModel.get("anthropic:claude-fable-5")).toBeUndefined();
+		expect(agg.byModel.get("anthropic:claude-haiku-4-5")?.input).toBe(30);
+		expect(agg.distinctResponses).toBe(1);
+	});
+
+	it("counts the session, project and day on the first in-window entry only", () => {
+		const agg = createAggregate();
+		const fold = createFoldState();
+		const state = createFileState();
+		const entries = [
+			header({ timestamp: OLD }),
+			assistant("a1", { input: 10 }),
+			assistant(
+				"a2",
+				{ input: 5 },
+				{},
+				{ timestamp: "2026-07-21T09:00:00.000Z" },
+			),
+		];
+		for (const e of entries) ingestEntry(agg, e, state, fold, SINCE);
+
+		expect(agg.sessions.size).toBe(1);
+		expect(agg.projectDirs.size).toBe(1);
+		expect([...agg.activeDays].sort()).toEqual(["2026-07-20", "2026-07-21"]);
+		expect(agg.firstTs).toBe(TS_MS);
+		expect(agg.lastTs).toBe(Date.parse("2026-07-21T09:00:00.000Z"));
+	});
+
+	it("counts toolCall blocks by name, deduped by call id, and tallies content blocks", () => {
+		const content = [
+			{ type: "thinking", thinking: "..." },
+			{ type: "text", text: "hi" },
+			{ type: "toolCall", id: "call_1", name: "bash", arguments: {} },
+			{ type: "toolCall", id: "call_2", name: "read", arguments: {} },
+			// a user extension's tool — kept as a plain count, fail-closed
+			{
+				type: "toolCall",
+				id: "call_3",
+				name: "my-extension-tool",
+				arguments: {},
+			},
+		];
+		const { agg } = ingestAll([
+			header(),
+			assistant("a1", { input: 10 }, { content }),
+			// the /fork duplicate carries the same call ids — not double counted
+			assistant("a1", { input: 10 }, { content }),
+		]);
+		expect(agg.toolCalls.get("bash")).toBe(1);
+		expect(agg.toolCalls.get("read")).toBe(1);
+		expect(agg.toolCalls.get("my-extension-tool")).toBe(1);
+		expect(agg.thinkingBlocks).toBe(1);
+		expect(agg.textBlocks).toBe(1);
+	});
+
+	it("does not count a user-typed bashExecution as a tool call", () => {
+		const { agg } = ingestAll([
+			header(),
+			{
+				type: "message",
+				id: "b1b1b1b1",
+				parentId: null,
+				timestamp: TS,
+				message: {
+					role: "bashExecution",
+					command: "rm -rf /secret",
+					output: "...",
+					exitCode: 0,
+					cancelled: false,
+					truncated: false,
+					timestamp: TS_MS,
+				},
+			},
+		]);
+		expect(agg.toolCalls.size).toBe(0);
+	});
+
+	it("counts nothing at all for a file with no in-window entry", () => {
+		const agg = createAggregate();
+		const fold = createFoldState();
+		const state = createFileState();
+		const entries = [
+			header({ timestamp: OLD }),
+			assistant(
+				"a1",
+				{ input: 999 },
+				{ timestamp: Date.parse(OLD) },
+				{ timestamp: OLD },
+			),
+		];
+		for (const e of entries) ingestEntry(agg, e, state, fold, SINCE);
+
+		expect(agg.sessions.size).toBe(0);
+		expect(agg.projectDirs.size).toBe(0);
+		expect(agg.activeDays.size).toBe(0);
+		expect(agg.byModel.size).toBe(0);
+	});
+});

--- a/packages/cli/src/harness/pi/analyzer.ts
+++ b/packages/cli/src/harness/pi/analyzer.ts
@@ -1,0 +1,297 @@
+// Pure fold over parsed pi session-file entries. No I/O, no console.
+//
+// Wayfinder ticket #126 (map #121). Field semantics come from
+// docs/research/harness-adapters-2026-08.md (§pi-mono), read off the vendor
+// doc set shipped in /opt/pi-coding-agent/docs and verified against the real
+// files in ~/.pi/agent/sessions. Every field is untrusted and optional: entries
+// arrive as `unknown` and are narrowed here.
+//
+// THE LOAD-BEARING FACTS (research §2-§3):
+//   - `usage.input` already EXCLUDES cache traffic — no subtraction (Codex,
+//     inverted); `reasoning` is a subset of `output` — never add it;
+//   - `cacheWrite1h` is a SUBSET of `cacheWrite`, so the TTL split maps onto
+//     TokenCounts exactly: pi is the only harness that hands the re-pricer
+//     the split instead of a lower bound;
+//   - /fork and /clone copy entries into a second file KEEPING entry ids, so
+//     usage dedup is cross-file, and the 8-hex id alone collides at corpus
+//     scale — the key is `${id}:${timestamp}:${totalTokens}`;
+//   - `compaction.retainedTail` embeds assistant messages that already appear
+//     as their own entries earlier in the same file — never descend into it;
+//   - pi's own `usage.cost` is computed against an unpinned network-refreshed
+//     table — uncitable, so cost comes from @aistack/pricing only.
+//
+// Pricing keys follow #123's binding rule: every row is keyed
+// `modelKeyFor(provider, model)` with pi's own provider id verbatim. Only
+// `anthropic`/`openai`/`google` reach vendor rates; a router-billed response
+// (`openrouter:anthropic/claude-opus-4.6`) stays unpriced, which is the safe
+// direction — it did not pay vendor list price.
+
+import {
+	apiEquivalentCost,
+	modelKeyFor,
+	normalizeModel,
+	type TokenCounts,
+} from "@aistack/pricing";
+import {
+	addModelUsage,
+	asArr,
+	asName,
+	asNum,
+	asObj,
+	asStr,
+	bump,
+	countsTotal,
+	createAggregate as createSharedAggregate,
+	type Aggregate as SharedAggregate,
+} from "../shared/aggregate.js";
+
+/** Cross-file dedup lives in FoldState, not the aggregate's `seen`. */
+export type Aggregate = SharedAggregate<never>;
+
+export function createAggregate(): Aggregate {
+	return createSharedAggregate<never>();
+}
+
+/**
+ * Scan-level fold state, shared across every file in one scan: /fork and
+ * /clone duplicate entries into a second file keeping their ids, so the dedup
+ * set cannot be per-file.
+ */
+export type FoldState = {
+	seenUsage: Set<string>;
+};
+
+export function createFoldState(): FoldState {
+	return { seenUsage: new Set() };
+}
+
+/** Per-file fold state. */
+export type FileState = {
+	sessionId: string | null;
+	cwd: string | null;
+	/** Pricing key of the nearest preceding assistant message or model_change. */
+	modelKey: string | null;
+	/** True once any in-window entry was counted for this file. */
+	counted: boolean;
+};
+
+export function createFileState(): FileState {
+	return { sessionId: null, cwd: null, modelKey: null, counted: false };
+}
+
+/**
+ * Fold one parsed session-file entry into the aggregate.
+ *
+ * `sinceMs` is applied HERE rather than in the scanner because context entries
+ * (the header, `model_change`) must update `state` even when they predate the
+ * window — a session resumed today bills today's usage to a model named last
+ * week. The window filter reads the entry's ISO timestamp first and falls back
+ * to the message's Unix-ms timestamp, the same order pricing uses.
+ */
+export function ingestEntry(
+	agg: Aggregate,
+	raw: unknown,
+	state: FileState,
+	fold: FoldState,
+	sinceMs?: number,
+): void {
+	const rec = asObj(raw);
+	if (!rec) return;
+	agg.records++;
+
+	const type = asStr(rec.type);
+	const message = type === "message" ? asObj(rec.message) : null;
+	const role = message ? asStr(message.role) : null;
+
+	// Context updates happen regardless of the window.
+	if (type === "session") {
+		state.sessionId = asStr(rec.id) ?? state.sessionId;
+		state.cwd = asStr(rec.cwd) ?? state.cwd;
+		return;
+	}
+	if (type === "model_change") {
+		const provider = asStr(rec.provider);
+		const model = asStr(rec.modelId);
+		if (provider && model) state.modelKey = toPricingKey(provider, model);
+	}
+	if (role === "assistant" && message) {
+		const provider = asStr(message.provider);
+		const model = asStr(message.model);
+		if (provider && model) state.modelKey = toPricingKey(provider, model);
+	}
+
+	// Entry-level ISO timestamp first, message-level Unix ms as the fallback.
+	const entryTs = Date.parse(asStr(rec.timestamp) ?? "");
+	const msgTs = message ? asNum(message.timestamp) : 0;
+	const tsMs = !Number.isNaN(entryTs) ? entryTs : msgTs > 0 ? msgTs : null;
+
+	const inWindow = sinceMs === undefined || (tsMs !== null && tsMs >= sinceMs);
+	if (!inWindow) return;
+
+	if (tsMs !== null) {
+		agg.activeDays.add(new Date(tsMs).toISOString().slice(0, 10));
+		agg.firstTs = agg.firstTs === null ? tsMs : Math.min(agg.firstTs, tsMs);
+		agg.lastTs = agg.lastTs === null ? tsMs : Math.max(agg.lastTs, tsMs);
+	}
+	noteActivity(agg, state);
+
+	if (role === "assistant" && message) {
+		agg.assistantRecords++;
+		// `model` is what pi asked for, `responseModel` what the API says it
+		// served. Routers make them differ, and then the rate for `model`
+		// cannot be cited — the tokens surface as unpriced instead.
+		const served = asStr(message.responseModel);
+		const priceable = served === null || served === asStr(message.model);
+		const outcome = countUsage(
+			agg,
+			fold,
+			rec,
+			msgTs,
+			message.usage,
+			state.modelKey,
+			tsMs,
+			priceable,
+		);
+		// A /fork duplicate repeats the content blocks too; the call-id dedup
+		// already covers tool calls, but the thinking/text tallies have no ids.
+		if (outcome !== "duplicate") ingestContent(agg, message.content);
+	} else if (role === "toolResult" && message) {
+		// "Nested LLM work performed by the tool" — real spend, counted by
+		// pi's own footer. No model of its own, so it bills to the model in
+		// effect, the way Codex deltas bill to the nearest turn_context.
+		countUsage(agg, fold, rec, msgTs, message.usage, state.modelKey, tsMs);
+	} else if (type === "compaction" || type === "branch_summary") {
+		// Summary generation is real spend (optional `usage` on the entry). The
+		// materialized `retainedTail` embeds assistant messages that already
+		// appear as their own entries — deliberately never walked.
+		countUsage(agg, fold, rec, 0, rec.usage, state.modelKey, tsMs);
+	}
+}
+
+/** Count the file's session and cwd once, on its first in-window entry. */
+function noteActivity(agg: Aggregate, state: FileState): void {
+	if (state.counted) return;
+	state.counted = true;
+	if (state.sessionId) agg.sessions.add(state.sessionId);
+	// Counted, never published — same standing non-goal as Claude project dirs.
+	agg.projectDirs.add(state.cwd ?? "(unknown)");
+}
+
+/** Fold one usage block into the totals, behind the cross-file dedup. */
+function countUsage(
+	agg: Aggregate,
+	fold: FoldState,
+	rec: Record<string, unknown>,
+	msgTsMs: number,
+	usageRaw: unknown,
+	modelKey: string | null,
+	tsMs: number | null,
+	priceable = true,
+): "counted" | "duplicate" | "none" {
+	const counts = readCounts(usageRaw);
+	if (!counts) return "none";
+	const total = countsTotal(counts);
+	if (total === 0) return "none";
+
+	// /fork and /clone write the same entry into a second file with its id
+	// intact, so dedup is cross-file. The 8-hex id alone has a real birthday
+	// collision at corpus scale, so the timestamps and the token total ride
+	// along — two genuinely different responses sharing an id stay two.
+	const id = asStr(rec.id);
+	if (id) {
+		const key = `${id}:${asStr(rec.timestamp) ?? ""}:${msgTsMs}:${total}`;
+		if (fold.seenUsage.has(key)) {
+			agg.continuationsFolded++;
+			return "duplicate";
+		}
+		fold.seenUsage.add(key);
+	} else {
+		agg.unkeyedResponses++;
+	}
+
+	if (tsMs === null) agg.untimestampedResponses++;
+	agg.distinctResponses++;
+	const key = modelKey ?? "(unknown)";
+	addModelUsage(
+		agg,
+		key,
+		counts,
+		priceable ? apiEquivalentCost(key, counts, tsMs) : null,
+	);
+	// pi has no subagents by vendor design — everything is the main thread,
+	// which keeps `subagentShare` an honest 0 (same case as Codex).
+	agg.mainTokens += total;
+	return "counted";
+}
+
+/**
+ * Compose the pricing key from pi's own provider and model ids (#123's
+ * binding rule). pi spells fast mode as an id SUFFIX (`claude-opus-5-fast`)
+ * and has no `usage.speed` field, so the suffix is translated into the price
+ * table's `#fast` marker here. A model genuinely named `-fast` by a provider
+ * the table does not cover stays unpriced either way, so the translation
+ * cannot invent a rate.
+ */
+function toPricingKey(provider: string, model: string): string {
+	const fast = model.endsWith("-fast");
+	const marked = fast ? `${model.slice(0, -"-fast".length)}#fast` : model;
+	return normalizeModel(modelKeyFor(provider, marked));
+}
+
+/**
+ * Assistant content blocks: tool calls plus the thinking/text tallies.
+ *
+ * `bashExecution` entries are deliberately NOT counted as tool calls — they
+ * are user-typed `!` commands, not something the model chose. A name outside
+ * PI_BUILTIN_TOOLS is a user extension's tool; it stays a plain count and the
+ * shared fail-closed payload filter withholds the name. pi has no MCP, no
+ * subagents and no skill tool by vendor design, so those maps stay EMPTY —
+ * absent from the payload, never zero (#40).
+ */
+function ingestContent(agg: Aggregate, contentRaw: unknown): void {
+	for (const blockRaw of asArr(contentRaw)) {
+		const block = asObj(blockRaw);
+		if (!block) continue;
+		const type = asStr(block.type);
+		if (type === "thinking") {
+			agg.thinkingBlocks++;
+		} else if (type === "text") {
+			agg.textBlocks++;
+		} else if (type === "toolCall") {
+			const name = asName(block.name);
+			if (!name) continue;
+			// /fork duplicates keep call ids, so the shared dedup set makes the
+			// copy a repeat rather than a double count.
+			const callId = asStr(block.id);
+			if (callId) {
+				if (agg.toolCallDedup.has(callId)) continue;
+				agg.toolCallDedup.add(callId);
+			} else {
+				agg.toolBlocksWithoutId++;
+			}
+			bump(agg.toolCalls, name);
+		}
+	}
+}
+
+/** The Usage shape shared by assistant/toolResult messages and summary entries. */
+function readCounts(usageRaw: unknown): TokenCounts | null {
+	const u = asObj(usageRaw);
+	if (!u) return null;
+	const cacheWrite = asNum(u.cacheWrite);
+	const split =
+		typeof u.cacheWrite1h === "number" && Number.isFinite(u.cacheWrite1h);
+	const cacheWrite1h = split
+		? Math.min(Math.max(u.cacheWrite1h as number, 0), cacheWrite)
+		: 0;
+	return {
+		// Already exclusive of cache traffic — no subtraction (research §2).
+		input: asNum(u.input),
+		// `reasoning` is a subset of `output` — never added.
+		output: asNum(u.output),
+		cacheWrite5m: split ? cacheWrite - cacheWrite1h : 0,
+		cacheWrite1h,
+		cacheWriteUnsplit: split ? 0 : cacheWrite,
+		cacheRead: asNum(u.cacheRead),
+	};
+}

--- a/packages/cli/src/harness/pi/scan.test.ts
+++ b/packages/cli/src/harness/pi/scan.test.ts
@@ -1,0 +1,215 @@
+// The pi scanner's file-level behavior — wayfinder ticket #126 (map #121):
+// the vendor's own version header as the genuineness fingerprint, the
+// version ceiling (a newer schema reads as unreadable, never as zero), the
+// cross-file /fork dedup, and swallowed-not-thrown read failures.
+
+import {
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { finalize } from "../shared/aggregate.js";
+import { createAggregate } from "./analyzer.js";
+import { isSessionFile, scan, sessionRoots } from "./scan.js";
+
+const TS = "2026-07-20T12:00:00.000Z";
+const TS_MS = Date.parse(TS);
+
+const header = (over: Record<string, unknown> = {}) => ({
+	type: "session",
+	version: 3,
+	id: "019f8fe5-f4d5-744d-9b02-4a9bad77279d",
+	timestamp: TS,
+	cwd: "/home/u/secret-project",
+	...over,
+});
+
+const assistant = (id: string, input: number) => ({
+	type: "message",
+	id,
+	parentId: null,
+	timestamp: TS,
+	message: {
+		role: "assistant",
+		content: [],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-fable-5",
+		usage: {
+			input,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: input,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: TS_MS,
+	},
+});
+
+const FILE_A =
+	"2026-07-20T12-00-00-000Z_019f8fe5-f4d5-744d-9b02-4a9bad77279d.jsonl";
+const FILE_B =
+	"2026-07-20T12-30-00-000Z_019f8fe6-a076-7626-b43c-68bb3b08976a.jsonl";
+
+let root: string;
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "aistack-pi-scan-"));
+});
+
+afterEach(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+function writeSession(
+	cwdDir: string,
+	basename: string,
+	records: unknown[],
+): string {
+	const dir = join(root, cwdDir);
+	mkdirSync(dir, { recursive: true });
+	const full = join(dir, basename);
+	writeFileSync(full, `${records.map((r) => JSON.stringify(r)).join("\n")}\n`);
+	return full;
+}
+
+describe("isSessionFile", () => {
+	it("matches pi's timestamp_uuid.jsonl names and nothing else", () => {
+		expect(isSessionFile(FILE_A)).toBe(true);
+		expect(isSessionFile("notes.jsonl")).toBe(false);
+		expect(isSessionFile("rollout-2026-07-20.jsonl")).toBe(false);
+		expect(isSessionFile(FILE_A.replace(".jsonl", ".json"))).toBe(false);
+	});
+});
+
+describe("sessionRoots", () => {
+	it("honors PI_CODING_AGENT_SESSION_DIR over PI_CODING_AGENT_DIR over the default", () => {
+		const prevDir = process.env.PI_CODING_AGENT_DIR;
+		const prevSess = process.env.PI_CODING_AGENT_SESSION_DIR;
+		try {
+			process.env.PI_CODING_AGENT_DIR = "/custom/agent";
+			delete process.env.PI_CODING_AGENT_SESSION_DIR;
+			expect(sessionRoots()).toEqual([join("/custom/agent", "sessions")]);
+			process.env.PI_CODING_AGENT_SESSION_DIR = "/custom/sessions";
+			expect(sessionRoots()).toEqual(["/custom/sessions"]);
+		} finally {
+			if (prevDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = prevDir;
+			if (prevSess === undefined)
+				delete process.env.PI_CODING_AGENT_SESSION_DIR;
+			else process.env.PI_CODING_AGENT_SESSION_DIR = prevSess;
+		}
+	});
+});
+
+describe("version-header gate", () => {
+	it("ingests a genuine session file", async () => {
+		writeSession("--home-u-secret-project--", FILE_A, [
+			header(),
+			assistant("a1", 100),
+		]);
+		const agg = createAggregate();
+		const stats = await scan(agg, { roots: [root] });
+		expect(stats.filesRead).toBe(1);
+		expect(stats.filesForeign).toBe(0);
+		expect(finalize(agg).models[0].tokens.input).toBe(100);
+		expect(finalize(agg).sessions).toBe(1);
+	});
+
+	it("excludes a file whose first line is not a pi session header", async () => {
+		writeSession("--home-u-secret-project--", FILE_A, [
+			{ type: "rollout", note: "someone else's log" },
+			assistant("a1", 999),
+		]);
+		const agg = createAggregate();
+		const stats = await scan(agg, { roots: [root] });
+		expect(stats.filesForeign).toBe(1);
+		expect(stats.filesRead).toBe(0);
+		expect(finalize(agg).totalTokens).toBe(0);
+	});
+
+	it("reads a session-format version above the known ceiling as unreadable, never as zero", async () => {
+		writeSession("--home-u-secret-project--", FILE_A, [
+			header({ version: 4 }),
+			assistant("a1", 999),
+		]);
+		const agg = createAggregate();
+		const stats = await scan(agg, { roots: [root] });
+		expect(stats.filesUnreadable).toBe(1);
+		expect(stats.filesRead).toBe(0);
+		expect(stats.unreadableFiles[0]?.reason).toBe("version-too-new");
+		expect(finalize(agg).totalTokens).toBe(0);
+	});
+
+	it("still reads the older v1/v2 formats — their usage fields never changed", async () => {
+		writeSession("--home-u-secret-project--", FILE_A, [
+			header({ version: 1 }),
+			assistant("a1", 50),
+		]);
+		const agg = createAggregate();
+		const stats = await scan(agg, { roots: [root] });
+		expect(stats.filesRead).toBe(1);
+		expect(finalize(agg).totalTokens).toBe(50);
+	});
+});
+
+describe("cross-file dedup and window", () => {
+	it("counts a /fork-duplicated response once across two files", async () => {
+		writeSession("--home-u-secret-project--", FILE_A, [
+			header(),
+			assistant("a1", 100),
+		]);
+		writeSession("--home-u-secret-project--", FILE_B, [
+			header({
+				id: "019f8fe6-a076-7626-b43c-68bb3b08976a",
+				parentSession: "/orig.jsonl",
+			}),
+			assistant("a1", 100),
+			assistant("b2", 25),
+		]);
+		const agg = createAggregate();
+		await scan(agg, { roots: [root] });
+		expect(finalize(agg).totalTokens).toBe(125);
+		expect(agg.continuationsFolded).toBe(1);
+		// two real sessions, one project directory
+		expect(finalize(agg).sessions).toBe(2);
+		expect(finalize(agg).projects).toBe(1);
+	});
+
+	it("skips a file untouched since the window opened", async () => {
+		const file = writeSession("--home-u-secret-project--", FILE_A, [
+			header(),
+			assistant("a1", 100),
+		]);
+		const old = new Date("2026-06-01T00:00:00Z");
+		utimesSync(file, old, old);
+		const agg = createAggregate();
+		const stats = await scan(agg, {
+			roots: [root],
+			sinceMs: Date.parse("2026-07-01T00:00:00Z"),
+		});
+		expect(stats.filesSkippedByMtime).toBe(1);
+		expect(stats.filesRead).toBe(0);
+	});
+
+	it("counts parse errors per line without dropping the file", async () => {
+		const dir = join(root, "--home-u-secret-project--");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(
+			join(dir, FILE_A),
+			`${JSON.stringify(header())}\n{broken json\n${JSON.stringify(assistant("a1", 10))}\n`,
+		);
+		const agg = createAggregate();
+		const stats = await scan(agg, { roots: [root] });
+		expect(stats.filesRead).toBe(1);
+		expect(agg.parseErrors).toBe(1);
+		expect(finalize(agg).totalTokens).toBe(10);
+	});
+});

--- a/packages/cli/src/harness/pi/scan.ts
+++ b/packages/cli/src/harness/pi/scan.ts
@@ -1,0 +1,229 @@
+// I/O shell around the pure pi analyzer: find session files, stream JSONL,
+// hand each parsed entry to ingestEntry. Nothing leaves this machine.
+//
+// Wayfinder ticket #126 (map #121), semantics from
+// docs/research/harness-adapters-2026-08.md (§pi-mono).
+//
+// STANDING NON-GOAL (locked in #13): raw transcripts, prompts, absolute paths,
+// and repo names never leave the machine. pi's files are MORE sensitive than
+// the other harnesses': there is no separate history file, so raw prompts,
+// bashExecution output, base64 screenshots, provider error bodies and the
+// munged-absolute-path directory names all sit on the same lines the scanner
+// parses. The analyzer reads named fields only; the directory name is never
+// even counted (the header's `cwd` is, as an opaque key). Streaming line by
+// line keeps a pasted screenshot from pulling megabytes into memory.
+// `~/.pi/agent/auth.json` holds credentials — only `sessions/` is ever walked.
+// Read errors are swallowed, not thrown: the error object carries the path.
+
+import { createReadStream, type Dirent } from "node:fs";
+import { readdir, realpath, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import readline from "node:readline";
+
+import { asNum, asObj, asStr } from "../shared/aggregate.js";
+import { emptyScanStats, type ScanStats } from "../shared/window.js";
+import {
+	type Aggregate,
+	createFileState,
+	createFoldState,
+	type FoldState,
+	ingestEntry,
+} from "./analyzer.js";
+
+/**
+ * The newest session-format version this scanner understands. The vendor doc
+ * states the ladder (v1 linear, v2 tree, v3 renamed hookMessage to custom);
+ * none of the changes touched `usage`, `model` or `timestamp`, so v1-v3 all
+ * read with one fold. A file ABOVE the ceiling may have reshaped those fields,
+ * so it counts as unreadable — a visible coverage figure — rather than being
+ * misread as zeros.
+ */
+export const MAX_SESSION_VERSION = 3;
+
+/** `PI_CODING_AGENT_DIR` honored, `~/.pi/agent` the default — mirrors pi. */
+export function piAgentDir(): string {
+	return (
+		process.env.PI_CODING_AGENT_DIR || path.join(homedir(), ".pi", "agent")
+	);
+}
+
+/**
+ * Only `sessions/` is read — `auth.json` (credentials), `settings.json` and
+ * the ACP session map live beside it and are out of bounds. A run started
+ * with `--session-dir` writes outside every discoverable root and is
+ * invisible, which is silence — the direction #40 permits.
+ */
+export function sessionRoots(): string[] {
+	const override = process.env.PI_CODING_AGENT_SESSION_DIR;
+	return [override || path.join(piAgentDir(), "sessions")];
+}
+
+/**
+ * pi names every session file `<munged-ISO-start>_<uuid>.jsonl`
+ * (`2026-07-23T16-54-00-149Z_019f8fe5-….jsonl`). Shared with `detect` (#101).
+ */
+const SESSION_FILE_RE =
+	/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/;
+
+/** What counts as a pi session file. */
+export function isSessionFile(basename: string): boolean {
+	return SESSION_FILE_RE.test(basename);
+}
+
+/** Recursive walk — the real layout is two levels (one directory per cwd). */
+async function* walkSessions(dir: string): AsyncGenerator<string> {
+	let entries: Dirent[];
+	try {
+		entries = await readdir(dir, { withFileTypes: true });
+	} catch {
+		return;
+	}
+	for (const e of entries) {
+		const full = path.join(dir, e.name);
+		if (e.isDirectory()) yield* walkSessions(full);
+		else if (e.isFile() && isSessionFile(e.name)) yield full;
+	}
+}
+
+export type ScanOptions = {
+	/** Only count entries with a timestamp at or after this epoch ms. */
+	sinceMs?: number;
+	onProgress?: (files: number) => void;
+	/** Override the discovered roots. Tests only. */
+	roots?: string[];
+};
+
+export async function scan(
+	agg: Aggregate,
+	opts: ScanOptions = {},
+): Promise<ScanStats> {
+	const stats: ScanStats = emptyScanStats();
+	const visited = new Set<string>();
+	// /fork and /clone duplicate entries ACROSS files, so the dedup state is
+	// one per scan, not one per file.
+	const fold = createFoldState();
+
+	for (const root of opts.roots ?? sessionRoots()) {
+		if (!(await exists(root))) continue;
+		for await (const file of walkSessions(root)) {
+			stats.filesFound++;
+
+			let resolved: string;
+			try {
+				resolved = await realpath(file);
+			} catch {
+				resolved = file;
+			}
+			if (visited.has(resolved)) {
+				stats.filesSkippedAsDuplicate++;
+				continue;
+			}
+			visited.add(resolved);
+
+			// Session files are append-only, so a file untouched since the window
+			// opened cannot hold an in-window entry.
+			if (opts.sinceMs !== undefined) {
+				try {
+					const st = await stat(file);
+					if (st.mtimeMs < opts.sinceMs) {
+						stats.filesSkippedByMtime++;
+						continue;
+					}
+				} catch {
+					/* unreadable stat — fall through and try to read it */
+				}
+			}
+
+			agg.files++;
+			stats.filesRead++;
+			if (opts.onProgress && agg.files % 200 === 0) opts.onProgress(agg.files);
+			try {
+				const verdict = await ingestFile(agg, fold, file, opts.sinceMs);
+				if (verdict === "foreign") {
+					// The first line is not a pi session header: another tool wrote
+					// this file. Its usage stayed out of the aggregate entirely.
+					stats.filesForeign++;
+					stats.filesRead--;
+					const seen = stats.foreignOriginators.get("(no-pi-header)") ?? 0;
+					stats.foreignOriginators.set("(no-pi-header)", seen + 1);
+				} else if (verdict === "version-too-new") {
+					stats.filesUnreadable++;
+					stats.filesRead--;
+					stats.unreadableFiles.push({
+						path: path.relative(root, file),
+						reason: "version-too-new",
+					});
+				}
+			} catch {
+				// Swallow deliberately: the error object carries the absolute path.
+				stats.filesUnreadable++;
+				stats.filesRead--;
+				stats.unreadableFiles.push({
+					path: path.relative(root, file),
+					reason: "read-error",
+				});
+			}
+		}
+	}
+	return stats;
+}
+
+async function exists(p: string): Promise<boolean> {
+	try {
+		await stat(p);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Stream one session file through the fold. The vendor put the fingerprint on
+ * line 1 — `{"type":"session"}` with a numeric `version` — so the verdict
+ * lands before any usage is folded, and a foreign or too-new file leaves the
+ * aggregate untouched by construction (no parse-then-fold buffering needed).
+ */
+async function ingestFile(
+	agg: Aggregate,
+	fold: FoldState,
+	file: string,
+	sinceMs?: number,
+): Promise<"ok" | "foreign" | "version-too-new"> {
+	const rl = readline.createInterface({
+		input: createReadStream(file, { encoding: "utf8" }),
+		crlfDelay: Number.POSITIVE_INFINITY,
+	});
+	const state = createFileState();
+	let first = true;
+	try {
+		for await (const line of rl) {
+			if (!line) continue;
+			agg.lines++;
+			let entry: unknown;
+			try {
+				entry = JSON.parse(line);
+			} catch {
+				agg.parseErrors++;
+				continue;
+			}
+			if (first) {
+				first = false;
+				const header = asObj(entry);
+				const version = header ? asNum(header.version) : 0;
+				if (!header || asStr(header.type) !== "session" || version < 1) {
+					agg.lines--;
+					return "foreign";
+				}
+				if (version > MAX_SESSION_VERSION) {
+					agg.lines--;
+					return "version-too-new";
+				}
+			}
+			ingestEntry(agg, entry, state, fold, sinceMs);
+		}
+	} finally {
+		rl.close();
+	}
+	return "ok";
+}

--- a/src/features/measured/copy.ts
+++ b/src/features/measured/copy.ts
@@ -226,8 +226,10 @@ export function coverageCaveat(s: HarnessSnapshot): string | null {
 export function harnessLabel(name: string): string {
 	if (name === "claude-code") return HARNESS;
 	if (name === "codex") return "Codex";
-	// The brand spells itself lowercase, so the discriminator is the label.
+	// These brands spell themselves lowercase, so the discriminator is the
+	// label — but each is an explicit row, so a rename cannot leak a raw slug.
 	if (name === "opencode") return "opencode";
+	if (name === "pi-mono") return "pi-mono";
 	return name;
 }
 


### PR DESCRIPTION
Resolves alp82/aistack#126 (map alp82/aistack#121).

## What this does

The CLI reads pi session history behind the harness seam, prices it at ingest, and publishes it as its own snapshot beside Claude Code, Codex and opencode.

- **Detection follows #101**: `hasRecentFile` over `~/.pi/agent/sessions` (env overrides honored), matched on pi's `<timestamp>_<uuid>.jsonl` names. The walk is 2 levels and a handful of stat calls.
- **The vendor's version header is the fingerprint.** Line 1 must be `{"type":"session"}` with a numeric version. A version above the known ceiling (3) counts as `version-too-new` unreadable - a visible coverage figure, never a misread zero.
- **Usage mapping is exact.** `usage.input` already excludes cache traffic (no subtraction), `reasoning` is a subset of `output` (never added), and `cacheWrite1h` is a subset of `cacheWrite`, so the TTL split lands on `TokenCounts` with no lower bound. pi is the only harness that hands the backend re-pricer the split instead of a guess.
- **All four usage locations count**: assistant messages, toolResult nested LLM work, compaction and branch-summary generation - the same set pi's own footer sums. `retainedTail` is never descended.
- **Cross-file dedup.** `/fork` and `/clone` copy entries keeping their ids, so dedup is scan-level with a composite `id:entryTs:msgTs:total` key (the 8-hex id alone collides at corpus scale).
- **Pricing keys carry pi's provider id** (#123 binding rule). Only anthropic/openai/google reach vendor rates; `openrouter:anthropic/claude-opus-4.6` stays unpriced; local providers price at a real zero. pi's `-fast` id suffix translates to the table's `#fast` key. A `responseModel` that disagrees with `model` makes the response unpriced. pi's own `usage.cost` is never read.
- **Positive claims only (#40).** MCP, subagents and skills do not exist in pi by vendor design and stay absent, not zero. `bashExecution` entries are user-typed commands, not tool calls, and are not counted. Builtin tools are the vendor's seven names, fail-closed.
- **Nothing leaves the machine.** Named fields only, streamed line by line (a pasted screenshot never pulls megabytes into memory), read errors swallowed, only `sessions/` walked - `auth.json` is never opened.

## Verification

Against the real install on this machine: 3 files, 3 sessions, 2 projects, all zero-usage 400 responses - matching the research (`docs/research/harness-adapters-2026-08.md`). A live non-zero validation run was attempted and still hits the account's quota 400, so magnitudes rest on the vendor docs, the binary's own usage mapping, and the test fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TuPYyH6JxiDRSnJa6sCvK