### PR TITLE
Task: the refined /sync page and CLI output (alp82/aistack#131)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@use-aistack/cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Measure and share your AI stack from your terminal",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -24,6 +24,7 @@ import {
 import { runAutoSync } from "../autosync/run.js";
 import { DEFAULT_FREQUENCY_HOURS, getSettings, getToken } from "../config.js";
 import { stageSync } from "../sync/stage.js";
+import { fmtReceivedAt } from "../sync/summary.js";
 import { dim, intro, lime, outro, outroCancel, outroError } from "../theme.js";
 import { offerConnectUpsell } from "./connect.js";
 import { performLogin } from "./login.js";
@@ -153,8 +154,13 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
 	try {
 		const res = await syncPublish(staged.token as string, staged.bodyJson);
 		s.stop("Published");
+		// The last thing read is the result, not a receipt (#130): the stamp is
+		// human-form, and the link gets its own line under a sentence that names
+		// the proof. The path stays in the terminal — no browser is opened.
 		const lines = [
-			`Snapshot received at ${new Date(res.receivedAt).toISOString()}`,
+			`Snapshot received ${fmtReceivedAt(res.receivedAt)}`,
+			"",
+			"Your stack now shows what actually ran:",
 			lime(res.url),
 		];
 		if (res.keptPrivate.refused && staged.body.keptPrivate !== undefined) {

--- a/packages/cli/src/sync/server.ts
+++ b/packages/cli/src/sync/server.ts
@@ -25,6 +25,7 @@
 
 import { type SyncPublishResult, syncPublish } from "../api.js";
 import { type StageDeps, type StagedSend, stageSync } from "./stage.js";
+import { fmtReceivedAt } from "./summary.js";
 
 const SERVER_NAME = "aistack";
 const SERVER_VERSION = "0.3.0";
@@ -254,8 +255,12 @@ export function createSyncServer(
 				publish(approvedStage.token as string, approvedStage.bodyJson).then(
 					(res) => {
 						if (staged?.id === approvedStage.id) staged = null;
+						// Same ending as the terminal channel (#130): the result last,
+						// the stamp in human form.
 						const lines = [
-							`Published. Snapshot received at ${new Date(res.receivedAt).toISOString()}.`,
+							`Published. Snapshot received ${fmtReceivedAt(res.receivedAt)}.`,
+							"",
+							"Your stack now shows what actually ran:",
 							res.url,
 						];
 						const kp = approvedStage.body.keptPrivate;

--- a/packages/cli/src/sync/summary.test.ts
+++ b/packages/cli/src/sync/summary.test.ts
@@ -15,6 +15,7 @@ import { emptyScanStats } from "../harness/shared/window.js";
 import {
 	buildGateDialog,
 	buildGateSummary,
+	fmtReceivedAt,
 	fmtTokens,
 	fmtUSD,
 	type GateContext,
@@ -141,6 +142,12 @@ describe("formatting", () => {
 	test("dollars are whole with a ≈", () => {
 		expect(fmtUSD(5839.75)).toBe("≈$5,840");
 	});
+
+	test("the received stamp drops the milliseconds and the T/Z machine form (#130)", () => {
+		expect(fmtReceivedAt(Date.UTC(2026, 7, 10, 21, 3, 44, 123))).toBe(
+			"2026-08-10 21:03 UTC",
+		);
+	});
 });
 
 describe("totalUSD — never a dollar without its pricing table (#46)", () => {
@@ -207,6 +214,22 @@ describe("beat two — the dialog (binding copy, #48)", () => {
 });
 
 describe("beat one — the summary", () => {
+	test("the searched line names every harness this build looks for (#130)", () => {
+		const summary = buildGateSummary(ctx({}));
+		const lines = summary.split("\n");
+		const toIdx = lines.findIndex((l) => l.startsWith("to        "));
+		expect(lines[toIdx + 1]).toBe(
+			"searched  claude code, codex, opencode, pi-mono",
+		);
+	});
+
+	test("the harness header prints even for a single harness (#130)", () => {
+		// A `searched` line naming four harnesses followed by one unlabeled block
+		// is unreadable, so the header is unconditional — an intentional output
+		// change for every single-harness user.
+		expect(buildGateSummary(ctx({}))).toContain("— Claude Code 2.1.220");
+	});
+
 	test("names the destination and the changes URL before any send", () => {
 		const summary = buildGateSummary(
 			ctx({ withKeptPrivateHalf: true, keptPrivate: KEPT }),

--- a/packages/cli/src/sync/summary.ts
+++ b/packages/cli/src/sync/summary.ts
@@ -10,7 +10,7 @@
 // Nothing in this file is accepted as a caller-supplied argument beside the
 // payload — the spike promoted that from a caution to a demonstrated property.
 
-import { harnessLabel } from "../harness/index.js";
+import { HARNESS_ADAPTERS, harnessLabel } from "../harness/index.js";
 import type {
 	KeptPrivateAtom,
 	NameCategory,
@@ -61,6 +61,15 @@ export function fmtUSD(n: number): string {
 }
 
 const fmtPct = (share: number): string => `${(share * 100).toFixed(1)}%`;
+
+/**
+ * `2026-08-10 21:03 UTC` — the publish receipt's stamp (#130). Milliseconds
+ * and the ISO `T`/`Z` machine form dropped: the last thing a person reads
+ * should be the result, not a receipt.
+ */
+export function fmtReceivedAt(ms: number): string {
+	return `${new Date(ms).toISOString().slice(0, 16).replace("T", " ")} UTC`;
+}
 
 /**
  * The dollar figure the gate names, or `null` when none may render.
@@ -196,17 +205,14 @@ export function scanNoteLines(stats: ScanStats, label: string): string[] {
 }
 
 /** One harness's payload block: window, activity, cost, models, inventory. */
-function payloadBlock(
-	payload: MeasuredPayload,
-	showHeader: boolean,
-	stats?: ScanStats,
-): string[] {
+function payloadBlock(payload: MeasuredPayload, stats?: ScanStats): string[] {
 	const out: string[] = [];
-	if (showHeader) {
-		out.push(
-			`— ${harnessLabel(payload.harness.name)}${payload.harness.version ? ` ${payload.harness.version}` : ""}`,
-		);
-	}
+	// The header is unconditional (#130): the `searched` line above names four
+	// harnesses, so an unlabeled block would be unreadable even when only one
+	// harness was found.
+	out.push(
+		`— ${harnessLabel(payload.harness.name)}${payload.harness.version ? ` ${payload.harness.version}` : ""}`,
+	);
 	out.push(
 		`window    ${payload.window.days} days · ${payload.window.from} → ${payload.window.to}`,
 	);
@@ -271,12 +277,18 @@ export function buildGateSummary(ctx: GateContext): string {
 		);
 	}
 
-	// One block per detected harness. With a single harness the header line is
-	// dropped, so the single-harness preview reads exactly as it always did.
+	// What the CLI LOOKED FOR, in search order — a claim about the CLI, never
+	// about the person's behavior, so it stays inside #40 (#130). Without it, a
+	// harness the scan misses reads identically to a harness never installed.
+	out.push(
+		`searched  ${HARNESS_ADAPTERS.map((a) => harnessLabel(a.name).toLowerCase()).join(", ")}`,
+	);
+
+	// One block per detected harness, each under its own header.
 	for (const payload of payloads) {
 		const stats = ctx.scanStats?.[payload.harness.name];
-		out.push(...payloadBlock(payload, payloads.length > 1, stats));
 		out.push("");
+		out.push(...payloadBlock(payload, stats));
 	}
 	if (out[out.length - 1] === "") out.pop();
 

--- a/src/features/activity/feed.ts
+++ b/src/features/activity/feed.ts
@@ -81,6 +81,10 @@ export function dayBucket(at: number, now: number): string {
 const HARNESS_LABELS: Record<string, string> = {
 	"claude-code": "Claude Code",
 	codex: "Codex",
+	// Lowercase brands: the wire name is the label, but each is an explicit
+	// row so a rename cannot silently leak a raw slug (#130).
+	opencode: "opencode",
+	"pi-mono": "pi-mono",
 };
 
 /** Wire names in words. An unknown harness keeps its wire spelling. */

--- a/src/features/leaderboard/board.ts
+++ b/src/features/leaderboard/board.ts
@@ -46,6 +46,10 @@ export function trendWords(
 const HARNESS_LABELS: Record<string, string> = {
 	"claude-code": "Claude Code",
 	codex: "Codex",
+	// Lowercase brands: the wire name is the label, but each is an explicit
+	// row so a rename cannot silently leak a raw slug (#130).
+	opencode: "opencode",
+	"pi-mono": "pi-mono",
 };
 
 export function harnessLabel(name: string): string {

--- a/src/routes/sync.tsx
+++ b/src/routes/sync.tsx
@@ -8,12 +8,7 @@ import {
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import { AutoSyncNote } from "@/features/measured/AutoSyncNote";
 import { CommandLine } from "@/features/measured/CommandLine";
-import {
-	HARNESS,
-	KICKER,
-	MONO_LABEL,
-	SYNC_CMD,
-} from "@/features/measured/copy";
+import { KICKER, MONO_LABEL, SYNC_CMD } from "@/features/measured/copy";
 import { seoMeta } from "@/lib/seo";
 import { cn } from "@/lib/utils";
 
@@ -26,23 +21,26 @@ export const Route = createFileRoute("/sync")({
 	component: SyncPage,
 	head: () => ({
 		meta: seoMeta({
-			title: "Sync your stack - AI Stack",
+			title: "Show what actually ran - AI Stack",
 			description:
-				"Publish a rolling 30-day reading of what actually ran, straight from your own machine. One command, an approval gate, nothing else.",
+				"Publish the reading behind your stack — sessions, models, tokens, and cost at API prices — straight from your own machine. One command, an approval gate, nothing else.",
 			url: "/sync",
 		}),
 	}),
 });
 
+// Copy locked by #130 (docs/prototypes/sync-path-2026-08.md). Proof leads,
+// discovery rides underneath; cancel is the safety line under the ask, never
+// the ask. The harness list lives in the boundary band and nowhere else.
 const STEPS: { title: string; body: string; cmd?: string }[] = [
 	{
 		title: "Sync",
-		body: `Scans your local ${HARNESS} and Codex history and shows you the full summary in the terminal — every number, every name. On the first run it opens your browser to link this machine; you name it, and you can revoke it any time.`,
+		body: "Scans your local agent history and prints the full summary in your terminal — every number, every name. On the first run it opens your browser to link this machine. You name it, and you can revoke it any time.",
 		cmd: SYNC_CMD,
 	},
 	{
 		title: "Approve",
-		body: "Nothing sends until you pick Publish. Cancel sends nothing. The exact bytes you approved go on the wire.",
+		body: "Nothing sends until you pick Publish. Cancel sends nothing, and you keep the reading you just saw. The exact bytes you approved go on the wire.",
 	},
 ];
 
@@ -73,12 +71,30 @@ function SyncPage() {
 					{KICKER}
 				</p>
 				<h1 className="mt-2 text-4xl font-black tracking-tighter text-fg-primary md:text-6xl">
-					Sync your stack
+					Show what actually ran
 				</h1>
 				<p className="mt-4 max-w-xl text-fg-muted">
-					A rolling 30-day reading of what actually ran, published from your own
-					machine. One command, an approval gate, nothing else.
+					You listed the tools you use. This publishes the reading behind the
+					list — sessions, models, tokens, and cost at API prices — straight
+					from your own machine.
 				</p>
+
+				{/* The boundary band (#130): what the tool READS comes before what it
+				    sends. One boundary, stated once — it is why raw data never leaves
+				    the machine, and why chat apps cannot be measured. The page never
+				    names the chat apps: the boundary sentence carries the fact. */}
+				<div className="mt-10 border border-stroke-strong bg-bg-panel p-6">
+					<p className="font-mono text-xs font-semibold uppercase tracking-widest text-accent-lime">
+						what it reads
+					</p>
+					<p className="mt-3 max-w-lg text-sm text-fg-primary">
+						aistack reads files your agents already wrote on this machine. That
+						is all it reads.
+					</p>
+					<p className="mt-2 max-w-lg text-sm text-fg-muted">
+						Claude Code, Codex, opencode and pi-mono write those files.
+					</p>
+				</div>
 
 				<div className="mt-10 space-y-8">
 					{STEPS.map((s, i) => (


### PR DESCRIPTION
Builds wayfinder ticket alp82/aistack#131 (map #121), per the copy locked in #130 and `docs/prototypes/sync-path-2026-08.md`.

## /sync

- New hero: **Show what actually ran**. The old "Sync your stack" headline is retired (page title too).
- New **boundary band** under the hero: what the tool reads comes before what it sends. The four harness names live here and nowhere else. The page does not name the chat apps.
- Step 1 loses its inline harness naming. Step 2 gains the safety line: "and you keep the reading you just saw".
- The publishes/stays grid, `AutoSyncNote` and the machines link are untouched.

## CLI

- `searched  claude code, codex, opencode, pi-mono` at the top of beat one, derived from the adapter registry in search order. It reports what the CLI looked for, not what the person ran (#40).
- The per-harness header is **unconditional** — the one intended regression: output changes for every existing single-harness user. `summary.test.ts` binds the new shape with intent.
- The publish ending reads as the result, not a receipt: `Snapshot received 2026-08-10 21:03 UTC`, then the link under "Your stack now shows what actually ran:". Same ending on the MCP channel.
- Version bumped to **0.7.1** — the sequencing note in #131 resolves to a second release, since 0.7.0 already shipped the adapters. npm publish is a separate owner step (OTP).

## Also

- Explicit `opencode`/`pi-mono` rows added to the two remaining `harnessLabel` copies (leaderboard, activity feed). The two copies the spec named already had them (shipped early with #126).
- `HARNESS = "Claude Code"` in `copy.ts` untouched, as the ticket directs — stack-page copy, out of scope.

All 123 test files pass (1845 tests). The page verified server-rendering on the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TuPYyH6JxiDRSnJa6sCvK