### PR TITLE
Task: the admin-only site-wide view (alp82/aistack#132)

### DIFF
--- a/convex/viewAnalytics.test.ts
+++ b/convex/viewAnalytics.test.ts
@@ -14,6 +14,7 @@ import schema from './schema'
 import { api } from './_generated/api'
 import type { MutationCtx } from './_generated/server'
 import type { Id } from './_generated/dataModel'
+import { ADMIN_EMAILS } from './lib/admin'
 
 const modules = import.meta.glob('./**/*.{js,ts}')
 
@@ -359,4 +360,166 @@ test('an owner with nothing counted reports no first day at all', async () => {
   const asM = t.withIdentity({ tokenIdentifier: 'convex|owner-m' })
   const result = await asM.query(api.viewAnalytics.mine, {})
   expect(result?.firstCountedDayMs).toBeNull()
+})
+
+// ---------------------------------------------------------------------------
+// The site-wide reader (#132) — the guard
+//
+// The `global` counter belongs to nobody, so its reader is gated on
+// `isAdmin(ctx)` INSIDE the query. A client-side `/admin` route guard protects
+// nothing — any authed client can call a public function directly.
+// ---------------------------------------------------------------------------
+
+test('siteWide: a signed-out caller gets nothing', async () => {
+  const t = convexTest(schema, modules)
+  expect(await t.query(api.viewAnalytics.siteWide, {})).toBeNull()
+})
+
+test('siteWide: a signed-in non-admin gets nothing, even with a creator profile', async () => {
+  const t = convexTest(schema, modules)
+  await seedCreator(t, { userId: 'owner-n', slug: 'owner-n' })
+  const asOwner = t.withIdentity({ tokenIdentifier: 'convex|owner-n' })
+  expect(await asOwner.query(api.viewAnalytics.siteWide, {})).toBeNull()
+})
+
+test('siteWide: an admin gets an answer', async () => {
+  const t = convexTest(schema, modules)
+  const asAdmin = t.withIdentity({
+    tokenIdentifier: 'convex|admin',
+    email: ADMIN_EMAILS[0],
+  })
+  const result = await asAdmin.query(api.viewAnalytics.siteWide, {})
+  expect(result).not.toBeNull()
+})
+
+// ---------------------------------------------------------------------------
+// The site-wide reader — what it counts
+// ---------------------------------------------------------------------------
+
+function asAdminOn(t: ReturnType<typeof convexTest>) {
+  return t.withIdentity({
+    tokenIdentifier: 'convex|admin',
+    email: ADMIN_EMAILS[0],
+  })
+}
+
+test('siteWide: reads the global counter only, never a sum of per-target rows', async () => {
+  // The global counter dedupes one visitor once per day across the site. A sum
+  // over per-target rows would count one visitor once per page they opened, so
+  // the per-target rows must not leak into this number.
+  const t = convexTest(schema, modules)
+  const { stackId } = await seedCreator(t, { userId: 'owner-o', slug: 'owner-o' })
+  const day = today()
+  await seedCounter(t, {
+    targetKind: 'stack',
+    targetId: stackId,
+    dayStartMs: day,
+    referrerBucket: 'direct',
+    count: 40,
+  })
+  await seedCounter(t, {
+    targetKind: 'aggregate',
+    targetId: 'global',
+    dayStartMs: day,
+    referrerBucket: 'direct',
+    count: 7,
+  })
+
+  const result = await asAdminOn(t).query(api.viewAnalytics.siteWide, {})
+  expect(result?.total).toBe(7)
+  expect(result?.days).toEqual([{ at: day, value: 7 }])
+})
+
+test('siteWide: a day sums its buckets, and quiet days between counted ones read as zero', async () => {
+  const t = convexTest(schema, modules)
+  const day = today()
+  await seedCounter(t, {
+    targetKind: 'aggregate',
+    targetId: 'global',
+    dayStartMs: day - 2 * DAY_MS,
+    referrerBucket: 'social',
+    count: 4,
+  })
+  await seedCounter(t, {
+    targetKind: 'aggregate',
+    targetId: 'global',
+    dayStartMs: day,
+    referrerBucket: 'social',
+    count: 2,
+  })
+  await seedCounter(t, {
+    targetKind: 'aggregate',
+    targetId: 'global',
+    dayStartMs: day,
+    referrerBucket: 'direct',
+    count: 1,
+  })
+
+  const result = await asAdminOn(t).query(api.viewAnalytics.siteWide, {})
+  expect(result?.days).toEqual([
+    { at: day - 2 * DAY_MS, value: 4 },
+    { at: day - 1 * DAY_MS, value: 0 },
+    { at: day, value: 3 },
+  ])
+  expect(result?.firstCountedDayMs).toBe(day - 2 * DAY_MS)
+})
+
+test('siteWide: referrer buckets are split out, largest first, empty ones dropped', async () => {
+  const t = convexTest(schema, modules)
+  const day = today()
+  await seedCounter(t, {
+    targetKind: 'aggregate',
+    targetId: 'global',
+    dayStartMs: day,
+    referrerBucket: 'ai',
+    count: 5,
+  })
+  await seedCounter(t, {
+    targetKind: 'aggregate',
+    targetId: 'global',
+    dayStartMs: day - DAY_MS,
+    referrerBucket: 'search',
+    count: 2,
+  })
+
+  const result = await asAdminOn(t).query(api.viewAnalytics.siteWide, {})
+  expect(result?.referrers).toEqual([
+    { bucket: 'ai', count: 5 },
+    { bucket: 'search', count: 2 },
+  ])
+})
+
+test('siteWide: days older than the window are left out of every number', async () => {
+  const t = convexTest(schema, modules)
+  const day = today()
+  await seedCounter(t, {
+    targetKind: 'aggregate',
+    targetId: 'global',
+    dayStartMs: day - 40 * DAY_MS,
+    referrerBucket: 'direct',
+    count: 99,
+  })
+  await seedCounter(t, {
+    targetKind: 'aggregate',
+    targetId: 'global',
+    dayStartMs: day,
+    referrerBucket: 'direct',
+    count: 1,
+  })
+
+  const result = await asAdminOn(t).query(api.viewAnalytics.siteWide, {})
+  expect(result?.total).toBe(1)
+  expect(result?.windowDays).toBe(30)
+})
+
+test('siteWide: with nothing counted, the answer is an honest empty, not a fabricated zero-series', async () => {
+  // The counter starts existing the day this ships. An empty series and a null
+  // first day let the page say "counting starts now" instead of drawing a flat
+  // zero line over days nobody was counting.
+  const t = convexTest(schema, modules)
+  const result = await asAdminOn(t).query(api.viewAnalytics.siteWide, {})
+  expect(result?.total).toBe(0)
+  expect(result?.days).toEqual([])
+  expect(result?.firstCountedDayMs).toBeNull()
+  expect(result?.referrers).toEqual([])
 })

--- a/convex/viewAnalytics.ts
+++ b/convex/viewAnalytics.ts
@@ -16,7 +16,8 @@ import { query } from './_generated/server'
 import type { QueryCtx } from './_generated/server'
 import type { Doc } from './_generated/dataModel'
 import { ReferrerBucket } from './schema'
-import { utcDayStart } from './views'
+import { AGGREGATE_TARGET_ID, utcDayStart } from './views'
+import { isAdmin } from './lib/admin'
 
 type ReferrerBucketValue = Infer<typeof ReferrerBucket>
 
@@ -188,6 +189,86 @@ export const mine = query({
       firstCountedDayMs,
       total,
       targets,
+      referrers: [...referrers.entries()]
+        .map(([bucket, count]) => ({ bucket, count }))
+        .sort((a, b) => b.count - a.count || a.bucket.localeCompare(b.bucket)),
+    }
+  },
+})
+
+/**
+ * The site-wide reader (#132, map #121) — the first reader the `global`
+ * counter has ever had.
+ *
+ * ADMIN-ONLY, and gated HERE. A client-side `/admin` route guard protects
+ * nothing — any authed client can call a public function directly — so the
+ * query itself refuses a non-admin with `null`, exactly as `admin.ts` does.
+ * Kept admin-only on purpose: it leaves "do view counts ever become public"
+ * an open question rather than answering it by accident.
+ *
+ * It reads ONLY the `aggregate`/`global` rows, never a sum over the per-target
+ * counters. The global counter dedupes one visitor once per day across the
+ * whole site, so it is the honest arrivals number; summing per-target rows
+ * would count one visitor once per page they opened.
+ */
+export const siteWide = query({
+  args: {},
+  returns: v.union(
+    v.object({
+      windowDays: v.number(),
+      /** UTC midnight of the oldest day the window can hold. */
+      windowStartMs: v.number(),
+      /** UTC midnight of today, the last day of the series. */
+      endDayMs: v.number(),
+      /** The oldest day with a counted visit, or null when there are none. */
+      firstCountedDayMs: v.union(v.number(), v.null()),
+      total: v.number(),
+      /** Empty when nothing was ever counted. Otherwise one entry per day. */
+      days: v.array(DayPoint),
+      /** Non-empty buckets only, largest first. */
+      referrers: v.array(v.object({ bucket: ReferrerBucket, count: v.number() })),
+    }),
+    v.null()
+  ),
+  handler: async (ctx) => {
+    if (!(await isAdmin(ctx))) return null
+
+    const endDayMs = utcDayStart(Date.now())
+    const windowStartMs = endDayMs - (WINDOW_DAYS - 1) * DAY_MS
+
+    const rows = await ctx.db
+      .query('viewCounters')
+      .withIndex('by_target_day', (q) =>
+        q
+          .eq('targetKind', 'aggregate')
+          .eq('targetId', AGGREGATE_TARGET_ID)
+          .gte('dayStartMs', windowStartMs)
+      )
+      .collect()
+
+    const byDay = new Map<number, number>()
+    const referrers = new Map<ReferrerBucketValue, number>()
+    let total = 0
+    let firstCountedDayMs: number | null = null
+    for (const row of rows) {
+      byDay.set(row.dayStartMs, (byDay.get(row.dayStartMs) ?? 0) + row.count)
+      referrers.set(
+        row.referrerBucket,
+        (referrers.get(row.referrerBucket) ?? 0) + row.count
+      )
+      total += row.count
+      if (firstCountedDayMs === null || row.dayStartMs < firstCountedDayMs) {
+        firstCountedDayMs = row.dayStartMs
+      }
+    }
+
+    return {
+      windowDays: WINDOW_DAYS,
+      windowStartMs,
+      endDayMs,
+      firstCountedDayMs,
+      total,
+      days: fillDays(byDay, endDayMs),
       referrers: [...referrers.entries()]
         .map(([bucket, count]) => ({ bucket, count }))
         .sort((a, b) => b.count - a.count || a.bucket.localeCompare(b.bucket)),

--- a/convex/views.test.ts
+++ b/convex/views.test.ts
@@ -5,6 +5,7 @@ import schema from './schema'
 import { api, internal } from './_generated/api'
 import type { MutationCtx } from './_generated/server'
 import type { Id } from './_generated/dataModel'
+import { ADMIN_EMAILS } from './lib/admin'
 
 const modules = import.meta.glob('./**/*.{js,ts}')
 
@@ -222,6 +223,43 @@ test('a signed-in user counts on the aggregate page — it has no owner', async 
     ...baseArgs,
     targetKind: 'aggregate',
     targetId: 'global',
+  })
+
+  expect(result.counted).toBe(true)
+})
+
+test('a signed-in admin does not count on the aggregate page — they own the site', async () => {
+  // The per-target rule already excludes an owner from their own counter. The
+  // aggregate counter's owner is the site's admin, and the number exists so the
+  // admin can read a send — their own browsing must not be in it.
+  const t = convexTest(schema, modules)
+  const asAdmin = t.withIdentity({
+    tokenIdentifier: 'convex|admin',
+    email: ADMIN_EMAILS[0],
+  })
+
+  const result = await asAdmin.mutation(api.views.record, {
+    ...baseArgs,
+    targetKind: 'aggregate',
+    targetId: 'global',
+  })
+
+  expect(result.counted).toBe(false)
+})
+
+test("an admin still counts on another owner's stack, like any visitor", async () => {
+  // Admin-exclusion is scoped to the aggregate target. On a per-target counter
+  // the admin is an ordinary visitor, and dropping them would undercount.
+  const t = convexTest(schema, modules)
+  const { stackId } = await seedStack(t, { userId: 'u-any', slug: 'creator-any' })
+  const asAdmin = t.withIdentity({
+    tokenIdentifier: 'convex|admin',
+    email: ADMIN_EMAILS[0],
+  })
+
+  const result = await asAdmin.mutation(api.views.record, {
+    ...baseArgs,
+    targetId: stackId,
   })
 
   expect(result.counted).toBe(true)

--- a/convex/views.ts
+++ b/convex/views.ts
@@ -10,6 +10,7 @@ import { internalMutation, mutation } from './_generated/server'
 import type { MutationCtx } from './_generated/server'
 import { ReferrerBucket, ViewTargetKind } from './schema'
 import { consume } from './rateLimit'
+import { isAdmin } from './lib/admin'
 import type { Infer } from 'convex/values'
 
 type ViewTargetKindValue = Infer<typeof ViewTargetKind>
@@ -106,6 +107,14 @@ export const record = mutation({
     const identity = await ctx.auth.getUserIdentity()
     const viewerId = identity?.tokenIdentifier.split('|')[1] ?? null
     if (viewerId !== null && viewerId === target.userId) {
+      return { counted: false }
+    }
+
+    // The aggregate counter's owner is the site's admin (#132). It exists so
+    // the admin can read a campaign, and their own browsing must not be in it.
+    // Per-target counters are untouched — there the admin is an ordinary
+    // visitor.
+    if (args.targetKind === 'aggregate' && (await isAdmin(ctx))) {
       return { counted: false }
     }
 

--- a/src/components/admin/AdminViewsTab.tsx
+++ b/src/components/admin/AdminViewsTab.tsx
@@ -1,0 +1,150 @@
+import { useQuery } from "convex/react";
+import {
+	BarsChart,
+	type ChartBar,
+	type ChartSeries,
+	formatExact,
+	TimeSeriesChart,
+} from "@/features/charts";
+import { REFERRER_LABELS, rangeLabel } from "@/features/settings/AnalyticsPage";
+import { api } from "../../../convex/_generated/api";
+
+/**
+ * Views — the admin-only site-wide read surface (#132, map #121).
+ *
+ * The FIRST reader the `global` counter has ever had, built so a broadcast can
+ * be read at all: site-wide arrivals by day, split by where the visit came
+ * from. The real guard is `isAdmin(ctx)` inside `viewAnalytics.siteWide` — the
+ * `/admin` route gate above this component is a convenience, never the
+ * protection.
+ *
+ * Two honesty rules carry over from the owner-private page. The number is
+ * deduped daily visitors, never people and never page loads. And a day nobody
+ * was counting is a gap, not a zero — the series starts at the first counted
+ * day.
+ *
+ * One rule is new: DO NOT QUOTE THIS FIGURE PUBLICLY. `views.record` accepts a
+ * caller-supplied visitor hash, which is fine while the number is private and
+ * ranks nothing. Publishing it changes that bargain.
+ */
+export function AdminViewsTab() {
+	const data = useQuery(api.viewAnalytics.siteWide, {});
+
+	if (data === undefined) {
+		return (
+			<Shell>
+				<p className="mt-8 font-mono text-sm text-fg-muted">Loading...</p>
+			</Shell>
+		);
+	}
+
+	// The query answers null for a non-admin. The route already redirected, so
+	// this renders only in the gap while auth settles.
+	if (data === null) {
+		return (
+			<Shell>
+				<p className="mt-8 font-mono text-sm text-fg-muted">Not available.</p>
+			</Shell>
+		);
+	}
+
+	const range = rangeLabel(
+		data.firstCountedDayMs,
+		data.windowStartMs,
+		data.windowDays,
+	);
+	const series: ChartSeries[] =
+		data.days.length > 0
+			? [{ key: "site", label: "Site-wide", points: data.days }]
+			: [];
+	const bars: ChartBar[] = data.referrers.map((r) => ({
+		key: r.bucket,
+		label: REFERRER_LABELS[r.bucket],
+		value: r.count,
+	}));
+
+	return (
+		<Shell>
+			{data.total > 0 && (
+				<div className="mt-8 border-2 border-stroke-strong bg-bg-panel p-6">
+					<p className="font-mono text-4xl font-black text-accent-lime">
+						{formatExact(data.total)}
+					</p>
+					<p className="mt-1 font-mono text-xs uppercase tracking-[0.2em] text-fg-muted">
+						deduped daily visitors · site-wide · {range}
+					</p>
+				</div>
+			)}
+
+			{data.total === 0 ? (
+				<div className="mt-8 border-2 border-stroke-strong bg-bg-panel p-6">
+					<p className="font-mono text-sm text-fg-primary">
+						No visits counted yet.
+					</p>
+					<p className="mt-2 text-sm text-fg-secondary">
+						The site-wide counter starts on the day this surface shipped. Days
+						before that were never counted, so they are not shown as zeros.
+					</p>
+				</div>
+			) : (
+				<>
+					{series.length > 0 && (
+						<section className="mt-8">
+							<h2 className="font-mono text-xs font-bold uppercase tracking-[0.2em] text-fg-muted">
+								Visitors per day
+							</h2>
+							<TimeSeriesChart
+								className="mt-3"
+								series={series}
+								ariaLabel="Site-wide deduped daily visitors per day"
+								ariaDescription={`One line for the whole site, ${range}.`}
+								valueLabel="Visitors"
+								caption={`deduped daily visitors · ${range}`}
+							/>
+						</section>
+					)}
+
+					{bars.length > 0 && (
+						<section className="mt-8">
+							<h2 className="font-mono text-xs font-bold uppercase tracking-[0.2em] text-fg-muted">
+								Where they came from
+							</h2>
+							<p className="mt-2 max-w-prose text-sm leading-relaxed text-fg-secondary">
+								Decided once per visit, from the page the visitor came off. This
+								is the campaign read: a broadcast shows up here as a jump in one
+								bucket on the days after the send.
+							</p>
+							<BarsChart
+								className="mt-3"
+								bars={bars}
+								ariaLabel="Site-wide deduped daily visitors by where the visit came from"
+								valueLabel="Visitors"
+							/>
+						</section>
+					)}
+				</>
+			)}
+		</Shell>
+	);
+}
+
+/** The heading and the labeling that every state of this tab shows. */
+function Shell({ children }: { readonly children: React.ReactNode }) {
+	return (
+		<div className="mx-auto max-w-3xl px-6 py-12">
+			<h1 className="font-mono text-xs font-bold uppercase tracking-[0.2em] text-fg-muted">
+				Site-wide views
+			</h1>
+			<p className="mt-3 max-w-prose text-sm leading-relaxed text-fg-secondary">
+				One visitor counts once per UTC day across the whole site. A visitor is
+				a browser on a network, not a person. Your own visits while signed in as
+				admin are left out. These are not page loads.
+			</p>
+			<p className="mt-3 max-w-prose text-sm leading-relaxed text-fg-muted">
+				Admin-only, and the figure is inflatable by anyone who wants to — do not
+				quote it anywhere public.
+			</p>
+			{children}
+		</div>
+	);
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -18,6 +18,7 @@ import Header from "../components/Header";
 import PosthogProvider from "../integrations/posthog/provider";
 import TanStackQueryDevtools from "../integrations/tanstack-query/devtools";
 import { getToken } from "../lib/auth-server";
+import { useRecordView } from "../lib/useRecordView";
 import {
 	AUTH_TOKEN_TIMEOUT_MS,
 	useConvexAuthFromBetterAuth,
@@ -119,6 +120,12 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
 function RootComponent() {
 	const context = useRouteContext({ from: Route.id });
 	const useAuth = useConvexAuthFromBetterAuth(context.token);
+	// The site-wide counter (#132). One visitor counts once per UTC day across
+	// the whole site, under the sentinel target `global` — the number the
+	// admin-only Views tab reads. Fired from the root so EVERY page counts;
+	// until this call existed the sentinel had a writer capability and no
+	// caller, and the counter stayed empty.
+	useRecordView("aggregate", "global");
 	return (
 		<ConvexProviderWithAuth
 			client={context.convexQueryClient.convexClient}

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -6,7 +6,7 @@ import {
 	useSearch,
 } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
-import { ClipboardCheck, Flag, Mail } from "lucide-react";
+import { ChartNoAxesColumn, ClipboardCheck, Flag, Mail } from "lucide-react";
 import { useMemo } from "react";
 import {
 	AdminEmailTab,
@@ -14,11 +14,12 @@ import {
 } from "@/components/admin/AdminEmailTab";
 import { AdminQualityTab } from "@/components/admin/AdminQualityTab";
 import { AdminReviewTab } from "@/components/admin/AdminReviewTab";
+import { AdminViewsTab } from "@/components/admin/AdminViewsTab";
 import { coerceEnum } from "@/lib/searchParams";
 import { seoMeta } from "@/lib/seo";
 import { api } from "../../convex/_generated/api";
 
-type AdminTab = "review" | "quality" | "email";
+type AdminTab = "review" | "quality" | "email" | "views";
 
 export const ADMIN_SEARCH_DEFAULTS = {
 	tab: "review" as AdminTab,
@@ -33,7 +34,7 @@ export const Route = createFileRoute("/admin")({
 	): { tab?: AdminTab; view?: EmailSubTab } => ({
 		tab: coerceEnum(
 			search.tab,
-			["review", "quality", "email"] as const,
+			["review", "quality", "email", "views"] as const,
 			"review",
 		),
 		view: coerceEnum(
@@ -154,6 +155,18 @@ function AdminPage() {
 							<Mail className="size-4" />
 							Email
 						</button>
+						<button
+							type="button"
+							onClick={() => setSearch({ tab: "views" })}
+							className={`inline-flex items-center gap-2 border-b-2 px-6 py-4 font-mono text-sm font-semibold uppercase tracking-wide transition-colors -mb-[2px] ${
+								tab === "views"
+									? "border-accent-lime text-accent-lime"
+									: "border-transparent text-fg-muted hover:text-fg-primary"
+							}`}
+						>
+							<ChartNoAxesColumn className="size-4" />
+							Views
+						</button>
 						<LivingStacks />
 					</div>
 				</div>
@@ -168,6 +181,7 @@ function AdminPage() {
 					onViewChange={(v) => setSearch({ view: v })}
 				/>
 			)}
+			{tab === "views" && <AdminViewsTab />}
 		</div>
 	);
 }


### PR DESCRIPTION
Resolves alp82/aistack#132 (map alp82/aistack#121).

## What this ships

- **The global counter's first writer.** The ticket assumed the sentinel was "written on every page view". It was not: `views.record` *accepts* `aggregate`/`global`, but no page ever sent it — prod holds **zero** aggregate rows. `__root.tsx` now fires `useRecordView("aggregate", "global")`, so every page counts, including the pages a campaign lands on (`/`, `/sync`, `/leaderboard`) that had no counter at all.
- **The reader: `viewAnalytics.siteWide`.** Admin-gated **inside the query** with `isAdmin(ctx)` — the `/admin` route gate is a convenience, never the protection. Reads only the `aggregate` rows: the global counter dedupes one visitor once per day site-wide, so summing per-target rows would double-count a visitor per page opened.
- **Admin exclusion on the write side.** The aggregate counter's owner is the admin, so their signed-in browsing does not count on it — mirroring the per-target owner rule. On another owner's stack the admin still counts like any visitor.
- **The `/admin` Views tab.** Same honesty rules as the owner page (deduped daily visitors, series starts at the first counted day) plus a do-not-quote-publicly warning: `visitorHash` is caller-supplied, accepted only while the number is private.

## Review without a preview

The surface cannot be previewed (needs a signed-in admin; a worktree container cannot sign in). The guard is therefore proven server-side in `convex/viewAnalytics.test.ts`: signed-out → null, signed-in non-admin (with a creator profile) → null, admin → data. The write-side exclusion and its scope are proven in `convex/views.test.ts`. Full suite: 123 files, 1855 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TuPYyH6JxiDRSnJa6sCvK