### PR TITLE
Keep feature-update visible in the admin broadcasts UI

### DIFF
--- a/convex/email.ts
+++ b/convex/email.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { Resend } from "resend";
 import { render } from "@react-email/render";
 import { WaitlistLaunchEmail } from "../src/emails/WaitlistLaunchEmail";
+import { FeatureUpdateEmail } from "../src/emails/FeatureUpdateEmail";
 import { SyncBroadcastEmail } from "../src/emails/SyncBroadcastEmail";
 import { UNSUBSCRIBE_PLACEHOLDER } from "../src/emails/styles";
 import { signUnsubscribeToken } from "./emailToken";
@@ -80,8 +81,13 @@ const BROADCASTS: Record<
     // When marking a broadcast sent, also add its id to SENT_BROADCASTS in EmailBroadcastsSection.tsx (UI gate).
     alreadySent: true,
   },
-  // "feature-update" was retired unsent (map #121): its items (projects,
-  // accent colors) are deferred to a later email. The template file stays.
+  // Registered and never sent. Its items (projects, accent colors) wait for
+  // their own send; the owner keeps it visible in the admin UI meanwhile.
+  "feature-update": {
+    subject: "New on AI Stack: Promote, Share & Customize Your Stack",
+    render: () => render(FeatureUpdateEmail({})),
+    audience: "waitlist+members",
+  },
   "sync-broadcast": {
     subject: "Show your real usage on your stack",
     render: () => render(SyncBroadcastEmail({})),

--- a/src/components/admin/EmailBroadcastsSection.tsx
+++ b/src/components/admin/EmailBroadcastsSection.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { api } from "../../../convex/_generated/api";
+import { FeatureUpdateEmail } from "../../emails/FeatureUpdateEmail";
 import { SyncBroadcastEmail } from "../../emails/SyncBroadcastEmail";
 import { WaitlistLaunchEmail } from "../../emails/WaitlistLaunchEmail";
 import { Dialog } from "../ui/Dialog";
@@ -39,8 +40,14 @@ const BROADCAST_EMAILS: BroadcastEmail[] = [
 		audience: "Waitlist",
 		component: <WaitlistLaunchEmail />,
 	},
-	// "feature-update" retired unsent (map #121); its items are deferred to a
-	// later email. The template file stays in src/emails.
+	{
+		id: "feature-update",
+		name: "New: Promote, Share & Customize",
+		description:
+			"Announce three new member features (projects, shareable stack image, accent colors) to waitlist subscribers and registered members",
+		audience: "Waitlist + Members",
+		component: <FeatureUpdateEmail />,
+	},
 	{
 		id: "sync-broadcast",
 		name: "Show Your Real Usage",


### PR DESCRIPTION
Part of alp82/aistack#134. Owner call on 2026-08-16: previous broadcasts stay in the admin UI. This restores the feature-update registry entry (convex/email.ts) and its admin card that #145 removed. It stays registered and never sent. Tests are untouched and green (61/61); they use sync-broadcast as the fixture id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TuPYyH6JxiDRSnJa6sCvK