### PR TITLE
Counter races from the previous reading on live updates

### DIFF
--- a/src/features/activity/PulseHero.tsx
+++ b/src/features/activity/PulseHero.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import SpeedingText from "@/components/speeding-text";
 import {
 	BrutalistSelect,
@@ -244,6 +244,16 @@ export function PulseHero({ band }: { readonly band: Band }) {
 	const { totals, usage, points, rows } = band;
 	const quiet = usage.stacks === 0;
 	const latest = rows[0];
+
+	// The band is a live Convex subscription, so a landing sync changes
+	// `usage.tokens` under an open tab. The counter then races FROM the reading
+	// the viewer is already looking at, not from zero — a replay of the whole
+	// count-up would claim the day started over. First paint still runs 0 → value.
+	const lastTokens = useRef(0);
+	const countFrom = lastTokens.current;
+	useEffect(() => {
+		lastTokens.current = usage.tokens;
+	}, [usage.tokens]);
 	const reel = [
 		`${fmtCount(usage.sessions)} sessions`,
 		`${fmtCount(usage.projects)} projects`,
@@ -289,6 +299,7 @@ export function PulseHero({ band }: { readonly band: Band }) {
 							<div className="hidden md:block">
 								<SpeedingText
 									value={usage.tokens}
+									from={countFrom}
 									suffix=" tokens"
 									duration={2600}
 									italic={false}
@@ -301,6 +312,7 @@ export function PulseHero({ band }: { readonly band: Band }) {
 							<div className="md:hidden">
 								<SpeedingText
 									value={usage.tokens}
+									from={countFrom}
 									suffix=" tokens"
 									duration={2600}
 									italic={false}

--- a/src/features/activity/__tests__/pulse-hero.test.tsx
+++ b/src/features/activity/__tests__/pulse-hero.test.tsx
@@ -24,6 +24,29 @@ describe("the hero", () => {
 		expect(reading?.textContent).toContain("41 projects");
 	});
 
+	it("keeps the canonical reading current when the live band moves", () => {
+		// The band is a live subscription; a landing sync re-renders the hero
+		// with a new level and the sr-only record follows it.
+		const { container, rerender } = render(<PulseHero band={band()} />);
+		rerender(
+			<PulseHero
+				band={band({
+					usage: {
+						sessions: 601,
+						projects: 41,
+						models: 8,
+						tools: 22,
+						tokens: 900_000_000,
+						stacks: 2,
+					},
+				})}
+			/>,
+		);
+		expect(container.querySelector(".sr-only")?.textContent).toContain(
+			"900M tokens measured",
+		);
+	});
+
 	it("names its window in the kicker", () => {
 		render(<PulseHero band={band()} />);
 		expect(screen.getByText("Usage in the last 24 hours")).toBeInTheDocument();


### PR DESCRIPTION
Follow-up to #148 (issue #147).

The band is a live Convex subscription, so a landing sync changes `usage.tokens` under an open tab — and SpeedingText re-runs its counter effect on a `value` change. Before this, that replayed the whole count-up from zero. Now `PulseHero` tracks the previous reading in a ref and passes it as `from`, so a live update rolls 106.2B → 106.5B with the same smear. First paint still races 0 → value.

Added a test pinning that a re-render with a new level updates the canonical sr-only reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2nkKJVsMPdD8Mm5xCoGEn