### PR TITLE
Fix the landing counter double-running on reload

### DIFF
--- a/src/integrations/posthog/provider.tsx
+++ b/src/integrations/posthog/provider.tsx
@@ -1,3 +1,4 @@
+import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { type FC, type ReactNode, useEffect, useState } from "react";
 import { IdentifyUser } from "./IdentifyUser";
@@ -6,13 +7,32 @@ interface PosthogProviderProps {
 	children: ReactNode;
 }
 
-// Defer PostHog mount until the browser is idle so the analytics SDK + flag
-// fetch don't compete with first-paint resources. Falls back to a 2s timeout
-// in browsers without `requestIdleCallback` (Safari < 18).
+// Defer PostHog INITIALIZATION until the browser is idle so the analytics SDK
+// + flag fetch don't compete with first-paint resources. Falls back to a 2s
+// timeout in browsers without `requestIdleCallback` (Safari < 18).
+//
+// Only the init is deferred — the React tree is IDENTICAL before and after.
+// This used to render `<>{children}</>` until idle and then swap in the
+// provider element, which reparented every route under a new element type and
+// made React unmount and remount the whole page ~450ms after load (visible as
+// the landing counter racing twice, and it silently wiped every route's local
+// state on every reload). The provider now always wraps `children` around the
+// module singleton, which is safe to hand out un-initialized: pre-init
+// captures are dropped, a contract `src/lib/analytics.ts` already documents.
 const PosthogProvider: FC<PosthogProviderProps> = ({ children }) => {
-	const [mounted, setMounted] = useState(false);
+	const [ready, setReady] = useState(false);
 
 	useEffect(() => {
+		const start = () => {
+			posthog.init(import.meta.env.VITE_PUBLIC_POSTHOG_KEY, {
+				api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+				ui_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST_UI,
+				defaults: "2025-05-24",
+				capture_exceptions: true, // Enables capturing exceptions via Error Tracking
+				debug: import.meta.env.MODE === "development",
+			});
+			setReady(true);
+		};
 		const w = window as Window & {
 			requestIdleCallback?: (
 				cb: () => void,
@@ -20,9 +40,7 @@ const PosthogProvider: FC<PosthogProviderProps> = ({ children }) => {
 			) => number;
 		};
 		if (typeof w.requestIdleCallback === "function") {
-			const handle = w.requestIdleCallback(() => setMounted(true), {
-				timeout: 2000,
-			});
+			const handle = w.requestIdleCallback(start, { timeout: 2000 });
 			return () => {
 				const cancel = (
 					window as Window & { cancelIdleCallback?: (h: number) => void }
@@ -30,26 +48,15 @@ const PosthogProvider: FC<PosthogProviderProps> = ({ children }) => {
 				if (typeof cancel === "function") cancel(handle);
 			};
 		}
-		const timer = setTimeout(() => setMounted(true), 2000);
+		const timer = setTimeout(start, 2000);
 		return () => clearTimeout(timer);
 	}, []);
 
-	if (!mounted) {
-		return <>{children}</>;
-	}
-
 	return (
-		<PHProvider
-			apiKey={import.meta.env.VITE_PUBLIC_POSTHOG_KEY}
-			options={{
-				api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
-				ui_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST_UI,
-				defaults: "2025-05-24",
-				capture_exceptions: true, // Enables capturing exceptions via Error Tracking
-				debug: import.meta.env.MODE === "development",
-			}}
-		>
-			<IdentifyUser />
+		<PHProvider client={posthog}>
+			{/* Held until init so identify() cannot fire into a dead SDK. The
+			    conditional keeps its slot (null), so `children` never move. */}
+			{ready ? <IdentifyUser /> : null}
 			{children}
 		</PHProvider>
 	);

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -35,7 +35,7 @@ export const Route = createFileRoute("/")({
 	// what a first-time visitor reads above the fold, and it should not wait for
 	// a hydrated client.
 	loader: async ({ context }) => {
-		const [, band] = await Promise.all([
+		const [stacks, band] = await Promise.all([
 			context.queryClient.ensureQueryData(
 				convexQuery(api.stacks.listPublished, {}),
 			),
@@ -43,7 +43,7 @@ export const Route = createFileRoute("/")({
 				convexQuery(api.activityFeed.band, {}),
 			),
 		]);
-		return { band };
+		return { stacks, band };
 	},
 	head: () => ({
 		meta: seoMeta({
@@ -58,10 +58,15 @@ export const Route = createFileRoute("/")({
 });
 
 function IndexRoute() {
+	// Both reads fall back to the loader snapshot, so the server and the
+	// hydrating client render the SAME page. Reading the live query alone left
+	// the SSR HTML without the featured stacks — a hydration mismatch that made
+	// React regenerate the tree and remount the route (double-running the
+	// hero's counter).
+	const { stacks: loadedStacks, band: loadedBand } = Route.useLoaderData();
 	const stacks = (useQuery(api.stacks.listPublished) ??
-		[]) as LandingStackPreview[];
+		loadedStacks) as LandingStackPreview[];
 	const me = useQuery(api.creators.getMe);
-	const { band: loadedBand } = Route.useLoaderData();
 	const band = useQuery(api.activityFeed.band, {}) ?? loadedBand;
 
 	return (


### PR DESCRIPTION
Fixes the reload double-count the owner reported on #147's hero — and the cause turned out to be two site-wide defects that predate the hero entirely.

**1. The whole page remounted ~450ms after every load.** `PosthogProvider` deferred the SDK until browser idle by rendering `<>{children}</>` first and swapping to `<PHProvider>{children}</PHProvider>` when idle fired. Reparenting children under a new element type makes React unmount and remount the entire subtree — every route, every reload, wiping all local state (the counter restarting from 0 was just the first visible symptom). The provider now always renders `<PHProvider client={posthog}>` around the module singleton and defers only `posthog.init()`. Pre-init captures are dropped — the exact contract `src/lib/analytics.ts` already documents. `IdentifyUser` holds a null slot until init so `identify()` cannot fire into a dead SDK.

**2. The landing HTML failed hydration.** `IndexRoute` read `stacks` from the live Convex query alone, which is `undefined` during SSR — the server rendered the page without `FeaturedStacksSection` while the hydrating client had it, so React threw and regenerated the tree client-side. Stacks now fall back to the loader snapshot exactly the way `band` already did.

Verified with headless Chromium against the dev server (mount/unmount instrumentation, since removed): before — hydration error + two full route remounts; after — one mount per level, no hydration error, PostHog still starts on idle.

Full suite green (124 files, 1866 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2nkKJVsMPdD8Mm5xCoGEn