### PR TITLE
Add a closing CTA to the sync broadcast

### DIFF
--- a/src/emails/SyncBroadcastEmail.tsx
+++ b/src/emails/SyncBroadcastEmail.tsx
@@ -222,6 +222,13 @@ export function SyncBroadcastEmail(props: {
 							</Section>
 						))}
 
+						{/* Closing CTA */}
+						<Section style={styles.ctaWrap}>
+							<Link href={`${ctaUrl}/sync`} style={styles.ctaAnimated}>
+								Sync your usage ⟶
+							</Link>
+						</Section>
+
 						{/* Privacy boundary */}
 						<Text
 							style={{


### PR DESCRIPTION
Part of alp82/aistack#134. Adds a second "Sync your usage" button at the bottom of the email, after the feature rows and before the privacy note, mirroring the waitlist-launch email's double-CTA pattern. Tests 61/61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TuPYyH6JxiDRSnJa6sCvK