### PR TITLE
Rename pi-mono to Pi in every display surface

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@use-aistack/cli",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Measure and share your AI stack from your terminal",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/src/harness/index.ts
+++ b/packages/cli/src/harness/index.ts
@@ -144,10 +144,12 @@ export const HARNESS_ADAPTERS: readonly HarnessAdapter[] = [
 export function harnessLabel(name: string): string {
 	if (name === CLAUDE_HARNESS_NAME) return "Claude Code";
 	if (name === CODEX_HARNESS_NAME) return "Codex";
-	// These brands spell themselves lowercase, so the discriminator IS the
-	// label - but each is an explicit row, so a rename cannot leak a raw slug.
+	// opencode spells itself lowercase, so its discriminator IS the label -
+	// but it is an explicit row, so a rename cannot leak a raw slug.
 	if (name === OPENCODE_HARNESS_NAME) return "opencode";
-	if (name === PI_HARNESS_NAME) return "pi-mono";
+	// The vendor renamed pi-mono to Pi (2026-08). The discriminator stays
+	// "pi-mono" - it is the wire id - only the display label changed.
+	if (name === PI_HARNESS_NAME) return "Pi";
 	return name;
 }
 

--- a/packages/cli/src/sync/summary.test.ts
+++ b/packages/cli/src/sync/summary.test.ts
@@ -219,7 +219,7 @@ describe("beat one - the summary", () => {
 		const lines = summary.split("\n");
 		const toIdx = lines.findIndex((l) => l.startsWith("to        "));
 		expect(lines[toIdx + 1]).toBe(
-			"searched  claude code, codex, opencode, pi-mono",
+			"searched  claude code, codex, opencode, pi",
 		);
 	});
 

--- a/src/components/admin/EmailBroadcastsSection.tsx
+++ b/src/components/admin/EmailBroadcastsSection.tsx
@@ -52,7 +52,7 @@ const BROADCAST_EMAILS: BroadcastEmail[] = [
 		id: "sync-broadcast",
 		name: "Show Your Real Usage",
 		description:
-			"Call to sync: the CLI reads Claude Code, Codex, opencode and pi-mono and adds real usage to the stack page",
+			"Call to sync: the CLI reads Claude Code, Codex, opencode and Pi and adds real usage to the stack page",
 		audience: "Waitlist + Members",
 		component: <SyncBroadcastEmail />,
 	},

--- a/src/emails/SyncBroadcastEmail.tsx
+++ b/src/emails/SyncBroadcastEmail.tsx
@@ -99,7 +99,7 @@ const HARNESS_LOGOS: { name: string; url: string }[] = [
 	{ name: "Claude Code", url: `${BASE_URL}/email/claude-logo.png` },
 	{ name: "Codex", url: `${BASE_URL}/email/codex-logo.png` },
 	{ name: "opencode", url: `${BASE_URL}/email/opencode-logo.png` },
-	{ name: "pi-mono", url: `${BASE_URL}/email/pi-mono-logo.png` },
+	{ name: "Pi", url: `${BASE_URL}/email/pi-mono-logo.png` },
 ];
 
 export function SyncBroadcastEmail(props: {
@@ -120,7 +120,7 @@ export function SyncBroadcastEmail(props: {
 			</Head>
 			<Preview>
 				The aistack CLI reads your local usage from Claude Code, Codex, opencode
-				and pi-mono and adds it to your stack page.
+				and Pi and adds it to your stack page.
 			</Preview>
 			<Body style={styles.body}>
 				<Container style={styles.container}>
@@ -159,8 +159,8 @@ export function SyncBroadcastEmail(props: {
 						<Text style={styles.p}>
 							On top of the tools you use, now you can also show how much you
 							use them. The aistack CLI reads your local usage data from Claude
-							Code, Codex, opencode and pi-mono. It adds session and token count
-							to your profile page.
+							Code, Codex, opencode and Pi. It adds session and token count to
+							your profile page.
 						</Text>
 
 						{/* Terminal mock with the owner's real reading */}
@@ -176,7 +176,7 @@ export function SyncBroadcastEmail(props: {
 							<Text style={termDim}>from your machine · sync preview</Text>
 							<Text style={termLine}>&nbsp;</Text>
 							<Text style={termLine}>
-								searched claude code, codex, opencode, pi-mono
+								searched claude code, codex, opencode, pi
 							</Text>
 							<Text style={termLine}>* sessions 572 · 30 days</Text>
 							<Text style={termLine}>* tokens 4.26B</Text>
@@ -228,7 +228,7 @@ export function SyncBroadcastEmail(props: {
 								Supported harnesses
 							</Text>
 							<Text style={unlockText}>
-								The CLI reads Claude Code, Codex, opencode and pi-mono.
+								The CLI reads Claude Code, Codex, opencode and Pi.
 							</Text>
 							<Row style={{ marginTop: 16 }}>
 								{HARNESS_LOGOS.map((harness) => (

--- a/src/features/activity/feed.ts
+++ b/src/features/activity/feed.ts
@@ -84,7 +84,7 @@ const HARNESS_LABELS: Record<string, string> = {
 	// Lowercase brands: the wire name is the label, but each is an explicit
 	// row so a rename cannot silently leak a raw slug (#130).
 	opencode: "opencode",
-	"pi-mono": "pi-mono",
+	"pi-mono": "Pi",
 };
 
 /** Wire names in words. An unknown harness keeps its wire spelling. */

--- a/src/features/leaderboard/board.ts
+++ b/src/features/leaderboard/board.ts
@@ -49,7 +49,7 @@ const HARNESS_LABELS: Record<string, string> = {
 	// Lowercase brands: the wire name is the label, but each is an explicit
 	// row so a rename cannot silently leak a raw slug (#130).
 	opencode: "opencode",
-	"pi-mono": "pi-mono",
+	"pi-mono": "Pi",
 };
 
 export function harnessLabel(name: string): string {

--- a/src/routes/sync.tsx
+++ b/src/routes/sync.tsx
@@ -81,8 +81,8 @@ function SyncPage() {
 					<Fold label="what it reads">
 						<p>
 							aistack reads files your agents already wrote on this machine.
-							That is all it reads. Claude Code, Codex, opencode and pi-mono
-							write those files.
+							That is all it reads. Claude Code, Codex, opencode and Pi write
+							those files.
 						</p>
 						<p className="mt-2">
 							On the first run it opens your browser to link this machine. You


### PR DESCRIPTION
Part of alp82/aistack#134. The vendor renamed pi-mono to Pi. Display labels change everywhere; the wire id, tool slug and pricing keys stay "pi-mono".

- CLI `harnessLabel`: "Pi" (the lowercased `searched` line prints "pi"); version bumped to 0.7.2, needs an npm publish to reach users.
- Web label maps: leaderboard and activity feed.
- `/sync` boundary sentence, the broadcast email (intro, preview, terminal mock, logo caption, harness row), and the admin card description.
- Prod tool catalog: renamed via `admin:updateTool` with the admin identity (name "Pi", slug `pi-mono` kept for URL stability).

Tests: summary.test.ts searched-line assertion updated with intent; 86/86 across CLI summary + email suites, 511-test package sweep green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TuPYyH6JxiDRSnJa6sCvK