### PR TITLE
Reconcile the template lead code with the locked wording (#267)

### DIFF
--- a/packages/workflow-rules/src/templateLead.test.ts
+++ b/packages/workflow-rules/src/templateLead.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, it } from "vitest";
 import {
+	LEAD_EVEN_SPLIT_POINTS,
+	LEAD_MIN_SESSIONS,
 	type PhaseLeadFacts,
+	renderLeadLines,
 	renderLeadMarkdown,
-	renderLeadSentences,
 } from "./templateLead.js";
 
-// The exact aggregate #196 ran phase-rules/v1 over: 464 real sessions across
-// 3 harnesses. https://github.com/alp82/aistack/issues/196
-const PROOF_FACTS: PhaseLeadFacts = {
-	sessionCount: 464,
+// The example printed in "The template lead" in docs/specs/workflow-surface.md,
+// locked by #220. The phase shares are the ones #196 measured over real history.
+const SPEC_FACTS: PhaseLeadFacts = {
+	sessionCount: 142,
 	harnessCount: 3,
+	harnessesPassingGate: 2,
+	windowDays: 30,
 	phaseShare: {
 		scout: 0.64,
 		build: 0.18,
@@ -18,84 +22,209 @@ const PROOF_FACTS: PhaseLeadFacts = {
 		unknown: 0.07,
 	},
 	verifySessionShare: 0.4,
-	handoffCount: 437,
-	handoffMedianWaitMinutes: 24,
-	modalStartHourLocal: 23,
+	handoffSessionShare: 0.62,
+	modalStartHourOwnerLocal: 23,
 	ruleVersion: "phase-rules/v1",
 };
 
-describe("renderLeadSentences: the #196 proof reproduces byte for byte", () => {
-	it("renders all five forms in order, matching the proof's markdown exactly", () => {
-		const sentences = renderLeadSentences(PROOF_FACTS).map(renderLeadMarkdown);
-		expect(sentences).toEqual([
-			"Across **464** sessions on **3** harnesses, **scout** takes the largest share of measured time (**64%**), then **build** (**18%**).",
-			"A verify step shows up in **40%** of sessions.",
-			"Work stops at a human gate **437** times, with a median wait of **24 min**.",
-			"Most sessions start around **23:00**.",
-			"The rules leave **7%** of measured time unclassified (`phase-rules/v1`).",
+const render = (facts: PhaseLeadFacts) =>
+	renderLeadLines(facts).map(renderLeadMarkdown);
+
+describe("renderLeadLines: the locked example reproduces byte for byte", () => {
+	it("renders the four lines from the spec, in order", () => {
+		expect(render(SPEC_FACTS)).toEqual([
+			"**142** sessions · **3** harnesses · last **30** days",
+			"Most measured time in these sessions goes to **scout** (**64%**), then **build** (**18%**).",
+			"verify in **40%** of sessions · handoff in **62%** of sessions · most start around **23:00** local",
+			"**7%** of measured time unclassified · `phase-rules/v1`",
+		]);
+	});
+
+	it("labels the four lines so a renderer can style each one", () => {
+		expect(renderLeadLines(SPEC_FACTS).map((l) => l.id)).toEqual([
+			"scope",
+			"mix",
+			"stats",
+			"small-print",
 		]);
 	});
 });
 
-describe("renderLeadSentences: an absent measurement drops its sentence", () => {
-	it("drops the phase-mix sentence with fewer than two named phases", () => {
-		const facts: PhaseLeadFacts = {
-			sessionCount: 10,
-			harnessCount: 1,
-			phaseShare: { scout: 0.9, unknown: 0.1 },
-		};
-		const ids = renderLeadSentences(facts).map((s) => s.id);
-		expect(ids).not.toContain("phase-mix");
+describe("renderLeadLines: the sessions are the subject, never the person", () => {
+	it("puts the sessions in the subject slot of the mix sentence", () => {
+		const mix = render(SPEC_FACTS)[1] ?? "";
+		expect(mix).toContain("in these sessions");
 	});
 
-	it("drops the verify sentence with no verify-presence data", () => {
-		const facts: PhaseLeadFacts = {
-			...PROOF_FACTS,
-			verifySessionShare: undefined,
-		};
-		const ids = renderLeadSentences(facts).map((s) => s.id);
-		expect(ids).not.toContain("verify-presence");
+	it("never publishes how long the human took to answer a handoff", () => {
+		const whole = render(SPEC_FACTS).join("\n");
+		expect(whole).not.toMatch(/wait/i);
+		expect(whole).not.toMatch(/min\b/);
 	});
 
-	it("drops the handoff sentence when there were zero handoff events", () => {
-		const facts: PhaseLeadFacts = {
-			...PROOF_FACTS,
-			handoffCount: 0,
-			handoffMedianWaitMinutes: undefined,
-		};
-		const ids = renderLeadSentences(facts).map((s) => s.id);
-		expect(ids).not.toContain("handoff-wait");
-	});
-
-	it("drops the start-hour sentence with no modal hour", () => {
-		const facts: PhaseLeadFacts = {
-			...PROOF_FACTS,
-			modalStartHourLocal: undefined,
-		};
-		const ids = renderLeadSentences(facts).map((s) => s.id);
-		expect(ids).not.toContain("start-hour");
-	});
-
-	it("drops the unknown-share sentence with no phase share at all", () => {
-		const facts: PhaseLeadFacts = { ...PROOF_FACTS, phaseShare: undefined };
-		const ids = renderLeadSentences(facts).map((s) => s.id);
-		expect(ids).not.toContain("unknown-share");
-		expect(ids).not.toContain("phase-mix");
-	});
-
-	it("renders nothing at all for empty facts", () => {
-		expect(renderLeadSentences({})).toEqual([]);
+	it("names the handoff figure as a share of sessions, not a raw count", () => {
+		const stats = render(SPEC_FACTS)[2] ?? "";
+		expect(stats).toContain("handoff in **62%** of sessions");
 	});
 });
 
-describe("renderLeadSentences: unknown-share falls back to phase-rules/v1 when ruleVersion is omitted", () => {
-	it("names phase-rules/v1 by default", () => {
-		const facts: PhaseLeadFacts = { ...PROOF_FACTS, ruleVersion: undefined };
-		const sentence = renderLeadSentences(facts).find(
-			(s) => s.id === "unknown-share",
+describe("renderLeadLines: the unknown share prints once, in small print", () => {
+	it("keeps the unknown share out of the mix sentence", () => {
+		expect(render(SPEC_FACTS)[1] ?? "").not.toContain("unclassified");
+	});
+
+	it("pairs the unknown share with the rule id on the last line", () => {
+		expect(render(SPEC_FACTS)[3] ?? "").toBe(
+			"**7%** of measured time unclassified · `phase-rules/v1`",
 		);
-		expect(sentence && renderLeadMarkdown(sentence)).toContain(
-			"`phase-rules/v1`",
+	});
+
+	it("falls back to phase-rules/v1 when no rule version is given", () => {
+		expect(
+			render({ ...SPEC_FACTS, ruleVersion: undefined })[3] ?? "",
+		).toContain("`phase-rules/v1`");
+	});
+});
+
+describe("renderLeadLines: a close top two never gets ranked", () => {
+	const close: PhaseLeadFacts = {
+		...SPEC_FACTS,
+		phaseShare: {
+			scout: 0.34,
+			build: 0.33,
+			verify: 0.13,
+			handoff: 0.13,
+			unknown: 0.07,
+		},
+	};
+
+	it("prints the even-split form inside the threshold", () => {
+		expect(render(close)[1] ?? "").toBe(
+			"**Scout** (**34%**) and **build** (**33%**) take similar shares of measured time.",
 		);
+	});
+
+	it("prints the ranked form once the gap clears the threshold", () => {
+		const gap = LEAD_EVEN_SPLIT_POINTS + 1;
+		const wide: PhaseLeadFacts = {
+			...SPEC_FACTS,
+			phaseShare: { scout: 0.4, build: (40 - gap) / 100, unknown: 0.07 },
+		};
+		expect(render(wide)[1] ?? "").toContain("goes to **scout**");
+	});
+
+	it("treats a gap exactly on the threshold as an even split", () => {
+		const onEdge: PhaseLeadFacts = {
+			...SPEC_FACTS,
+			phaseShare: {
+				scout: 0.4,
+				build: (40 - LEAD_EVEN_SPLIT_POINTS) / 100,
+				unknown: 0.07,
+			},
+		};
+		expect(render(onEdge)[1] ?? "").toContain("take similar shares");
+	});
+});
+
+describe("renderLeadLines: the floors withhold the whole lead", () => {
+	it("prints nothing below the session floor", () => {
+		const thin: PhaseLeadFacts = {
+			...SPEC_FACTS,
+			sessionCount: LEAD_MIN_SESSIONS - 1,
+		};
+		expect(renderLeadLines(thin)).toEqual([]);
+	});
+
+	it("prints at the session floor exactly", () => {
+		const atFloor: PhaseLeadFacts = {
+			...SPEC_FACTS,
+			sessionCount: LEAD_MIN_SESSIONS,
+		};
+		expect(renderLeadLines(atFloor).length).toBeGreaterThan(0);
+	});
+
+	it("prints nothing when no harness passes the playbook gate", () => {
+		expect(renderLeadLines({ ...SPEC_FACTS, harnessesPassingGate: 0 })).toEqual(
+			[],
+		);
+	});
+
+	it("still prints when the gate result is not asserted", () => {
+		const facts: PhaseLeadFacts = {
+			...SPEC_FACTS,
+			harnessesPassingGate: undefined,
+		};
+		expect(renderLeadLines(facts).length).toBeGreaterThan(0);
+	});
+});
+
+describe("renderLeadLines: the scope line counts every synced harness", () => {
+	it("counts all harnesses, including one the playbook gate held back", () => {
+		expect(render(SPEC_FACTS)[0] ?? "").toContain("**3** harnesses");
+	});
+
+	it("uses singular nouns for a one-session, one-harness stack", () => {
+		const solo: PhaseLeadFacts = {
+			...SPEC_FACTS,
+			sessionCount: 1,
+			harnessCount: 1,
+			windowDays: 1,
+		};
+		// Below the session floor, so ask the scope line for itself.
+		expect(
+			renderLeadMarkdown({
+				id: "scope",
+				parts:
+					renderLeadLines({ ...solo, sessionCount: LEAD_MIN_SESSIONS })[0]
+						?.parts ?? [],
+			}),
+		).toBe("**20** sessions · **1** harness · last **1** day");
+	});
+});
+
+describe("renderLeadLines: an absent measurement drops its line or segment", () => {
+	it("drops one stat segment and keeps the rest of the line", () => {
+		const facts: PhaseLeadFacts = {
+			...SPEC_FACTS,
+			verifySessionShare: undefined,
+		};
+		expect(render(facts)[2] ?? "").toBe(
+			"handoff in **62%** of sessions · most start around **23:00** local",
+		);
+	});
+
+	it("drops the whole stat line when no segment survives", () => {
+		const facts: PhaseLeadFacts = {
+			...SPEC_FACTS,
+			verifySessionShare: undefined,
+			handoffSessionShare: undefined,
+			modalStartHourOwnerLocal: undefined,
+		};
+		expect(renderLeadLines(facts).map((l) => l.id)).not.toContain("stats");
+	});
+
+	it("drops the mix line with fewer than two named phases", () => {
+		const facts: PhaseLeadFacts = {
+			...SPEC_FACTS,
+			phaseShare: { scout: 0.9, unknown: 0.1 },
+		};
+		expect(renderLeadLines(facts).map((l) => l.id)).not.toContain("mix");
+	});
+
+	it("drops the mix and the small print with no phase share at all", () => {
+		const ids = renderLeadLines({ ...SPEC_FACTS, phaseShare: undefined }).map(
+			(l) => l.id,
+		);
+		expect(ids).not.toContain("mix");
+		expect(ids).not.toContain("small-print");
+	});
+
+	it("drops the scope line with no window", () => {
+		const facts: PhaseLeadFacts = { ...SPEC_FACTS, windowDays: undefined };
+		expect(renderLeadLines(facts).map((l) => l.id)).not.toContain("scope");
+	});
+
+	it("renders nothing at all for empty facts", () => {
+		expect(renderLeadLines({})).toEqual([]);
 	});
 });

--- a/packages/workflow-rules/src/templateLead.ts
+++ b/packages/workflow-rules/src/templateLead.ts
@@ -1,52 +1,87 @@
 // The deterministic template lead: `lead-templates/v1`.
 //
-// Wayfinder ticket #214 (map #200). The five sentence forms and their
-// proof-of-life numbers come from ticket #196: run over 464 real sessions
-// across 3 harnesses with no LLM involved, all five read correctly.
-// ADR-0002 rules out an LLM anywhere in this surface, so the lead is fixed
-// sentence forms over measured numbers, versioned the same way the metric
-// and phase rules are.
+// Built in #214, and its wording locked in #220 (map #200). The measured
+// numbers come from #196: phase-rules/v1 over 464 real sessions across 3
+// harnesses, no LLM involved. ADR-0002 rules out an LLM anywhere in this
+// surface, so the lead is fixed forms over measured numbers, versioned the
+// same way the metric and phase rules are. The forms themselves are spelled
+// out under "The template lead" in docs/specs/workflow-surface.md.
 //
-// A sentence is built from typed PARTS rather than one baked string, because
-// a "value" the reader sees highlighted (a bold number, a phase name) is a
-// styling decision for whoever renders it (ticket #215's podium, or the
-// CLI's plain-text approve-gate preview) - this module only owns the words
-// and the numbers, not the markup. `renderLeadMarkdown` is the one
-// concrete rendering this package ships, and it exists to keep the proof in
-// #196 checkable byte for byte.
+// THE SESSIONS ARE THE SUBJECT, NEVER THE PERSON. Every classified event is a
+// tool call the harness made, so scout at 64% is mostly the agent reading. A
+// sentence with no subject lets a reader supply one, and on a profile page
+// they supply the person, which is both wrong and the unflattering reading.
+// "Most measured time IN THESE SESSIONS" costs three words and fixes it.
+// #196 flagged this; #220 answered it. Do not drop the subject.
 //
-// "An absent measurement drops its sentence" (spec) - each sentence builder
-// returns `undefined` when the facts it needs aren't there, and the missing
-// sentence is skipped rather than rendered with a placeholder.
+// A line is built from typed PARTS rather than one baked string, because a
+// "value" the reader sees highlighted (a bold number, a phase name) is a
+// styling decision for whoever renders it (#215's podium, or the CLI's
+// plain-text approve-gate preview) - this module owns the words and the
+// numbers, not the markup. `renderLeadMarkdown` is the one concrete rendering
+// this package ships, and it keeps the spec's example checkable byte for byte.
 //
-// Local time. "Start hours are stored in UTC and rendered in the reader's
-// own time, so a public page never shows a stranger a UTC clock" (spec) -
-// `modalStartHourLocal` is therefore the CALLER's job to localize before
-// calling this module; nothing here touches a timezone.
+// "An absent measurement drops its sentence" (spec) - each builder returns
+// `undefined` when its facts aren't there, and the stat line drops segments
+// one at a time before dropping itself.
+//
+// Local time. The spec used to say start hours render in the READER's own
+// time. #220 overturned that: a reader in Tokyo would see the owner's 23:00
+// habit as 06:00, which describes nobody. `modalStartHourOwnerLocal` is the
+// OWNER's local hour, localized by the caller, and it renders labeled
+// "local". Nothing here touches a timezone.
 
 import type { PhaseId } from "./types.js";
 
 export const LEAD_TEMPLATES_V1 = "lead-templates/v1";
+
+/**
+ * Within this many percentage points, the top two phases are not ranked.
+ * Ranking a one-point gap invents a winner the measurement does not support.
+ */
+export const LEAD_EVEN_SPLIT_POINTS = 10;
+
+/**
+ * Below this many sessions the lead does not print at all. A four-session
+ * stack would say "most measured time goes to scout (67%)": true, and
+ * meaningless. The session count in the scope line only warns a reader who
+ * stops to do the arithmetic.
+ */
+export const LEAD_MIN_SESSIONS = 20;
 
 export type LeadPart =
 	| { kind: "text"; text: string }
 	| { kind: "value"; text: string }
 	| { kind: "code"; text: string };
 
-export type LeadSentence = { id: string; parts: readonly LeadPart[] };
+/** One of the four lines: `scope`, `mix`, `stats`, `small-print`. */
+export type LeadLine = { id: string; parts: readonly LeadPart[] };
 
 export type PhaseLeadFacts = {
+	/** Sessions in the window, across every synced harness. */
 	sessionCount?: number;
+	/** EVERY synced harness, including one the playbook gate held back. */
 	harnessCount?: number;
+	/**
+	 * How many harnesses cleared the playbook gate (20% unknown or less).
+	 * Zero withholds the whole lead. Omitted means the caller did not assert
+	 * either way, and the lead prints.
+	 */
+	harnessesPassingGate?: number;
+	/** The payload's own rolling window, named in the scope line so one page never carries two. */
+	windowDays?: number;
 	/** Share of TOTAL measured time (including `unknown`) per phase, summing to 1. */
 	phaseShare?: Partial<Record<PhaseId, number>>;
 	/** Share of sessions containing at least one verify-phase event. */
 	verifySessionShare?: number;
-	/** Raw count of handoff (blocking human-gate) events across every session. */
-	handoffCount?: number;
-	handoffMedianWaitMinutes?: number;
-	/** The hour (0-23) most sessions start in, already localized by the caller. */
-	modalStartHourLocal?: number;
+	/**
+	 * Share of sessions that stop at least once for a handoff. #220 replaced
+	 * the raw event count, which had no denominator, and dropped the median
+	 * wait, which measured how fast the human answered rather than the work.
+	 */
+	handoffSessionShare?: number;
+	/** The hour (0-23) most sessions start in, in the OWNER's local time. */
+	modalStartHourOwnerLocal?: number;
 	/** Defaults to the phase rule set that produced `phaseShare` when omitted. */
 	ruleVersion?: string;
 };
@@ -55,10 +90,17 @@ const txt = (text: string): LeadPart => ({ kind: "text", text });
 const val = (text: string): LeadPart => ({ kind: "value", text });
 const code = (text: string): LeadPart => ({ kind: "code", text });
 
-const pct = (share: number): string => `${Math.round(share * 100)}%`;
+const SEP = " · ";
+
+/** Whole percentage points, which is what the reader sees, so the prose never contradicts the number. */
+const points = (share: number): number => Math.round(share * 100);
+const pct = (share: number): string => `${points(share)}%`;
 const localHour = (hour: number): string =>
 	`${String(hour).padStart(2, "0")}:00`;
-const minutes = (m: number): string => `${Math.round(m)} min`;
+const plural = (n: number, one: string, many: string): string =>
+	n === 1 ? one : many;
+const capitalize = (s: string): string =>
+	s.charAt(0).toUpperCase() + s.slice(1);
 
 const NAMED_PHASES: readonly PhaseId[] = [
 	"scout",
@@ -67,119 +109,152 @@ const NAMED_PHASES: readonly PhaseId[] = [
 	"handoff",
 ];
 
-/** "Across N sessions on H harnesses, PHASE1 takes the largest share of measured time (P1%), then PHASE2 (P2%)." */
-function phaseMixSentence(facts: PhaseLeadFacts): LeadSentence | undefined {
-	const { sessionCount, harnessCount, phaseShare } = facts;
-	if (!sessionCount || !harnessCount || !phaseShare) return undefined;
-	const ranked = NAMED_PHASES.map((phase) => ({
-		phase,
-		share: phaseShare[phase],
-	})).filter(
-		(e): e is { phase: PhaseId; share: number } => e.share !== undefined,
-	);
-	ranked.sort((a, b) => b.share - a.share);
-	const first = ranked[0];
-	const second = ranked[1];
-	if (!first || !second) return undefined;
+/** "142 sessions · 3 harnesses · last 30 days" */
+function scopeLine(facts: PhaseLeadFacts): LeadLine | undefined {
+	const { sessionCount, harnessCount, windowDays } = facts;
+	if (!sessionCount || !harnessCount || !windowDays) return undefined;
 	return {
-		id: "phase-mix",
+		id: "scope",
 		parts: [
-			txt("Across "),
 			val(String(sessionCount)),
-			txt(" sessions on "),
+			txt(` ${plural(sessionCount, "session", "sessions")}${SEP}`),
 			val(String(harnessCount)),
-			txt(" harnesses, "),
-			val(first.phase),
-			txt(" takes the largest share of measured time ("),
-			val(pct(first.share)),
-			txt("), then "),
-			val(second.phase),
-			txt(" ("),
-			val(pct(second.share)),
-			txt(")."),
-		],
-	};
-}
-
-/** "A verify step shows up in P% of sessions." */
-function verifyPresenceSentence(
-	facts: PhaseLeadFacts,
-): LeadSentence | undefined {
-	if (facts.verifySessionShare === undefined) return undefined;
-	return {
-		id: "verify-presence",
-		parts: [
-			txt("A verify step shows up in "),
-			val(pct(facts.verifySessionShare)),
-			txt(" of sessions."),
-		],
-	};
-}
-
-/** "Work stops at a human gate N times, with a median wait of M min." */
-function handoffWaitSentence(facts: PhaseLeadFacts): LeadSentence | undefined {
-	if (!facts.handoffCount || facts.handoffMedianWaitMinutes === undefined)
-		return undefined;
-	return {
-		id: "handoff-wait",
-		parts: [
-			txt("Work stops at a human gate "),
-			val(String(facts.handoffCount)),
-			txt(" times, with a median wait of "),
-			val(minutes(facts.handoffMedianWaitMinutes)),
-			txt("."),
-		],
-	};
-}
-
-/** "Most sessions start around HH:00." */
-function startHourSentence(facts: PhaseLeadFacts): LeadSentence | undefined {
-	if (facts.modalStartHourLocal === undefined) return undefined;
-	return {
-		id: "start-hour",
-		parts: [
-			txt("Most sessions start around "),
-			val(localHour(facts.modalStartHourLocal)),
-			txt("."),
-		],
-	};
-}
-
-/** "The rules leave U% of measured time unclassified (`rule-version`)." */
-function unknownShareSentence(facts: PhaseLeadFacts): LeadSentence | undefined {
-	const unknown = facts.phaseShare?.unknown;
-	if (unknown === undefined) return undefined;
-	return {
-		id: "unknown-share",
-		parts: [
-			txt("The rules leave "),
-			val(pct(unknown)),
-			txt(" of measured time unclassified ("),
-			code(facts.ruleVersion ?? "phase-rules/v1"),
-			txt(")."),
+			txt(` ${plural(harnessCount, "harness", "harnesses")}${SEP}last `),
+			val(String(windowDays)),
+			txt(` ${plural(windowDays, "day", "days")}`),
 		],
 	};
 }
 
 /**
- * The five `lead-templates/v1` forms, in fixed order, with any sentence
- * whose measurement is absent skipped rather than rendered empty.
+ * "Most measured time in these sessions goes to scout (64%), then build (18%)."
+ *
+ * Within `LEAD_EVEN_SPLIT_POINTS`, the ranked form is replaced by
+ * "Scout (34%) and build (33%) take similar shares of measured time."
  */
-export function renderLeadSentences(
-	facts: PhaseLeadFacts,
-): readonly LeadSentence[] {
-	return [
-		phaseMixSentence(facts),
-		verifyPresenceSentence(facts),
-		handoffWaitSentence(facts),
-		startHourSentence(facts),
-		unknownShareSentence(facts),
-	].filter((s): s is LeadSentence => s !== undefined);
+function mixLine(facts: PhaseLeadFacts): LeadLine | undefined {
+	const { phaseShare } = facts;
+	if (!phaseShare) return undefined;
+	const ranked = NAMED_PHASES.map((phase) => ({
+		phase,
+		share: phaseShare[phase],
+	}))
+		.filter(
+			(e): e is { phase: PhaseId; share: number } => e.share !== undefined,
+		)
+		.sort((a, b) => b.share - a.share);
+	const [first, second] = ranked;
+	if (!first || !second) return undefined;
+
+	const evenSplit =
+		points(first.share) - points(second.share) <= LEAD_EVEN_SPLIT_POINTS;
+
+	return {
+		id: "mix",
+		parts: evenSplit
+			? [
+					val(capitalize(first.phase)),
+					txt(" ("),
+					val(pct(first.share)),
+					txt(") and "),
+					val(second.phase),
+					txt(" ("),
+					val(pct(second.share)),
+					txt(") take similar shares of measured time."),
+				]
+			: [
+					txt("Most measured time in these sessions goes to "),
+					val(first.phase),
+					txt(" ("),
+					val(pct(first.share)),
+					txt("), then "),
+					val(second.phase),
+					txt(" ("),
+					val(pct(second.share)),
+					txt(")."),
+				],
+	};
 }
 
-/** Bold values, code-styled rule ids - the exact markdown form #196 proved against real data. */
-export function renderLeadMarkdown(sentence: LeadSentence): string {
-	return sentence.parts
+/**
+ * "verify in 40% of sessions · handoff in 62% of sessions · most start around 23:00 local"
+ *
+ * Three figures on one mono line rather than three more sentences: metric
+ * cells would give them the weight of the token headline, and they are not
+ * that important. Each segment drops on its own.
+ */
+function statsLine(facts: PhaseLeadFacts): LeadLine | undefined {
+	const segments: LeadPart[][] = [];
+	if (facts.verifySessionShare !== undefined) {
+		segments.push([
+			txt("verify in "),
+			val(pct(facts.verifySessionShare)),
+			txt(" of sessions"),
+		]);
+	}
+	if (facts.handoffSessionShare !== undefined) {
+		segments.push([
+			txt("handoff in "),
+			val(pct(facts.handoffSessionShare)),
+			txt(" of sessions"),
+		]);
+	}
+	if (facts.modalStartHourOwnerLocal !== undefined) {
+		segments.push([
+			txt("most start around "),
+			val(localHour(facts.modalStartHourOwnerLocal)),
+			txt(" local"),
+		]);
+	}
+	if (segments.length === 0) return undefined;
+	return {
+		id: "stats",
+		parts: segments.flatMap((seg, i) => (i === 0 ? seg : [txt(SEP), ...seg])),
+	};
+}
+
+/**
+ * "7% of measured time unclassified · phase-rules/v1"
+ *
+ * The unknown bucket never hides, and it prints exactly once. Before #220 it
+ * appeared in both the lead and the derivation.
+ */
+function smallPrintLine(facts: PhaseLeadFacts): LeadLine | undefined {
+	const unknown = facts.phaseShare?.unknown;
+	if (unknown === undefined) return undefined;
+	return {
+		id: "small-print",
+		parts: [
+			val(pct(unknown)),
+			txt(` of measured time unclassified${SEP}`),
+			code(facts.ruleVersion ?? "phase-rules/v1"),
+		],
+	};
+}
+
+/**
+ * The four `lead-templates/v1` lines, in fixed order, with any line whose
+ * measurement is absent skipped rather than rendered empty.
+ *
+ * Two floors withhold the whole lead: fewer than `LEAD_MIN_SESSIONS`
+ * sessions, and no harness clearing the playbook gate. Both exist because a
+ * mix that unreliable is not worth publishing, and printing it anyway just
+ * moves the judgment onto the reader. The rest of the section still renders.
+ */
+export function renderLeadLines(facts: PhaseLeadFacts): readonly LeadLine[] {
+	if (facts.harnessesPassingGate === 0) return [];
+	if ((facts.sessionCount ?? 0) < LEAD_MIN_SESSIONS) return [];
+	return [
+		scopeLine(facts),
+		mixLine(facts),
+		statsLine(facts),
+		smallPrintLine(facts),
+	].filter((l): l is LeadLine => l !== undefined);
+}
+
+/** Bold values, code-styled rule ids: the exact markdown the spec's example prints. */
+export function renderLeadMarkdown(line: LeadLine): string {
+	return line.parts
 		.map((part) => {
 			if (part.kind === "value") return `**${part.text}**`;
 			if (part.kind === "code") return `\`${part.text}\``;


### PR DESCRIPTION
Resolves [#267](https://github.com/alp82/aistack/issues/267), part of [map #200](https://github.com/alp82/aistack/issues/200). Unblocks [#213](https://github.com/alp82/aistack/issues/213).

[PR #265](https://github.com/alp82/aistack/pull/265) and [PR #266](https://github.com/alp82/aistack/pull/266) were in flight at the same time. #265 built the template lead against the spec as it stood before [#220](https://github.com/alp82/aistack/issues/220) locked the wording, so neither was wrong and the two disagreed. This brings the code to the spec.

## What it renders now

```
**142** sessions · **3** harnesses · last **30** days
Most measured time in these sessions goes to **scout** (**64%**), then **build** (**18%**).

verify in **40%** of sessions · handoff in **62%** of sessions · most start around **23:00** local

**7%** of measured time unclassified · `phase-rules/v1`
```

The first test asserts that byte for byte against the example in the spec.

## Changes

| Before | Now |
|---|---|
| `renderLeadSentences`, five sentences | `renderLeadLines`, four lines with ids `scope` / `mix` / `stats` / `small-print` |
| "Across 464 sessions on 3 harnesses, scout takes the largest share..." | Scope line, then "Most measured time **in these sessions** goes to scout (64%), then build (18%)." |
| `handoffCount` plus `handoffMedianWaitMinutes` | `handoffSessionShare`. The wait is gone. |
| Unknown share as a fifth sentence | `small-print` line, once, with the rule id |
| Ranked mix always | Even-split form within `LEAD_EVEN_SPLIT_POINTS` (10) |
| No floors | `LEAD_MIN_SESSIONS` (20), and `harnessesPassingGate: 0` withholds the lead |
| `modalStartHourLocal`, reader's time | `modalStartHourOwnerLocal`, rendered labeled "local" |
| No window in the copy | `windowDays` in the scope line |

## Why the wait figure had to go

`handoffMedianWaitMinutes` measured how long the human took to answer a blocking question. It was the one number in the lead about the person rather than the work, and #220 dropped it. A test now asserts the rendered lead contains no `wait` and no `min`, so it cannot come back by accident.

Removing it before [#213](https://github.com/alp82/aistack/issues/213) is the point of the blocking edge: on the wire it would have cost a version bump to take off.

## Verification

- 23 tests in `templateLead.test.ts`, written first and red before the change.
- Full package suite: 562 passing across 34 files.
- `biome check` clean, no new `tsc` errors, em-dash guard passing.
- No callers existed, so nothing downstream broke.

## Follow-up tickets

**No new tickets.** This unblocks one existing ticket: [#213 Task: extend the sync wire with workflow and four pending fields](https://github.com/alp82/aistack/issues/213), which returns to the frontier once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fu2UYXr1VCkMiJ4LrABeyz