### PR TITLE
Extend the sync wire with workflow and four pending fields (#213)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,10 +73,12 @@ never published - `tsup` bundles it into the CLI's `dist`.
 * The CLI prices each response at its own timestamp, at ingest. That figure is
   exact and always wins.
 * The backend re-prices at READ time in `convex/lib/reprice.ts`, filling gaps
-  only. Its figures are LOWER BOUNDS: the wire carries one merged `cacheWrite`
-  (so it charges the cheap 5-minute tier, about 8% low for Claude Code), and it
-  has no per-response timestamps (so a window straddling a repricing pays the
-  cheaper rate).
+  only. Its figures are LOWER BOUNDS, for one remaining reason: it has no
+  per-response timestamps, so a window straddling a repricing pays the cheaper
+  rate. The cache-write bias is gone from new payloads. The wire carries the
+  5-minute/1-hour split as `tokens.cacheWriteTtl`, and the repricer charges each
+  tier its own rate; a payload from before that field still merges into one
+  `cacheWrite` and charges the cheap tier, about 8% low for Claude Code.
 * Every surface that prints dollars prints the price-table id and the share of
   tokens the figure covers. `publishCost` on the stack is the consent gate:
   check the flag. The presence of dollars in the data is not consent.

--- a/convex/httpCli.test.ts
+++ b/convex/httpCli.test.ts
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest'
 import { api, internal } from './_generated/api'
 import type { Id } from './_generated/dataModel'
 import schema from './schema'
-import { sha256Hex } from './httpCli'
+import { sha256Hex, stripRetiredResourceFields } from './httpCli'
 import { FULL_CLI_TOKEN_SCOPES, type CliTokenScope } from './lib/cliScopes'
 import { DEFAULT_MAX_REQUESTS, SHARED_BUCKET_MAX_REQUESTS } from './rateLimit'
 
@@ -613,5 +613,44 @@ describe('authStart budget', () => {
 
   test('the high cap really is higher than the normal one', async () => {
     expect(SHARED_BUCKET_MAX_REQUESTS).toBeGreaterThan(DEFAULT_MAX_REQUESTS)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Retired wire fields (#213)
+// ---------------------------------------------------------------------------
+
+describe('stripRetiredResourceFields', () => {
+  test('drops scope so an installed CLI still publishes', () => {
+    // Resources became stack-only in June 2026 and `scope` has been ignored
+    // since. `ResourceInput` kept tolerating it, which made the field read as
+    // part of the contract; the tolerance lives here now, and the validator
+    // lists only what the wire means.
+    expect(
+      stripRetiredResourceFields({
+        type: 'rule',
+        name: 'r',
+        group: 'claude-code',
+        stableKey: 'k:rule:r',
+        scope: 'project',
+      }),
+    ).toEqual({
+      type: 'rule',
+      name: 'r',
+      group: 'claude-code',
+      stableKey: 'k:rule:r',
+    })
+  })
+
+  test('leaves an item that never carried it untouched', () => {
+    const item = { type: 'rule', name: 'r', group: 'g', stableKey: 'k' }
+    expect(stripRetiredResourceFields(item)).toEqual(item)
+  })
+
+  test('passes a non-object through for the validator to refuse', () => {
+    // Rejecting shape is the validator's job, not this function's. Returning
+    // something object-shaped here would turn a client bug into a stored row.
+    expect(stripRetiredResourceFields(null)).toBeNull()
+    expect(stripRetiredResourceFields('nope')).toBe('nope')
   })
 })

--- a/convex/httpCli.ts
+++ b/convex/httpCli.ts
@@ -344,6 +344,24 @@ export const authPoll = httpAction(async (ctx, request) => {
   return jsonResponse({ status: 'expired' })
 })
 
+/**
+ * Drop wire fields the resource contract no longer has (#213).
+ *
+ * `scope` is the one: resources became stack-only in June 2026 and the field
+ * has been ignored ever since, but `ResourceInput` kept tolerating it so that
+ * installed CLIs would still publish. Tolerance belongs here rather than in the
+ * validator - a validator lists the contract, and a field listed there reads as
+ * part of it. Stripping at the edge retires the field from the contract without
+ * breaking a single installed client.
+ */
+export function stripRetiredResourceFields(item: unknown): unknown {
+  if (typeof item !== 'object' || item === null || Array.isArray(item)) {
+    return item
+  }
+  const { scope: _retired, ...rest } = item as Record<string, unknown>
+  return rest
+}
+
 export const stackCollect = httpAction(async (ctx, request) => {
   const authResult = await validateBearerToken(ctx as any, request, 'collect')
   if (authResult instanceof Response) return authResult
@@ -382,7 +400,7 @@ export const stackCollect = httpAction(async (ctx, request) => {
   const result = await ctx.runMutation(internal.httpCliHelpers.upsertStackResources, {
     creatorId: creator._id,
     stackId: tokenStackId,
-    resources: body.resources,
+    resources: body.resources.map(stripRetiredResourceFields) as any,
   })
 
   const now = Date.now()
@@ -442,6 +460,20 @@ function parseTrigger(raw: unknown): 'manual' | 'auto' | undefined {
 }
 
 /**
+ * Read the publishing CLI's own version (#213).
+ *
+ * Dropped rather than rejected, like `parseAutoSync`: it answers an operational
+ * question about the fleet, and refusing an approved sync over a malformed
+ * version string would trade the measurement for the metadata. Bounded to the
+ * same 32 characters the login route uses, so one field has one bound.
+ */
+function parseCliVersion(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') return undefined
+  const trimmed = raw.trim()
+  return trimmed.length > 0 && trimmed.length <= 32 ? trimmed : undefined
+}
+
+/**
  * POST /api/cli/sync - publish one approved measured-layer snapshot.
  *
  * Wayfinder ticket #38 (map #29). The destination is the stack bound to the
@@ -464,6 +496,8 @@ export const syncPublish = httpAction(async (ctx, request) => {
     keptPrivate?: unknown
     autoSync?: unknown
     trigger?: unknown
+    workflow?: unknown
+    cliVersion?: unknown
   }
   try {
     body = await request.json()
@@ -471,8 +505,9 @@ export const syncPublish = httpAction(async (ctx, request) => {
     return jsonResponse({ error: 'Invalid JSON body' }, 400)
   }
   // `payloads` is the batch a #67 client sends - one per detected harness.
-  // The old single `payload` stays accepted for installed CLIs (same wire
-  // tolerance as ResourceInput.scope) until a wire bump retires it.
+  // The old single `payload` stays accepted for installed CLIs until a wire
+  // bump retires it, the way `scope` was retired in #213: strip it at this
+  // edge, and leave the contract saying only what it means.
   if (!body.payload && !(Array.isArray(body.payloads) && body.payloads.length > 0)) {
     return jsonResponse({ error: 'Missing required field: payloads' }, 400)
   }
@@ -495,6 +530,16 @@ export const syncPublish = httpAction(async (ctx, request) => {
       // Additive and optional (#102): a 0.6.x CLI sends nothing and its syncs
       // read as manual, which is what keeps the switch honest until #103 ships.
       trigger: parseTrigger(body.trigger),
+      // Additive and optional (#213). Unlike the two fields above this one is
+      // NOT parsed here: it goes to the closed `WorkflowSection` validator in
+      // the mutation, exactly like the payloads, and a malformed section is the
+      // client's fault and surfaces as a 400. The drop-rather-than-reject rule
+      // above is for telemetry nothing user-facing reads; the workflow section
+      // is measurement, and a silently dropped measurement is a wrong page.
+      workflow: body.workflow as any,
+      // Additive and optional (#213), bounded the same way the login route
+      // bounds it.
+      cliVersion: parseCliVersion(body.cliVersion),
     })
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
@@ -550,6 +595,9 @@ export const syncConfig = httpAction(async (ctx, request) => {
     // Fails closed with the rest of the stack-level half (#48): with no bearer
     // there is no stack to ask, and the direction that transmits LESS is off.
     reviewKeptPrivate: false,
+    // And again for the workflow section (#213). The client's bundled default
+    // matches, so an unreachable server publishes measurement and no workflow.
+    publishWorkflow: false,
     optIns: EMPTY_OPT_INS,
     stack: null,
     // Fails closed too (#102): with no stack in hand there is no permission to
@@ -583,6 +631,7 @@ export const syncConfig = httpAction(async (ctx, request) => {
     ...config,
     publishCost: stackConfig.publishCost,
     reviewKeptPrivate: stackConfig.reviewKeptPrivate,
+    publishWorkflow: stackConfig.publishWorkflow,
     optIns: stackConfig.optIns,
     stack: { name: stackConfig.stackName, slug: stackConfig.stackSlug },
     // What gates `sync --auto` (#103). Null means the stack has never had a

--- a/convex/httpCliHelpers.test.ts
+++ b/convex/httpCliHelpers.test.ts
@@ -101,10 +101,16 @@ async function resourcesForOwner(
 }
 
 // ---------------------------------------------------------------------------
-// upsertStackResources - scope coercion
+// upsertStackResources - every item lands on the stack
+//
+// These three cases used to differ by the `scope` each item carried. #213
+// retired the field from `ResourceInput` and moved the tolerance for old CLIs
+// to `stripRetiredResourceFields` at the HTTP edge, so what reaches this
+// mutation never mentions scope. The cases stay because what they assert is
+// still true and still worth asserting: one owner kind, and no project links.
 // ---------------------------------------------------------------------------
 
-test('TC-01: upsertStackResources with scope:project input lands on stack - no project links', async () => {
+test('TC-01: upsertStackResources lands a rule on the stack - no project links', async () => {
   const t = convexTest(schema, modules)
   const { creatorId, stackId } = await seedCreatorAndStack(t)
 
@@ -118,7 +124,6 @@ test('TC-01: upsertStackResources with scope:project input lands on stack - no p
         type: 'rule',
         name: 'scope-coerce',
         group: 'claude-code',
-        scope: 'project',
         stableKey: 'k:rule:scope-coerce',
         files: [{ name: 'r.md', content: 'v1' }],
       },
@@ -144,7 +149,7 @@ test('TC-01: upsertStackResources with scope:project input lands on stack - no p
   expect(stack!.updatedAt).toBeGreaterThan(preCall)
 })
 
-test('TC-02: upsertStackResources with scope:global lands on stack', async () => {
+test('TC-02: a second rule lands on the stack as well', async () => {
   const t = convexTest(schema, modules)
   const { creatorId, stackId } = await seedCreatorAndStack(t)
 
@@ -156,7 +161,6 @@ test('TC-02: upsertStackResources with scope:global lands on stack', async () =>
         type: 'rule',
         name: 'already-global',
         group: 'claude-code',
-        scope: 'global',
         stableKey: 'k:rule:already-global',
         files: [{ name: 'g.md', content: 'global' }],
       },
@@ -173,7 +177,7 @@ test('TC-02: upsertStackResources with scope:global lands on stack', async () =>
   expect(allLinks[0].ownerKind).toBe('stack')
 })
 
-test('TC-03: upsertStackResources with scope omitted lands on stack', async () => {
+test('TC-03: an item with no owner hint at all lands on the stack', async () => {
   const t = convexTest(schema, modules)
   const { creatorId, stackId } = await seedCreatorAndStack(t)
 
@@ -207,7 +211,6 @@ test('TC-04: upsertStackResources three scope variants all land on stack', async
         type: 'rule',
         name: 'r-project',
         group: 'claude-code',
-        scope: 'project',
         stableKey: 'k:rule:r-project',
         files: [{ name: 'a.md', content: 'a' }],
       },
@@ -215,7 +218,6 @@ test('TC-04: upsertStackResources three scope variants all land on stack', async
         type: 'rule',
         name: 'r-global',
         group: 'claude-code',
-        scope: 'global',
         stableKey: 'k:rule:r-global',
         files: [{ name: 'b.md', content: 'b' }],
       },
@@ -331,7 +333,6 @@ test('TC-07: upsertStackResources merge - A preserved, B updated, C added', asyn
         type: 'rule',
         name: 'A',
         group: 'claude-code',
-        scope: 'project',
         stableKey: 'k:rule:A',
         files: [{ name: 'A.md', content: 'A v1' }],
       },
@@ -339,7 +340,6 @@ test('TC-07: upsertStackResources merge - A preserved, B updated, C added', asyn
         type: 'rule',
         name: 'B',
         group: 'claude-code',
-        scope: 'project',
         stableKey: 'k:rule:B',
         files: [{ name: 'B.md', content: 'B v1' }],
       },

--- a/convex/httpCliHelpers.ts
+++ b/convex/httpCliHelpers.ts
@@ -77,8 +77,9 @@ export const upsertStackResources = internalMutation({
     }
 
     // Every resource collected through the CLI is stack-owned. Old published
-    // CLIs may still send a scope field on items; ResourceInput tolerates it and
-    // upsertResourcesForOwner ignores it, so the payload passes through as-is.
+    // CLIs may still send a scope field on items; `stripRetiredResourceFields`
+    // in httpCli drops it at the edge (#213), so what arrives here already
+    // matches `ResourceInput`.
     await upsertResourcesForOwner(ctx, {
       addedBy: args.creatorId,
       ownerKind: 'stack',

--- a/convex/lib/reprice.test.ts
+++ b/convex/lib/reprice.test.ts
@@ -162,9 +162,9 @@ describe('repriceSnapshot - the gap filler (#93)', () => {
   })
 
   it('charges a merged cache write at the CHEAP tier', () => {
-    // The wire carries one `cacheWrite`, so the 5m/1h split the CLI priced from
-    // is gone. Assuming the 1.25x tier under-reports Claude Code by ~8%, which
-    // is what keeps every server-side figure a lower bound.
+    // A pre-#213 payload carries one `cacheWrite`, so the 5m/1h split the CLI
+    // priced from is gone. Assuming the 1.25x tier under-reports Claude Code by
+    // ~8%, which is what keeps every server-side figure a lower bound.
     const out = repriceSnapshot({
       models: [{ id: 'claude-opus-5', tokens: tokens({ cacheWrite: MTOK }) }],
       window: JULY,
@@ -172,6 +172,81 @@ describe('repriceSnapshot - the gap filler (#93)', () => {
       publishCost: true,
     })
     expect(out.models[0].apiEquivalentUSD).toBeCloseTo(6.25, 9) // $5 x 1.25
+  })
+
+  it('charges each TTL tier its own rate when the split is on the wire (#213)', () => {
+    // The whole point of the split. Half the writes are 1-hour, and the 1h tier
+    // costs 2.0x input against the 5m tier's 1.25x - so this reads $8.125 where
+    // the merged form reads $6.25, and the 30% gap is the bias #213 removes.
+    const out = repriceSnapshot({
+      models: [
+        {
+          id: 'claude-opus-5',
+          tokens: tokens({
+            cacheWrite: MTOK,
+            cacheWriteTtl: {
+              fiveMinute: MTOK / 2,
+              oneHour: MTOK / 2,
+              unsplit: 0,
+            },
+          }),
+        },
+      ],
+      window: JULY,
+      publishedTable: 'anthropic-list-2026-01-01',
+      publishCost: true,
+    })
+    // $5 x (0.5 x 1.25 + 0.5 x 2.0), rounded to cents like every figure here.
+    expect(out.models[0].apiEquivalentUSD).toBe(8.13)
+  })
+
+  it('prices an unsplit remainder at the cheap tier (#213)', () => {
+    // `unsplit` is what the harness reported with no TTL attached. Charging it
+    // at 2.0x would let an estimate overstate, and this module has exactly one
+    // direction it may resolve an unknown in.
+    const out = repriceSnapshot({
+      models: [
+        {
+          id: 'claude-opus-5',
+          tokens: tokens({
+            cacheWrite: MTOK,
+            cacheWriteTtl: { fiveMinute: 0, oneHour: 0, unsplit: MTOK },
+          }),
+        },
+      ],
+      window: JULY,
+      publishedTable: 'anthropic-list-2026-01-01',
+      publishCost: true,
+    })
+    expect(out.models[0].apiEquivalentUSD).toBeCloseTo(6.25, 9)
+  })
+
+  it('reads a Google cache write as plain input, split or not (#123, #213)', () => {
+    // The TTL tiers are Anthropic's. A vendor whose cache multipliers are 1.0
+    // must not acquire a 2.0x tier by carrying a breakdown.
+    const split = repriceSnapshot({
+      models: [
+        {
+          id: 'gemini-3-pro',
+          tokens: tokens({
+            cacheWrite: MTOK,
+            cacheWriteTtl: { fiveMinute: 0, oneHour: MTOK, unsplit: 0 },
+          }),
+        },
+      ],
+      window: JULY,
+      publishedTable: null,
+      publishCost: true,
+    })
+    const merged = repriceSnapshot({
+      models: [{ id: 'gemini-3-pro', tokens: tokens({ cacheWrite: MTOK }) }],
+      window: JULY,
+      publishedTable: null,
+      publishCost: true,
+    })
+    expect(split.models[0].apiEquivalentUSD).toBe(
+      merged.models[0].apiEquivalentUSD
+    )
   })
 
   it('charges a cache read at a tenth of the input rate', () => {

--- a/convex/lib/reprice.ts
+++ b/convex/lib/reprice.ts
@@ -20,11 +20,16 @@
  * Two facts are lost by the time a payload lands, and both are resolved
  * downward so the result stays a lower bound:
  *
- *   1. The wire carries ONE merged `cacheWrite`. The 5m tier costs 1.25x input
- *      and the 1h tier 2.0x, and the split is gone - so everything charges the
- *      5m rate. Measured against a stack the CLI priced exactly, this
- *      under-reports Claude Code by roughly 8%. Codex is exact, because every
- *      Codex row carries `cacheWrite: 0`.
+ *   1. A pre-#213 payload carries ONE merged `cacheWrite`. The 5m tier costs
+ *      1.25x input and the 1h tier 2.0x, and the split is gone - so everything
+ *      charges the 5m rate. Measured against a stack the CLI priced exactly,
+ *      this under-reports Claude Code by roughly 8%. Codex is exact, because
+ *      every Codex row carries `cacheWrite: 0`.
+ *
+ *      #213 put the split on the wire, and `estimateModelUSD` uses it when it
+ *      is there. That removes this source of bias for new payloads and leaves
+ *      it for old ones, which is why the "at least" framing stays: a reading
+ *      can now be exact on one row and biased low on the one beside it.
  *   2. There are no per-response timestamps. When the window straddles a
  *      repricing (`claude-sonnet-5` on 2026-09-01), the share of tokens on each
  *      side is unknowable, so the CHEAPER rate prices the whole window.
@@ -44,12 +49,23 @@ import {
   pricingTableFor,
 } from '@aistack/pricing'
 
-/** The token block on the wire - one merged `cacheWrite`, no TTL split. */
+/**
+ * The token block on the wire.
+ *
+ * `cacheWrite` is the total and is always present. `cacheWriteTtl` is the
+ * breakdown a #213 client also sends; the three sum to `cacheWrite`.
+ */
 export type WireTokens = {
   input: number
   output: number
   cacheWrite: number
   cacheRead: number
+  cacheWriteTtl?: {
+    fiveMinute: number
+    oneHour: number
+    /** Writes a harness reported with no TTL. Priced at the 5-minute rate. */
+    unsplit: number
+  }
 }
 
 export type WireModel = {
@@ -139,11 +155,19 @@ export function estimateModelUSD(
   // The multipliers are the model's vendor's, not Anthropic's - a Google cache
   // write is charged as plain input, and 1.25x there would overstate.
   const c = cacheMultipliersFor(id)
+  // With the TTL breakdown (#213) each tier pays its own rate. Without it every
+  // write pays the cheap tier, which keeps the estimate a lower bound. `unsplit`
+  // is on the 5-minute side because that is what the harness left unstated, and
+  // guessing the expensive tier is the one direction this module may not go.
+  const ttl = t.cacheWriteTtl
+  const write = ttl
+    ? (ttl.fiveMinute + ttl.unsplit) * c.write5m + ttl.oneHour * c.write1h
+    : t.cacheWrite * c.write5m
   const costs = periods.map(
     (p) =>
       (t.input * p.input +
         t.output * p.output +
-        t.cacheWrite * p.input * c.write5m +
+        write * p.input +
         t.cacheRead * p.input * c.read) /
       M
   )

--- a/convex/measured.test.ts
+++ b/convex/measured.test.ts
@@ -637,6 +637,165 @@ describe('publishForToken - the destination comes from the token', () => {
       t.mutation(internal.measured.publishForToken, { tokenId, payload: payload() }),
     ).rejects.toThrow(/no longer exists/i)
   })
+
+  // -------------------------------------------------------------------------
+  // The #213 wire: the workflow section and the publishing CLI's version
+  // -------------------------------------------------------------------------
+
+  const phaseTotals = () => ({
+    scout: 640,
+    build: 180,
+    verify: 60,
+    handoff: 50,
+    unknown: 70,
+  })
+
+  const workflow = (over: Record<string, unknown> = {}) => ({
+    aggregateVersion: 'workflow-aggregates/v1',
+    harnesses: [
+      {
+        harness: 'claude-code',
+        phase: {
+          ruleVersion: 'phase-rules/v1',
+          publishable: true,
+          sessions: 142,
+          phaseSec: phaseTotals(),
+          phaseEvents: phaseTotals(),
+          waitingSec: 12,
+          idleSec: 30,
+          unknownShare: 0.07,
+          sessionRows: [],
+        },
+        activity: [{ weekdayUtc: 5, hourUtc: 23, events: 17 }],
+      },
+    ],
+    git: {
+      testFileRuleVersion: 'test-files/v1',
+      fileTypeRuleVersion: 'file-types/v1',
+      totalCommits: 214,
+      lateNightCommits: 30,
+      additions: 9000,
+      removals: 3400,
+      changedLinesPerCommit: [40, 12],
+      testFileCommits: 5,
+      changedLinesByExtension: [{ extension: '.ts', changedLines: 500 }],
+      withheldExtensionLines: 20,
+      weekdayHourCells: [{ weekday: 5, hour: 23, commits: 3 }],
+    },
+    metrics: [
+      {
+        metricId: 'late-night-commit-share',
+        ruleVersion: 'metric-rules/v1',
+        value: 0.14,
+        band: { low: 0.05, high: 0.2 },
+        coverage: 1,
+      },
+    ],
+    ...over,
+  })
+
+  test('accepts a workflow section beside the payloads (#213)', async () => {
+    // The wire has to take the shape before anything can persist it. #218 adds
+    // the storage; until then the section is validated, bounded, and dropped,
+    // so a CLI publishing one is never refused.
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    const tokenId = await seedToken(t, { stackId })
+
+    const result = await t.mutation(internal.measured.publishForToken, {
+      tokenId,
+      payloads: [payload()],
+      workflow: workflow(),
+    })
+    expect(result.snapshotIds).toHaveLength(1)
+  })
+
+  test('refuses a workflow section that breaks its bounds (#213)', async () => {
+    // Closedness says which fields may arrive, never how long an array runs.
+    // A publish that trips this is refused whole: the gate showed the owner
+    // these exact bytes, and landing a trimmed version of them would publish
+    // something nobody approved.
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    const tokenId = await seedToken(t, { stackId })
+
+    await expect(
+      t.mutation(internal.measured.publishForToken, {
+        tokenId,
+        payloads: [payload()],
+        workflow: workflow({
+          metrics: Array.from({ length: 65 }, (_, i) => ({
+            metricId: `m-${i}`,
+            ruleVersion: 'metric-rules/v1',
+            value: 1,
+            band: { low: 0, high: 2 },
+            coverage: 1,
+          })),
+        }),
+      }),
+    ).rejects.toThrow(/workflow.metrics must hold at most 64/)
+  })
+
+  test('refuses two workflow entries claiming one harness (#213)', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    const tokenId = await seedToken(t, { stackId })
+    const one = workflow()
+
+    await expect(
+      t.mutation(internal.measured.publishForToken, {
+        tokenId,
+        payloads: [payload()],
+        workflow: { ...one, harnesses: [one.harnesses[0], one.harnesses[0]] },
+      }),
+    ).rejects.toThrow(/distinct harness/i)
+  })
+
+  test('stamps the publishing CLI version on every row of the batch (#213)', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    const tokenId = await seedToken(t, { stackId })
+
+    await t.mutation(internal.measured.publishForToken, {
+      tokenId,
+      payloads: [payload(), payload({ harness: { name: 'codex', version: null } })],
+      cliVersion: '0.8.0',
+    })
+    const rows = await t.run((ctx) => ctx.db.query('measuredSnapshots').collect())
+    expect(rows.map((r) => r.cliVersion)).toEqual(['0.8.0', '0.8.0'])
+  })
+
+  test('leaves the version absent when an older client sends none (#213)', async () => {
+    // An untagged row IS the answer: that machine is on a wire older than the
+    // field, which is the question a wire bump asks.
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    const tokenId = await seedToken(t, { stackId })
+
+    await t.mutation(internal.measured.publishForToken, {
+      tokenId,
+      payload: payload(),
+    })
+    const rows = await t.run((ctx) => ctx.db.query('measuredSnapshots').collect())
+    expect(rows[0].cliVersion).toBeUndefined()
+  })
+
+  test('drops an unreadable version rather than losing the sync (#213)', async () => {
+    // The sync is what the owner approved. A garbled version tag is not worth
+    // refusing it over - unlike the workflow section, which is measurement.
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    const tokenId = await seedToken(t, { stackId })
+
+    await t.mutation(internal.measured.publishForToken, {
+      tokenId,
+      payload: payload(),
+      cliVersion: 'nine\u0000point\u0000one',
+    })
+    const rows = await t.run((ctx) => ctx.db.query('measuredSnapshots').collect())
+    expect(rows).toHaveLength(1)
+    expect(rows[0].cliVersion).toBeUndefined()
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -1886,6 +2045,9 @@ describe('sync config', () => {
       publishCost: true,
       // #48 mirrors the same rule field-for-field: absent is on.
       reviewKeptPrivate: true,
+      // #213 makes it three (spec, "The wire"): the workflow section is a
+      // default-on opt-out too, so a stack that has never refused publishes it.
+      publishWorkflow: true,
       stackName: 'My Stack',
       // Composite, like every public stack URL - the gate prints it (#41).
       stackSlug: `my-stack-${shortId}`,
@@ -1902,6 +2064,17 @@ describe('sync config', () => {
     await t.run((ctx) => ctx.db.patch(stackId, { publishCost: false }))
     const config = await t.query(internal.measured.getSyncConfigForStack, { stackId })
     expect(config.publishCost).toBe(false)
+  })
+
+  test('the workflow switch refuses the same way cost does (#213)', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    await t.run((ctx) => ctx.db.patch(stackId, { publishWorkflow: false }))
+    const config = await t.query(internal.measured.getSyncConfigForStack, { stackId })
+    expect(config.publishWorkflow).toBe(false)
+    // The two switches are independent: refusing the workflow section says
+    // nothing about cost, and a stack that turns one off keeps the other.
+    expect(config.publishCost).toBe(true)
   })
 })
 
@@ -2292,6 +2465,36 @@ describe('GET /api/cli/sync-config', () => {
     const body = (await resp.json()) as { publishCost: boolean; stack: null }
     expect(body.publishCost).toBe(false)
     expect(body.stack).toBeNull()
+  })
+
+  test('carries the workflow switch, and fails it closed without a bearer (#213)', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    const token = `tok_${Math.random().toString(36).slice(2)}`
+    await t.run(async (ctx) =>
+      ctx.db.insert('cliTokens', {
+        tokenHash: await sha256Hex(token),
+        scopes: ['collect', 'sync'],
+        userId: USER,
+        stackId,
+        createdAt: Date.now(),
+        expiresAt: Date.now() + 90 * DAY,
+        lastUsedAt: Date.now(),
+      }),
+    )
+    const read = async (headers: Record<string, string> = {}) => {
+      const resp = await t.fetch('/api/cli/sync-config', { method: 'GET', headers })
+      return ((await resp.json()) as { publishWorkflow: boolean }).publishWorkflow
+    }
+
+    // Absent on the stack reads as opted IN, like the two switches beside it.
+    expect(await read({ Authorization: `Bearer ${token}` })).toBe(true)
+
+    await t.run((ctx) => ctx.db.patch(stackId, { publishWorkflow: false }))
+    expect(await read({ Authorization: `Bearer ${token}` })).toBe(false)
+
+    // No bearer, no stack to ask - and the direction that transmits less wins.
+    expect(await read()).toBe(false)
   })
 })
 

--- a/convex/measured.ts
+++ b/convex/measured.ts
@@ -1,5 +1,5 @@
 import { vendorModelId } from '@aistack/pricing'
-import { v } from 'convex/values'
+import { type Infer, v } from 'convex/values'
 import type { Doc, Id } from './_generated/dataModel'
 import type { MutationCtx, QueryCtx } from './_generated/server'
 import {
@@ -14,6 +14,7 @@ import {
   PublishedNameCategory,
   ReconcileAtomKind,
   SyncTrigger,
+  WorkflowSection,
 } from './schema'
 import { captureServerEvent } from './analytics'
 import { emitActivityEvent } from './activity'
@@ -228,6 +229,130 @@ function checkPayloadStrings(
 }
 
 /**
+ * The workflow section's counterpart to `checkPayloadStrings` (#213).
+ *
+ * Same two jobs: bound every client-supplied string, and bound every array a
+ * hostile client could grow without limit. The section is closed by its
+ * validator like the payload is, and closedness again says nothing about what
+ * sits inside a `v.string()` or how long an array runs.
+ *
+ * A violation REJECTS the whole publish rather than trimming the section. The
+ * gate showed the owner the exact bytes; landing a shortened version of them
+ * would publish something nobody approved.
+ *
+ * The caps are set well above real readings, not close to them. The proof run
+ * behind `phase-rules/v1` saw 464 sessions across three harnesses in a 30-day
+ * window, so a five-thousand-row cap per harness bounds the transaction without
+ * ever meeting an honest client.
+ */
+const WORKFLOW_LIMITS = {
+  harnesses: 8,
+  sessionRows: 5_000,
+  commits: 20_000,
+  /** A week of hours. Both heatmaps are keyed by (weekday, hour). */
+  cells: 7 * 24,
+  extensions: 128,
+  metrics: 64,
+  routingModels: 64,
+} as const
+
+export function checkWorkflowSection(
+  section: Infer<typeof WorkflowSection>
+): void {
+  const requireName = (value: string, where: string): void => {
+    if (!isDisplaySafeName(value)) {
+      throw new Error(
+        `${where} must be 1-${NAME_MAX} characters and carry no control or bidi characters`
+      )
+    }
+  }
+  const requireSize = (length: number, max: number, where: string): void => {
+    if (length > max) {
+      throw new Error(`${where} must hold at most ${max} entries`)
+    }
+  }
+
+  requireName(section.aggregateVersion, 'workflow.aggregateVersion')
+  requireSize(
+    section.harnesses.length,
+    WORKFLOW_LIMITS.harnesses,
+    'workflow.harnesses'
+  )
+
+  const seen = new Set<string>()
+  section.harnesses.forEach((harness, i) => {
+    const at = `workflow.harnesses[${i}]`
+    requireName(harness.harness, `${at}.harness`)
+    // One reading per harness, for the reason `publishForToken` gives about the
+    // payloads: two entries claiming the same harness make "the reading for this
+    // harness" depend on array order.
+    if (seen.has(harness.harness)) {
+      throw new Error('Each workflow harness entry must name a distinct harness')
+    }
+    seen.add(harness.harness)
+
+    if (harness.phase) {
+      requireName(harness.phase.ruleVersion, `${at}.phase.ruleVersion`)
+      requireSize(
+        harness.phase.sessionRows.length,
+        WORKFLOW_LIMITS.sessionRows,
+        `${at}.phase.sessionRows`
+      )
+    }
+    if (harness.routing) {
+      for (const side of ['main', 'subagents'] as const) {
+        requireSize(
+          harness.routing[side].length,
+          WORKFLOW_LIMITS.routingModels,
+          `${at}.routing.${side}`
+        )
+        harness.routing[side].forEach((row, j) => {
+          if (!isSanitizedModelId(row.model)) {
+            throw new Error(
+              `${at}.routing.${side}[${j}].model must be 1-${MODEL_ID_MAX} characters of A-Z a-z 0-9 . _ : -`
+            )
+          }
+        })
+      }
+    }
+    requireSize(harness.activity.length, WORKFLOW_LIMITS.cells, `${at}.activity`)
+  })
+
+  requireName(section.git.testFileRuleVersion, 'workflow.git.testFileRuleVersion')
+  requireName(section.git.fileTypeRuleVersion, 'workflow.git.fileTypeRuleVersion')
+  requireSize(
+    section.git.changedLinesPerCommit.length,
+    WORKFLOW_LIMITS.commits,
+    'workflow.git.changedLinesPerCommit'
+  )
+  requireSize(
+    section.git.changedLinesByExtension.length,
+    WORKFLOW_LIMITS.extensions,
+    'workflow.git.changedLinesByExtension'
+  )
+  section.git.changedLinesByExtension.forEach((row, i) => {
+    requireName(
+      row.extension,
+      `workflow.git.changedLinesByExtension[${i}].extension`
+    )
+  })
+  requireSize(
+    section.git.weekdayHourCells.length,
+    WORKFLOW_LIMITS.cells,
+    'workflow.git.weekdayHourCells'
+  )
+
+  requireSize(section.metrics.length, WORKFLOW_LIMITS.metrics, 'workflow.metrics')
+  section.metrics.forEach((metric, i) => {
+    requireName(metric.metricId, `workflow.metrics[${i}].metricId`)
+    requireName(metric.ruleVersion, `workflow.metrics[${i}].ruleVersion`)
+    if (metric.coverageTag !== undefined) {
+      requireName(metric.coverageTag, `workflow.metrics[${i}].coverageTag`)
+    }
+  })
+}
+
+/**
  * Shared insert path.
  *
  * A plain function, not a mutation the other mutation calls: routing this
@@ -241,7 +366,8 @@ async function insertSnapshot(
   ctx: MutationCtx,
   stackId: Id<'stacks'>,
   payload: Doc<'measuredSnapshots'>['payload'],
-  machine?: string
+  machine?: string,
+  cliVersion?: string
 ): Promise<{ snapshotId: Id<'measuredSnapshots'>; receivedAt: number }> {
   if (!SUPPORTED_SCHEMA_VERSIONS.includes(payload.schemaVersion)) {
     throw new Error(`Unsupported payload schemaVersion ${payload.schemaVersion}`)
@@ -269,6 +395,10 @@ async function insertSnapshot(
     // token to name a machine from, which is the pre-tagging state exactly, so
     // `visibleSources` treats both the same way.
     machine,
+    // Which CLI published this (#213). Absent from an older client, and that is
+    // the answer the version question wants: a row with no version is a row
+    // from before the field existed.
+    cliVersion,
     payload,
   })
   return { snapshotId, receivedAt }
@@ -1923,6 +2053,7 @@ export const getSyncConfigForStack = internalQuery({
   returns: v.object({
     publishCost: v.boolean(),
     reviewKeptPrivate: v.boolean(),
+    publishWorkflow: v.boolean(),
     stackName: v.string(),
     stackSlug: v.string(),
     optIns: OptInNames,
@@ -1944,6 +2075,9 @@ export const getSyncConfigForStack = internalQuery({
       // Same rule, same shape, deliberately (#48): absent means on, and the
       // approve gate names the switch before the first upload.
       reviewKeptPrivate: stack.reviewKeptPrivate !== false,
+      // The third bit, same rule again (#213): absent means the owner has never
+      // refused, so the workflow section publishes and the gate says so.
+      publishWorkflow: stack.publishWorkflow !== false,
       stackName: stack.name,
       // The approve gate points at `/stacks/{slug}/changes` BEFORE the first
       // send (#48 beat one), so the slug must be readable pre-publish (#41).
@@ -2346,9 +2480,8 @@ export const publishForToken = internalMutation({
   args: {
     tokenId: v.id('cliTokens'),
     /**
-     * Pre-#67 clients send exactly one payload here. Tolerated like
-     * `ResourceInput.scope` - an installed CLI keeps working until a wire
-     * bump retires the field.
+     * Pre-#67 clients send exactly one payload here. An installed CLI keeps
+     * working until a wire bump retires the field.
      */
     payload: v.optional(MeasuredPayload),
     /**
@@ -2377,6 +2510,29 @@ export const publishForToken = internalMutation({
      * nothing, and silence must not be read as a machine publishing on its own.
      */
     trigger: v.optional(SyncTrigger),
+    /**
+     * The measured workflow section (#213, spec "The wire"). ONE section per
+     * publish, beside the payloads: the Git half is per machine and the metric
+     * rows span every synced harness, so neither has a payload to sit in.
+     *
+     * Optional twice over. A pre-#213 CLI sends nothing, and a client whose
+     * owner turned `publishWorkflow` off sends nothing either - the switch is
+     * applied on the machine, so refusal and old-client look identical here, by
+     * design: there is no server-side state saying a section was withheld.
+     *
+     * ACCEPTED AND CHECKED HERE, STORED IN #218. The wire has to take the shape
+     * before anything can persist it, and the ticket that persists it also owns
+     * the fit and rotation state it feeds. Until then a section is validated,
+     * bounded, and dropped - so a CLI publishing one is never refused, and a
+     * malformed one never becomes someone else's problem to discover.
+     */
+    workflow: v.optional(WorkflowSection),
+    /**
+     * Which CLI is publishing (#213). Additive and optional like `trigger`: an
+     * older client sends nothing, and an untagged row is exactly the answer -
+     * that machine is on a wire older than this field.
+     */
+    cliVersion: v.optional(v.string()),
   },
   returns: v.object({
     snapshotIds: v.array(v.id('measuredSnapshots')),
@@ -2441,6 +2597,18 @@ export const publishForToken = internalMutation({
       .first()
     const isFirstSync = priorSnapshot === null
 
+    // Bounded on the way in, the way the payloads are (#213). It is dropped
+    // after this until #218 stores it, and a section that could not have landed
+    // must not read as accepted.
+    if (args.workflow) checkWorkflowSection(args.workflow)
+
+    // Same bar as any other name the wire carries: it is a string a client
+    // chose. An unreadable one is dropped rather than refused - the sync is what
+    // the owner approved, and a garbled version tag is not worth losing it.
+    const cliVersion = isDisplaySafeName(args.cliVersion ?? '')
+      ? args.cliVersion
+      : undefined
+
     const snapshotIds: Id<'measuredSnapshots'>[] = []
     let receivedAt = 0
     for (const payload of payloads) {
@@ -2453,7 +2621,8 @@ export const publishForToken = internalMutation({
         ctx,
         stack._id,
         payload,
-        token.name
+        token.name,
+        cliVersion
       )
       snapshotIds.push(inserted.snapshotId)
       receivedAt = inserted.receivedAt

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -68,9 +68,17 @@ const ResourcePackage = v.object({
 // send (#33 decisions 2-4); this shape is the second line, not the first.
 const MeasuredAtom = v.object({
   name: v.string(),
-  // Share, never a raw invocation count - counts are the map's designated
-  // post-P0 headroom metric and are deliberately left unspent.
   callShare: v.number(),
+  // The absolute invocation count behind the share (#213, map #121's pending
+  // wire item). Optional because a pre-#213 CLI publishes the share alone, and
+  // a share without its count is still a complete reading.
+  //
+  // The count needs its denominator to be interpretable, and the denominator is
+  // NOT the sum of the published atoms - shares are computed over every
+  // observed call, withheld ones included. `inventory.calls` carries the
+  // per-category total, so withheld calls are that total minus the published
+  // counts.
+  calls: v.optional(v.number()),
 })
 
 const MeasuredModel = v.object({
@@ -85,6 +93,23 @@ const MeasuredModel = v.object({
     output: v.number(),
     cacheWrite: v.number(),
     cacheRead: v.number(),
+    // The cache-write TTL breakdown (#213, map #121's pending wire item). The
+    // three sum to `cacheWrite`, which stays the total and stays required.
+    //
+    // Without it `convex/lib/reprice.ts` has to charge every cache write at the
+    // cheap 5-minute rate, which under-reports Claude Code by roughly 8%. The
+    // CLI has held the split since #126; only the wire merged it.
+    //
+    // ALL THREE OR NONE: an object, not three optional siblings, so a payload
+    // cannot carry half a breakdown. `unsplit` is the write total a harness
+    // reported without a TTL, and it prices at the 5-minute rate.
+    cacheWriteTtl: v.optional(
+      v.object({
+        fiveMinute: v.number(),
+        oneHour: v.number(),
+        unsplit: v.number(),
+      })
+    ),
   }),
   // Absent when publishCost is off, or when the model was not fully priced -
   // never zeroed (#33 decision 11).
@@ -131,6 +156,18 @@ const MeasuredPayloadFields = {
       subagents: v.number(),
       slashCommands: v.number(),
     }),
+    // Every observed call per category, withheld names included (#213). This is
+    // the denominator the shares were computed over, and the one the per-atom
+    // `calls` need. Optional for the same reason `calls` is.
+    calls: v.optional(
+      v.object({
+        builtinTools: v.number(),
+        mcpServers: v.number(),
+        skills: v.number(),
+        subagents: v.number(),
+        slashCommands: v.number(),
+      })
+    ),
   }),
   // Scan health (#33 decision 10). Cheap now, impossible later: snapshots are
   // immutable, so omitting this would leave a permanent hole in the history.
@@ -172,6 +209,162 @@ const MeasuredPayloadV2 = v.object({
 
 /** Immutable v1 counts and mergeable v2 sets, discriminated by version. */
 export const MeasuredPayload = v.union(MeasuredPayloadV1, MeasuredPayloadV2)
+
+// ---------------------------------------------------------------------------
+// The measured WORKFLOW section - wire format fixed by
+// docs/specs/workflow-surface.md ("The wire"), produced by
+// packages/cli/src/workflow (#219) and put on the wire by #213.
+//
+// It rides BESIDE the payloads, never inside one. Two reasons, and both are
+// structural rather than stylistic:
+//
+//   1. A payload is per harness. The Git half is per MACHINE (one repository is
+//      touched by whichever harness happened to open it), and the metric rows
+//      are computed across every synced harness at once. Neither has a harness
+//      to sit under.
+//   2. The payload validator is closed, and that closedness IS the privacy
+//      claim (#33). Widening it to hold a section with a different owner would
+//      spend the claim to save a nesting level.
+//
+// Closed the same way, for the same reason. Every field is additive and
+// optional at the body level, so a pre-#213 CLI keeps publishing and simply
+// ships no workflow section.
+// ---------------------------------------------------------------------------
+
+/** The five phase buckets, as seconds or as event counts. `unknown` is visible, never hidden. */
+const PhaseTotals = v.object({
+  scout: v.number(),
+  build: v.number(),
+  verify: v.number(),
+  handoff: v.number(),
+  unknown: v.number(),
+})
+
+/**
+ * One session's phase reading. No names, no timestamps, no session id: the
+ * start HOUR is the finest time this carries, and the rest are counts.
+ *
+ * The rows are load-bearing rather than detail. The template lead's session
+ * shares ("verify in 40% of sessions") and the playbook's medians are per
+ * session, and neither can be recovered from a harness-level total.
+ */
+const WorkflowSessionRow = v.object({
+  startHourUtc: v.number(),
+  eventCount: v.number(),
+  phaseSec: PhaseTotals,
+  phaseEvents: PhaseTotals,
+  waitingSec: v.number(),
+  idleSec: v.number(),
+  merged: v.boolean(),
+  verifyRuns: v.number(),
+  reviewRounds: v.number(),
+  openedWithScout: v.boolean(),
+})
+
+/** One harness's workflow reading, already reduced on the machine. */
+const HarnessWorkflow = v.object({
+  // A plain string, not a union of the four adapter names - the same rule
+  // `measuredSnapshots.harness` follows, so a fifth harness needs no migration.
+  harness: v.string(),
+  /**
+   * The phase playbook, ABSENT when this harness failed its own gate: the rules
+   * left more than 20% of its measured time unclassified (spec, "Phases"). The
+   * gate is per harness, so an unreadable harness holds back its own playbook
+   * and not the section.
+   */
+  phase: v.optional(
+    v.object({
+      /** The rule set that produced these numbers, e.g. `phase-rules/v1`. */
+      ruleVersion: v.string(),
+      publishable: v.boolean(),
+      sessions: v.number(),
+      phaseSec: PhaseTotals,
+      phaseEvents: PhaseTotals,
+      waitingSec: v.number(),
+      idleSec: v.number(),
+      unknownShare: v.number(),
+      sessionRows: v.array(WorkflowSessionRow),
+    })
+  ),
+  /** Main loop against subagents, by model. Absent on a harness that records no model per response. */
+  routing: v.optional(
+    v.object({
+      main: v.array(v.object({ model: v.string(), tokens: v.number() })),
+      subagents: v.array(v.object({ model: v.string(), tokens: v.number() })),
+    })
+  ),
+  /** Absent on a harness with no subagents at all, which is not the same as zero fan-out. */
+  delegation: v.optional(
+    v.object({
+      mainToolCalls: v.number(),
+      subagentToolCalls: v.number(),
+      widestFanOut: v.number(),
+      mostSubagents: v.number(),
+    })
+  ),
+  /** The week/time heatmap: one cell per weekday and UTC hour that saw an event. */
+  activity: v.array(
+    v.object({
+      weekdayUtc: v.number(),
+      hourUtc: v.number(),
+      events: v.number(),
+    })
+  ),
+})
+
+/**
+ * Local Git history, aggregated. The CLI reads only repositories that windowed
+ * sessions touched, and only counts leave the machine: no repository name, no
+ * path, no commit message, no sha.
+ */
+const GitWorkflow = v.object({
+  testFileRuleVersion: v.string(),
+  fileTypeRuleVersion: v.string(),
+  totalCommits: v.number(),
+  lateNightCommits: v.number(),
+  additions: v.number(),
+  removals: v.number(),
+  /** One entry per commit, for the log-scale dot strip. Order carries no meaning. */
+  changedLinesPerCommit: v.array(v.number()),
+  testFileCommits: v.number(),
+  /** Approved extensions only; everything else sums into `withheldExtensionLines`. */
+  changedLinesByExtension: v.array(
+    v.object({ extension: v.string(), changedLines: v.number() })
+  ),
+  withheldExtensionLines: v.number(),
+  weekdayHourCells: v.array(
+    v.object({ weekday: v.number(), hour: v.number(), commits: v.number() })
+  ),
+})
+
+/**
+ * One pool metric, as the machine measured it.
+ *
+ * FIT SPLITS BETWEEN THE MACHINE AND THE SERVER (spec, "Fit and rotation"). The
+ * CLI ships value, coverage, band and rule id and stays the only source of
+ * measured values; the server multiplies coverage by surprise, applies the
+ * rotation limit, and applies the owner's pins and hides, because the swap
+ * history and the overrides are server state. Neither half can compute the
+ * other's, so neither is duplicated here.
+ */
+const WorkflowMetric = v.object({
+  metricId: v.string(),
+  ruleVersion: v.string(),
+  value: v.number(),
+  band: v.object({ low: v.number(), high: v.number() }),
+  /** Share of synced harnesses this metric counts, 0..1. A Git metric reads 1. */
+  coverage: v.number(),
+  /** Names the harnesses counted, when not all of them record this metric. */
+  coverageTag: v.optional(v.string()),
+})
+
+export const WorkflowSection = v.object({
+  /** The aggregate shape these numbers were reduced to, e.g. `workflow-aggregates/v1`. */
+  aggregateVersion: v.string(),
+  harnesses: v.array(HarnessWorkflow),
+  git: GitWorkflow,
+  metrics: v.array(WorkflowMetric),
+})
 
 // The authored<->measured overlap is catalog slugs only (#33 decision 2), but
 // the dismissal key is kept wider than `tool` so a later surface can dismiss a
@@ -414,9 +607,11 @@ export const ResourceInput = v.object({
   group: v.string(),
   stableKey: v.string(),
   files: v.optional(v.array(ResourceFile)),
-  // Deprecated and ignored: tolerated so old published CLIs that still send
-  // scope keep working. The server discards it; nothing reads this field.
-  scope: v.optional(v.union(v.literal('global'), v.literal('project'))),
+  // `scope` is GONE (#213). It was tolerated here for old published CLIs, but a
+  // validator is the wrong place to hold wire tolerance: it made the field read
+  // as part of the contract. The HTTP edge in `httpCli.stackCollect` strips it
+  // now, next to `parseAutoSync` and `parseTrigger`, so an old CLI still
+  // publishes and the contract no longer names the field.
   upstream: v.optional(ResourceUpstream),
   pkg: v.optional(ResourcePackage),
 })
@@ -554,6 +749,13 @@ export default defineSchema({
     // survives ONLY because the approve gate names the switch before the first
     // upload, so the two hold each other up.
     reviewKeptPrivate: v.optional(v.boolean()),
+    // Whether the measured WORKFLOW section publishes (#213, spec "The wire").
+    // The third bit in the same family, and it mirrors `publishCost` field for
+    // field: absent reads as ON, and the refusal is applied CLIENT-side, so off
+    // means the section never enters the body and there is nothing to reveal
+    // server-side. The approve gate names this switch too, before the first
+    // upload, which is what a default-on opt-out has to earn.
+    publishWorkflow: v.optional(v.boolean()),
     published: v.boolean(),
     // WHO MAY AUTO-SYNC INTO THIS STACK, and how often (#100 decision 2, built
     // in #102). The permission used to live only in the machine's settings file
@@ -894,6 +1096,16 @@ export default defineSchema({
     // the payload, so it is not derivable after the fact. `convex/lib/sources.ts`
     // states what an untagged row means instead.
     machine: v.optional(v.string()),
+    // Which CLI wrote this row (#213, map #121's pending wire item). Before it,
+    // `cliVersion` reached PostHog and nothing else, so no query could answer
+    // "how many machines are still on an old wire" - the exact question every
+    // wire bump asks.
+    //
+    // Beside the payload rather than inside it, like `machine`: it describes the
+    // publisher, not the measurement, and the payload validator stays closed.
+    // Optional forever - rows written before #213 carry no version, and no
+    // backfill can invent one.
+    cliVersion: v.optional(v.string()),
     payload: MeasuredPayload,
   })
     .index('by_stack_capturedAt', ['stackId', 'capturedAt'])

--- a/packages/cli/src/harness/shared/allowlist.test.ts
+++ b/packages/cli/src/harness/shared/allowlist.test.ts
@@ -324,6 +324,27 @@ describe("loadSyncConfig", () => {
 		expect(await read(undefined)).toBe(false);
 	});
 
+	it("requires publishWorkflow to be exactly true, and defaults it off (#213)", async () => {
+		// The third switch, read the same way as the two above. An old server
+		// that has never heard of the field answers without it, and off is the
+		// right reading: it has nowhere to put the section either.
+		expect(BUNDLED_SYNC_CONFIG.publishWorkflow).toBe(false);
+
+		const read = async (value: unknown) => {
+			const loaded = await loadSyncConfig({
+				baseUrl: "https://aistack.to",
+				fetchImpl: (() =>
+					Promise.resolve(
+						jsonResponse({ ...GOOD_BODY, publishWorkflow: value }),
+					)) as unknown as typeof fetch,
+			});
+			return loaded.config.publishWorkflow;
+		};
+		expect(await read(true)).toBe(true);
+		expect(await read("yes")).toBe(false);
+		expect(await read(undefined)).toBe(false);
+	});
+
 	it("reads the server auto-sync permission, and tells absent from off", async () => {
 		// Three states, not two (#103). Absent is the ONE state a local opt-in may
 		// still seed, so it must never be folded into off.

--- a/packages/cli/src/harness/shared/allowlist.ts
+++ b/packages/cli/src/harness/shared/allowlist.ts
@@ -152,6 +152,14 @@ export type SyncConfig = {
 	 */
 	reviewKeptPrivate: boolean;
 	/**
+	 * Whether the measured workflow section publishes (#213).
+	 *
+	 * The third bit in this family and the same shape as the two above: a
+	 * stack-level preference, default on, applied here on the machine. Off means
+	 * `buildSyncBody` leaves the section out of the bytes entirely.
+	 */
+	publishWorkflow: boolean;
+	/**
 	 * The stack the bearer token is bound to - where a publish would land.
 	 *
 	 * The approve gate must name its destination BEFORE the send (#33
@@ -201,6 +209,10 @@ export const BUNDLED_SYNC_CONFIG: SyncConfig = {
 	// upload the names it is holding back. The default is ON server-side, so this
 	// costs the owner one retry and never costs them a name.
 	reviewKeptPrivate: false,
+	// Fail closed a third time (#213). A machine that could not read the switch
+	// publishes measurement and no workflow section, which costs the owner one
+	// retry and can never publish a section they had turned off.
+	publishWorkflow: false,
 	// No fetch, no destination - and the gate refuses to publish without one.
 	stack: null,
 	// No fetch, no permission either. This costs nothing on its own: `stack` is
@@ -333,6 +345,11 @@ function readSyncConfig(raw: unknown): SyncConfig | null {
 		optIns: readOptIns(obj.optIns),
 		// Anything other than an explicit `true` keeps the names on the machine.
 		reviewKeptPrivate: obj.reviewKeptPrivate === true,
+		// And anything other than an explicit `true` keeps the workflow section
+		// off the wire. An old server that has never heard of the field answers
+		// without it, and that reads as off - which is right: it has no place to
+		// put the section either.
+		publishWorkflow: obj.publishWorkflow === true,
 		stack: readStack(obj.stack),
 		autoSync: readAutoSync(obj.autoSync),
 	};
@@ -346,8 +363,8 @@ function readSyncConfig(raw: unknown): SyncConfig | null {
 export async function loadSyncConfig(opts: {
 	baseUrl: string;
 	/**
-	 * Bearer for the authenticated half: `publishCost`, `optIns`,
-	 * `reviewKeptPrivate` and the destination stack. Absent, the server answers
+	 * Bearer for the authenticated half: `publishCost`, `publishWorkflow`,
+	 * `optIns`, `reviewKeptPrivate` and the destination stack. Absent, the server answers
 	 * with the anonymous fail-closed body - same allowlist, everything else off.
 	 */
 	token?: string;

--- a/packages/cli/src/harness/shared/payload.test.ts
+++ b/packages/cli/src/harness/shared/payload.test.ts
@@ -7,6 +7,7 @@ import {
 	type TokenCounts,
 } from "@aistack/pricing";
 import { describe, expect, it } from "vitest";
+import type { WorkflowExtraction } from "../../workflow/index.js";
 import {
 	cleanName,
 	createAggregate,
@@ -58,6 +59,7 @@ const HARNESS_PARAMS = {
 
 const config = (over: Partial<SyncConfig> = {}): SyncConfig => ({
 	publishCost: true,
+	publishWorkflow: true,
 	autoSync: null,
 	allowlist: {
 		mcpServers: ["github"],
@@ -177,13 +179,40 @@ describe("fail-closed names: an invented name CANNOT reach the payload", () => {
 		);
 	});
 
-	it("never publishes a raw invocation count, only shares", () => {
-		// Counts are the map's designated post-P0 headroom metric (#33).
+	it("publishes the count beside the share, and nothing else (#213)", () => {
+		// Counts were the map's designated headroom metric under #33 and #213
+		// spends it. An atom carries exactly three fields: a share is unusable
+		// for anything absolute, and a count with no fixed shape is a blob.
 		for (const category of Object.values(payload.inventory)) {
 			if (!Array.isArray(category)) continue;
 			for (const atom of category) {
-				expect(Object.keys(atom).sort()).toEqual(["callShare", "name"]);
+				expect(Object.keys(atom).sort()).toEqual([
+					"callShare",
+					"calls",
+					"name",
+				]);
 			}
+		}
+	});
+
+	it("publishes the denominator its shares were computed over (#213)", () => {
+		// The count is only interpretable against the total it came from, and
+		// that total is NOT the sum of the published atoms - it includes every
+		// withheld call. Publishing one without the other would invite a reader
+		// to add the atoms up and call the result a complete inventory.
+		const calls = payload.inventory.calls;
+		for (const category of [
+			"builtinTools",
+			"mcpServers",
+			"skills",
+			"subagents",
+			"slashCommands",
+		] as const) {
+			const published = payload.inventory[category].reduce(
+				(sum, atom) => sum + atom.calls,
+				0,
+			);
+			expect(calls[category]).toBeGreaterThanOrEqual(published);
 		}
 	});
 });
@@ -313,6 +342,228 @@ describe("buildSyncBody - the unsealed half (#48)", () => {
 	});
 });
 
+describe("the cache-write TTL split on the wire (#213)", () => {
+	const withCacheWrites = (counts: Partial<TokenCounts>): MeasuredPayload => {
+		const agg = sharedAggregate();
+		const tokens: TokenCounts = {
+			input: 0,
+			output: 0,
+			cacheWrite5m: 0,
+			cacheWrite1h: 0,
+			cacheWriteUnsplit: 0,
+			cacheRead: 0,
+			...counts,
+		};
+		addModelUsage(agg, "claude-opus-5", tokens, null);
+		return buildPayload({
+			aggregate: agg,
+			stats: CLEAN_STATS,
+			syncConfig: config(),
+			now: NOW,
+			windowDays: 30,
+			...HARNESS_PARAMS,
+		}).payload;
+	};
+
+	it("ships the breakdown, and the three sum to the total", () => {
+		// The analyzer has held the split since #126; only the wire merged it,
+		// which forced the backend's repricer to charge every write at the cheap
+		// tier and under-report Claude Code by roughly 8%.
+		const payload = withCacheWrites({
+			cacheWrite5m: 300,
+			cacheWrite1h: 200,
+			cacheWriteUnsplit: 100,
+		});
+		const tokens = payload.models[0].tokens;
+		expect(tokens.cacheWrite).toBe(600);
+		expect(tokens.cacheWriteTtl).toEqual({
+			fiveMinute: 300,
+			oneHour: 200,
+			unsplit: 100,
+		});
+	});
+
+	it("omits the breakdown when there were no cache writes at all", () => {
+		// Three zeros state nothing the total does not already state, and an
+		// absent object is what tells a reader this harness reports no writes.
+		const payload = withCacheWrites({ input: 10, output: 5 });
+		expect(payload.models[0].tokens.cacheWrite).toBe(0);
+		expect(payload.models[0].tokens.cacheWriteTtl).toBeUndefined();
+	});
+
+	it("keeps a harness that reports no TTL entirely in `unsplit`", () => {
+		// opencode reports one cache-write figure with no tier. Splitting it by
+		// guess would hand the repricer a number nobody measured.
+		const payload = withCacheWrites({ cacheWriteUnsplit: 900 });
+		expect(payload.models[0].tokens.cacheWriteTtl).toEqual({
+			fiveMinute: 0,
+			oneHour: 0,
+			unsplit: 900,
+		});
+	});
+});
+
+describe("the workflow section on the wire (#213)", () => {
+	const built = () =>
+		buildPayload({
+			aggregate: createAggregate(),
+			stats: CLEAN_STATS,
+			syncConfig: config(),
+			now: NOW,
+			windowDays: 30,
+			...HARNESS_PARAMS,
+		});
+
+	const phaseTotals = () => ({
+		scout: 60,
+		build: 30,
+		verify: 5,
+		handoff: 3,
+		unknown: 2,
+	});
+
+	const extraction = (): WorkflowExtraction => ({
+		aggregateVersion: "workflow-aggregates/v1",
+		harnesses: [
+			{
+				aggregateVersion: "workflow-aggregates/v1",
+				harness: "claude-code",
+				phase: {
+					ruleVersion: "phase-rules/v1",
+					publishable: true,
+					sessions: 42,
+					phaseSec: phaseTotals(),
+					phaseEvents: phaseTotals(),
+					waitingSec: 4,
+					idleSec: 9,
+					unknownShare: 0.02,
+					sessionRows: [],
+				},
+				// Local-only: the per-session inputs the metric rules already
+				// reduced into `metricInputs`. The wire must not carry them.
+				facts: {
+					sessions: [{ harness: "claude-code", thinkingTokens: 1234 }],
+					activeDays: [{ date: "2026-07-24", parallelProjectCount: 2 }],
+				},
+				activity: [{ weekdayUtc: 5, hourUtc: 23, events: 17 }],
+			},
+		],
+		git: {
+			testFileRuleVersion: "test-files/v1",
+			fileTypeRuleVersion: "file-types/v1",
+			totalCommits: 12,
+			lateNightCommits: 3,
+			additions: 400,
+			removals: 120,
+			changedLinesPerCommit: [40, 12],
+			testFileCommits: 5,
+			changedLinesByExtension: [{ extension: ".ts", changedLines: 500 }],
+			withheldExtensionLines: 20,
+			weekdayHourCells: [{ weekday: 5, hour: 23, commits: 3 }],
+		},
+		metricInputs: [
+			{
+				metricId: "late-night-commit-share",
+				ruleVersion: "metric-rules/v1",
+				value: 0.25,
+				band: { low: 0.05, high: 0.2 },
+				coverage: 1,
+				coverageTag: undefined,
+			},
+		],
+	});
+
+	it("rides beside the payloads, never inside one", () => {
+		// The Git half is per MACHINE and the metric rows span every synced
+		// harness, so neither has a payload to sit in - and the closed payload
+		// validator is the privacy claim, which widening would spend.
+		const body = buildSyncBody(
+			[built()],
+			config(),
+			undefined,
+			"manual",
+			extraction(),
+		);
+		expect(body.workflow?.aggregateVersion).toBe("workflow-aggregates/v1");
+		expect(JSON.stringify(body.payloads)).not.toContain("phase-rules");
+	});
+
+	it("leaves the section out entirely when publishWorkflow is off", () => {
+		// The switch is applied here, on the machine. Off means the section is
+		// not in the bytes, so there is nothing server-side to reveal.
+		const body = buildSyncBody(
+			[built()],
+			config({ publishWorkflow: false }),
+			undefined,
+			"manual",
+			extraction(),
+		);
+		expect(body.workflow).toBeUndefined();
+		expect(JSON.stringify(body)).not.toContain("phase-rules");
+	});
+
+	it("fails closed when the config could not be fetched", () => {
+		const body = buildSyncBody(
+			[built()],
+			BUNDLED_SYNC_CONFIG,
+			undefined,
+			"manual",
+			extraction(),
+		);
+		expect(body.workflow).toBeUndefined();
+	});
+
+	it("drops the local facts half", () => {
+		// `facts` holds per-session records - thinking tokens, turn durations,
+		// effort per turn - that the CLI has already reduced into `metrics`.
+		// Shipping them too would put finer records on the wire than any surface
+		// reads, which is the opposite of what a closed section is for.
+		const body = buildSyncBody(
+			[built()],
+			config(),
+			undefined,
+			"manual",
+			extraction(),
+		);
+		expect(body.workflow?.harnesses[0]).not.toHaveProperty("facts");
+		expect(JSON.stringify(body)).not.toContain("1234");
+	});
+
+	it("omits an absent coverage tag instead of sending an empty one", () => {
+		// The server's validator takes an OPTIONAL string, so "no tag" is an
+		// absent key there, not a key holding undefined.
+		const body = buildSyncBody(
+			[built()],
+			config(),
+			undefined,
+			"manual",
+			extraction(),
+		);
+		expect(body.workflow?.metrics[0]).toEqual({
+			metricId: "late-night-commit-share",
+			ruleVersion: "metric-rules/v1",
+			value: 0.25,
+			band: { low: 0.05, high: 0.2 },
+			coverage: 1,
+		});
+	});
+
+	it("carries the publishing CLI's version beside the payloads", () => {
+		// The one operational question that had no answer: how many machines are
+		// still on an old wire. It reached PostHog and nothing else.
+		const body = buildSyncBody(
+			[built()],
+			config(),
+			undefined,
+			"manual",
+			undefined,
+			"0.8.0",
+		);
+		expect(body.cliVersion).toBe("0.8.0");
+		expect(JSON.stringify(body.payloads)).not.toContain("0.8.0");
+	});
+});
+
 describe("plugin-wrapper normalization end to end (#42 decision 5)", () => {
 	it("publishes the curated inner segment, never the plugin's name", () => {
 		const payload = build(
@@ -348,9 +599,13 @@ describe("share denominators include withheld atoms", () => {
 			),
 		]);
 		expect(payload.inventory.skills).toEqual([
-			{ name: "grilling", callShare: 0.1 },
+			{ name: "grilling", callShare: 0.1, calls: 1 },
 		]);
 		expect(payload.inventory.withheld.skills).toBe(1);
+		// The absolute figures explain the same gap the shares do (#213): ten
+		// calls were observed, one publishes by name, and nine are the withheld
+		// skill's - recoverable as a total, never as a name.
+		expect(payload.inventory.calls.skills).toBe(10);
 	});
 });
 

--- a/packages/cli/src/harness/shared/payload.ts
+++ b/packages/cli/src/harness/shared/payload.ts
@@ -14,6 +14,10 @@
 //      "reveal" server-side, because nothing was transmitted.
 
 import { baseModelId, pricingTableFor } from "@aistack/pricing";
+import type {
+	PublishableHarnessWorkflow,
+	WorkflowExtraction,
+} from "../../workflow/index.js";
 import {
 	type Aggregate,
 	cleanName,
@@ -42,6 +46,21 @@ export type PayloadModel = {
 		output: number;
 		cacheWrite: number;
 		cacheRead: number;
+		/**
+		 * The cache-write TTL breakdown (#213). The three sum to `cacheWrite`,
+		 * which stays the total.
+		 *
+		 * The analyzer has held this split since #126 and the wire merged it, so
+		 * the backend's read-time repricer had to charge every write at the cheap
+		 * 5-minute rate - about 8% low for Claude Code. Absent only when this
+		 * harness reports no cache writes at all.
+		 */
+		cacheWriteTtl?: {
+			fiveMinute: number;
+			oneHour: number;
+			/** Writes the harness reported with no TTL. Priced at the 5-minute rate. */
+			unsplit: number;
+		};
 	};
 	apiEquivalentUSD?: number;
 	/**
@@ -53,7 +72,17 @@ export type PayloadModel = {
 	pricingTable?: string;
 };
 
-export type PayloadAtom = { name: string; callShare: number };
+export type PayloadAtom = {
+	name: string;
+	callShare: number;
+	/**
+	 * The absolute invocation count behind the share (#213). Its denominator is
+	 * `inventory.calls` for the same category, NOT the sum of the published
+	 * atoms: shares are computed over every observed call, withheld ones
+	 * included, and the count keeps that property.
+	 */
+	calls: number;
+};
 
 export type PayloadInventory = {
 	builtinTools: PayloadAtom[];
@@ -63,6 +92,19 @@ export type PayloadInventory = {
 	slashCommands: PayloadAtom[];
 	/** DISTINCT names withheld per category, so the gap in the shares is explained. */
 	withheld: {
+		builtinTools: number;
+		mcpServers: number;
+		skills: number;
+		subagents: number;
+		slashCommands: number;
+	};
+	/**
+	 * Every observed call per category, withheld names included (#213) - the
+	 * denominator the shares were computed over. Withheld calls are this total
+	 * minus the published counts, so the absolute figures explain their own gap
+	 * the way `withheld` explains the shares'.
+	 */
+	calls: {
 		builtinTools: number;
 		mcpServers: number;
 		skills: number;
@@ -168,6 +210,7 @@ function buildCategory(
 		atoms: kept.map((a) => ({
 			name: a.name,
 			callShare: denominator ? round4(a.count / denominator) : 0,
+			calls: a.count,
 		})),
 		withheld,
 		keptPrivate,
@@ -190,6 +233,9 @@ type ModelGroup = {
 	input: number;
 	output: number;
 	cacheWrite: number;
+	cacheWrite5m: number;
+	cacheWrite1h: number;
+	cacheWriteUnsplit: number;
 	cacheRead: number;
 	costUSD: number;
 	unpricedTokens: number;
@@ -222,6 +268,9 @@ function groupModels(rows: readonly ModelRow[]): ModelGroup[] {
 				input: 0,
 				output: 0,
 				cacheWrite: 0,
+				cacheWrite5m: 0,
+				cacheWrite1h: 0,
+				cacheWriteUnsplit: 0,
 				cacheRead: 0,
 				costUSD: 0,
 				unpricedTokens: 0,
@@ -234,6 +283,9 @@ function groupModels(rows: readonly ModelRow[]): ModelGroup[] {
 		g.totalTokens += r.totalTokens;
 		g.input += r.tokens.input;
 		g.output += r.tokens.output;
+		g.cacheWrite5m += r.tokens.cacheWrite5m;
+		g.cacheWrite1h += r.tokens.cacheWrite1h;
+		g.cacheWriteUnsplit += r.tokens.cacheWriteUnsplit;
 		g.cacheWrite +=
 			r.tokens.cacheWrite5m +
 			r.tokens.cacheWrite1h +
@@ -262,6 +314,18 @@ function buildModels(
 				output: g.output,
 				cacheWrite: g.cacheWrite,
 				cacheRead: g.cacheRead,
+				// All three or none (#213), so a reader never sees half a
+				// breakdown. Omitted when there were no cache writes at all -
+				// three zeros state nothing the total does not already state.
+				...(g.cacheWrite > 0
+					? {
+							cacheWriteTtl: {
+								fiveMinute: g.cacheWrite5m,
+								oneHour: g.cacheWrite1h,
+								unsplit: g.cacheWriteUnsplit,
+							},
+						}
+					: {}),
 			},
 		};
 		// Absent, not zero: a partially-priced model reporting a dollar figure
@@ -353,36 +417,45 @@ export function buildPayload(input: BuildPayloadInput): BuiltPayload {
 		);
 	}
 
-	const totalToolCalls = finalized.totalToolCalls;
+	// One denominator per category, held rather than inlined: each is both the
+	// divisor for its shares and the total the payload publishes (#213), and the
+	// two must be the same number or the absolute counts would not add up.
+	const observedCalls = {
+		builtinTools: finalized.totalToolCalls,
+		mcpServers: sumCounts(finalized.mcpServers),
+		skills: sumCounts(finalized.skills),
+		subagents: sumCounts(finalized.subagents),
+		slashCommands: sumCounts(finalized.slashCommands),
+	};
 	const builtins = buildCategory(
 		finalized.tools,
 		builtinTools,
 		optIns.builtinTools,
-		totalToolCalls,
+		observedCalls.builtinTools,
 	);
 	const mcp = buildCategory(
 		finalized.mcpServers,
 		new Set(allowlist.mcpServers),
 		optIns.mcpServers,
-		sumCounts(finalized.mcpServers),
+		observedCalls.mcpServers,
 	);
 	const skills = buildCategory(
 		finalized.skills,
 		new Set(allowlist.skills),
 		optIns.skills,
-		sumCounts(finalized.skills),
+		observedCalls.skills,
 	);
 	const subagents = buildCategory(
 		finalized.subagents,
 		new Set(allowlist.subagents),
 		optIns.subagents,
-		sumCounts(finalized.subagents),
+		observedCalls.subagents,
 	);
 	const slash = buildCategory(
 		finalized.slashCommands,
 		new Set(allowlist.slashCommands),
 		optIns.slashCommands,
-		sumCounts(finalized.slashCommands),
+		observedCalls.slashCommands,
 	);
 
 	const models = buildModels(
@@ -431,6 +504,7 @@ export function buildPayload(input: BuildPayloadInput): BuiltPayload {
 				subagents: subagents.withheld,
 				slashCommands: slash.withheld,
 			},
+			calls: observedCalls,
 		},
 		coverage: {
 			filesScanned: stats.filesRead,
@@ -485,7 +559,91 @@ export type SyncBody = {
 	 * the same reason `autoSync` does: the payload validator is closed.
 	 */
 	trigger?: SyncTrigger;
+	/**
+	 * The measured workflow section (#213, spec "The wire"), one per sync.
+	 *
+	 * It rides BESIDE the payloads for two reasons a payload cannot answer: the
+	 * Git half is per machine, not per harness, and the metric rows are computed
+	 * across every synced harness at once. The closed payload validator is the
+	 * privacy claim (#33), and widening it to hold a section with a different
+	 * owner would spend that claim to save a nesting level.
+	 *
+	 * ABSENT WHEN `publishWorkflow` IS OFF. The switch is applied here, on the
+	 * machine, so refusing means the section never exists in the bytes and there
+	 * is nothing for a server to reveal.
+	 */
+	workflow?: PayloadWorkflow;
+	/**
+	 * The version of this CLI (#213).
+	 *
+	 * It answers one operational question that had no answer: how many machines
+	 * are still on an old wire. `cliVersion` reached PostHog and nothing else,
+	 * so no query over published rows could count them - which is the exact
+	 * question a wire bump asks.
+	 */
+	cliVersion?: string;
 };
+
+/**
+ * The workflow section as it goes on the wire.
+ *
+ * `WorkflowExtraction` minus its `facts`. The facts are the per-session inputs
+ * the metric rules read - effort per turn, thinking tokens, turn durations -
+ * and the CLI has already reduced them into `metrics`. Shipping them too would
+ * put finer-grained records on the wire than any surface reads, which is the
+ * opposite of what a closed section is for.
+ */
+export type PayloadWorkflow = {
+	aggregateVersion: string;
+	harnesses: Array<Omit<PublishableHarnessWorkflow, "facts">>;
+	git: WorkflowExtraction["git"];
+	metrics: PayloadWorkflowMetric[];
+};
+
+/**
+ * One pool metric on the wire.
+ *
+ * `FitInputRow` declares `coverageTag` as present-but-possibly-undefined, which
+ * is right in memory and wrong on a wire: the server's validator takes an
+ * OPTIONAL string, so "no tag" is an absent key, not a key holding undefined.
+ * `JSON.stringify` drops it either way; stating it here keeps the two ends
+ * describing the same bytes.
+ */
+export type PayloadWorkflowMetric = {
+	metricId: string;
+	ruleVersion: string;
+	value: number;
+	band: { low: number; high: number };
+	coverage: number;
+	coverageTag?: string;
+};
+
+/**
+ * Strip the local-only half and put the rest on the wire (#213).
+ *
+ * `coverageTag` is dropped when it is `undefined` rather than sent as null: the
+ * closed server validator takes an optional string, and "no tag" is an absent
+ * field there.
+ */
+export function toPayloadWorkflow(
+	extraction: WorkflowExtraction,
+): PayloadWorkflow {
+	return {
+		aggregateVersion: extraction.aggregateVersion,
+		harnesses: extraction.harnesses.map(({ facts: _local, ...rest }) => rest),
+		git: extraction.git,
+		metrics: extraction.metricInputs.map((row) => ({
+			metricId: row.metricId,
+			ruleVersion: row.ruleVersion,
+			value: row.value,
+			band: row.band,
+			coverage: row.coverage,
+			...(row.coverageTag === undefined
+				? {}
+				: { coverageTag: row.coverageTag }),
+		})),
+	};
+}
 
 /** The two ways a sync can fire. Absent on an old CLI, and that reads as manual. */
 export type SyncTrigger = "manual" | "auto";
@@ -534,14 +692,27 @@ export function buildSyncBody(
 	syncConfig: SyncConfig,
 	autoSync?: { enabled: boolean; frequencyHours: number },
 	trigger: SyncTrigger = "manual",
+	workflow?: WorkflowExtraction,
+	cliVersion?: string,
 ): SyncBody {
 	const payloads = built.map((b) => b.payload);
 	const base: SyncBody = autoSync
 		? { payloads, autoSync, trigger }
 		: { payloads, trigger };
-	if (!syncConfig.reviewKeptPrivate) return base;
+	// THE CONSENT GATE, APPLIED HERE (#213). Off means the section is not in the
+	// bytes, so it is not in the preview either and there is nothing server-side
+	// to withhold. Same shape as `reviewKeptPrivate` directly above, and same
+	// fail-closed default: a config the machine could not fetch reads as off.
+	const withWorkflow: SyncBody =
+		workflow && syncConfig.publishWorkflow
+			? { ...base, workflow: toPayloadWorkflow(workflow) }
+			: base;
+	const withVersion: SyncBody = cliVersion
+		? { ...withWorkflow, cliVersion }
+		: withWorkflow;
+	if (!syncConfig.reviewKeptPrivate) return withVersion;
 	return {
-		...base,
+		...withVersion,
 		keptPrivate: mergeKeptPrivate(built.map((b) => b.keptPrivate)),
 	};
 }

--- a/packages/cli/src/sync/server.test.ts
+++ b/packages/cli/src/sync/server.test.ts
@@ -43,6 +43,7 @@ function makeStaged(over: Partial<StagedSend> = {}): StagedSend {
 				slashCommands: [],
 			},
 			publishCost: true,
+			publishWorkflow: false,
 			autoSync: null,
 			optIns: EMPTY_KEPT as never,
 			reviewKeptPrivate: false,

--- a/packages/cli/src/sync/stage.test.ts
+++ b/packages/cli/src/sync/stage.test.ts
@@ -20,6 +20,7 @@ import {
 	windowStartMs,
 } from "../harness/shared/window.js";
 import type { HarnessAdapter } from "../harness/types.js";
+import { CLI_VERSION } from "../version.js";
 import { type StageDeps, stageId, stageSync } from "./stage.js";
 
 const NOW = Date.parse("2026-07-30T12:00:00.000Z");
@@ -27,6 +28,7 @@ const NOW = Date.parse("2026-07-30T12:00:00.000Z");
 const FETCHED: SyncConfig = {
 	allowlist: { mcpServers: [], skills: [], subagents: [], slashCommands: [] },
 	publishCost: true,
+	publishWorkflow: true,
 	optIns: EMPTY_OPT_INS,
 	reviewKeptPrivate: true,
 	stack: { name: "Alp's Daily Driver", slug: "alps-daily-driver" },
@@ -219,5 +221,44 @@ describe("stageSync", () => {
 		const staged = await stageSync(deps({ adaptersImpl: async () => [] }));
 		expect(staged.blockedReason).toContain("No active harness");
 		expect(staged.blockedReason).toContain("last 30 days");
+	});
+
+	test("stages the workflow section in the bytes the gate describes (#213)", async () => {
+		const staged = await stageSync(deps({ gitRunnerImpl: () => null }));
+		expect(staged.body.workflow?.aggregateVersion).toBe(
+			"workflow-aggregates/v1",
+		);
+		// One section per sync, not one per harness: the Git half is a property
+		// of the machine and the metric rows span every synced harness.
+		expect(staged.bodyJson).toContain('"workflow"');
+		expect(staged.summary).toContain("workflow  ");
+	});
+
+	test("skips the extraction entirely when the switch is off (#213)", async () => {
+		// The extraction shells out to `git` per touched repository. Doing that
+		// work and discarding it would be the one visible cost of a preference
+		// that is supposed to be free.
+		let gitCalls = 0;
+		const staged = await stageSync(
+			deps({
+				config: {
+					config: { ...FETCHED, publishWorkflow: false },
+					source: "fetched",
+				},
+				gitRunnerImpl: () => {
+					gitCalls++;
+					return null;
+				},
+			}),
+		);
+		expect(gitCalls).toBe(0);
+		expect(staged.body.workflow).toBeUndefined();
+		expect(staged.summary).toContain("workflow  not published");
+	});
+
+	test("stamps the publishing CLI's version on the body (#213)", async () => {
+		const staged = await stageSync(deps({ gitRunnerImpl: () => null }));
+		expect(staged.body.cliVersion).toBe(CLI_VERSION);
+		expect(staged.summary).toContain(`client    aistack ${CLI_VERSION}`);
 	});
 });

--- a/packages/cli/src/sync/stage.ts
+++ b/packages/cli/src/sync/stage.ts
@@ -43,6 +43,13 @@ import {
 	windowStartMs,
 } from "../harness/shared/window.js";
 import type { HarnessAdapter } from "../harness/types.js";
+import { CLI_VERSION } from "../version.js";
+import {
+	extractLocalWorkflow,
+	type GitWorkflowRunner,
+	type LocalHarnessWorkflow,
+	type WorkflowExtraction,
+} from "../workflow/index.js";
 import { buildGateDialog, buildGateSummary } from "./summary.js";
 
 export type StagedSend = {
@@ -76,6 +83,8 @@ export type StageDeps = {
 	}) => Promise<LoadedSyncConfig>;
 	/** Override the adapter set. Tests only. */
 	adaptersImpl?: (sinceMs: number) => Promise<HarnessAdapter[]>;
+	/** Override the Git reader the workflow extraction shells out to. Tests only. */
+	gitRunnerImpl?: GitWorkflowRunner;
 	getSettingsImpl?: () => Settings;
 	windowDays?: number;
 	/**
@@ -105,12 +114,19 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 
 	const built: BuiltPayload[] = [];
 	const scanStats: Record<string, ScanStats> = {};
+	// Collected per harness, extracted ONCE below (#213): local Git history is a
+	// property of the machine, not of whichever harness opened the repository,
+	// and the metric rows are computed across every synced harness at once.
+	const workflowScans: LocalHarnessWorkflow[] = [];
 	// One window start for detection AND for the scan (#101), so a harness that
 	// counts as detected is exactly a harness with something in the window.
 	const sinceMs = windowStartMs(now, windowDays);
 	for (const adapter of await adapters(sinceMs)) {
-		const { aggregate, stats } = await adapter.scan({ sinceMs });
+		const { aggregate, stats, workflow, workflowLocal } = await adapter.scan({
+			sinceMs,
+		});
 		scanStats[adapter.name] = stats;
+		workflowScans.push({ aggregate: workflow, local: workflowLocal });
 		built.push(
 			buildPayload({
 				aggregate,
@@ -129,7 +145,33 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 	// bytes are the bytes sent (#78). Absent from the settings file means this
 	// machine has never answered, which the backend reads as "never told us".
 	const settings = (deps.getSettingsImpl ?? getSettings)();
-	const body = buildSyncBody(built, config, settings.autoSync, deps.trigger);
+
+	// Git runs here and not inside an adapter's scan: the reducers hand back the
+	// working directories their sessions touched, and reading one repository once
+	// for all of them is both cheaper and the only way the commit counts stay
+	// right when two harnesses shared a checkout.
+	//
+	// The extraction is skipped entirely when the owner has the switch off. It
+	// shells out to `git` per repository, and running that work to throw it away
+	// would be the one visible cost of a preference that is supposed to be free.
+	const workflow: WorkflowExtraction | undefined =
+		workflowScans.length > 0 && config.publishWorkflow
+			? extractLocalWorkflow({
+					harnesses: workflowScans,
+					fromMs: sinceMs,
+					toMs: now,
+					...(deps.gitRunnerImpl ? { run: deps.gitRunnerImpl } : {}),
+				})
+			: undefined;
+
+	const body = buildSyncBody(
+		built,
+		config,
+		settings.autoSync,
+		deps.trigger,
+		workflow,
+		CLI_VERSION,
+	);
 	const bodyJson = JSON.stringify(body);
 	const keptPrivate = mergeKeptPrivate(built.map((b) => b.keptPrivate));
 

--- a/packages/cli/src/sync/summary.test.ts
+++ b/packages/cli/src/sync/summary.test.ts
@@ -10,7 +10,11 @@ import type {
 	SyncConfig,
 } from "../harness/shared/allowlist.js";
 import { EMPTY_OPT_INS } from "../harness/shared/allowlist.js";
-import type { MeasuredPayload, SyncBody } from "../harness/shared/payload.js";
+import type {
+	MeasuredPayload,
+	PayloadWorkflow,
+	SyncBody,
+} from "../harness/shared/payload.js";
 import { emptyScanStats } from "../harness/shared/window.js";
 import {
 	buildGateDialog,
@@ -63,9 +67,9 @@ function payload(over: Partial<MeasuredPayload> = {}): MeasuredPayload {
 			},
 		],
 		inventory: {
-			builtinTools: [{ name: "Bash", callShare: 0.4 }],
+			builtinTools: [{ name: "Bash", callShare: 0.4, calls: 400 }],
 			mcpServers: [],
-			skills: [{ name: "grilling", callShare: 0.1 }],
+			skills: [{ name: "grilling", callShare: 0.1, calls: 12 }],
 			subagents: [],
 			slashCommands: [],
 			withheld: {
@@ -74,6 +78,13 @@ function payload(over: Partial<MeasuredPayload> = {}): MeasuredPayload {
 				skills: 10,
 				subagents: 47,
 				slashCommands: 8,
+			},
+			calls: {
+				builtinTools: 1000,
+				mcpServers: 30,
+				skills: 120,
+				subagents: 90,
+				slashCommands: 20,
 			},
 		},
 		coverage: {
@@ -87,17 +98,84 @@ function payload(over: Partial<MeasuredPayload> = {}): MeasuredPayload {
 	};
 }
 
+/** A workflow section as `buildSyncBody` would have put it in the bytes (#213). */
+function workflow(over: Partial<PayloadWorkflow> = {}): PayloadWorkflow {
+	return {
+		aggregateVersion: "workflow-aggregates/v1",
+		harnesses: [
+			{
+				aggregateVersion: "workflow-aggregates/v1",
+				harness: "claude-code",
+				phase: {
+					ruleVersion: "phase-rules/v1",
+					publishable: true,
+					sessions: 142,
+					phaseSec: {
+						scout: 640,
+						build: 180,
+						verify: 60,
+						handoff: 50,
+						unknown: 70,
+					},
+					phaseEvents: {
+						scout: 64,
+						build: 18,
+						verify: 6,
+						handoff: 5,
+						unknown: 7,
+					},
+					waitingSec: 120,
+					idleSec: 300,
+					unknownShare: 0.07,
+					sessionRows: [],
+				},
+				activity: [{ weekdayUtc: 5, hourUtc: 23, events: 17 }],
+			},
+		],
+		git: {
+			testFileRuleVersion: "test-files/v1",
+			fileTypeRuleVersion: "file-types/v1",
+			totalCommits: 214,
+			lateNightCommits: 30,
+			additions: 9_000,
+			removals: 3_400,
+			changedLinesPerCommit: [40, 12],
+			testFileCommits: 5,
+			changedLinesByExtension: [{ extension: ".ts", changedLines: 500 }],
+			withheldExtensionLines: 20,
+			weekdayHourCells: [{ weekday: 5, hour: 23, commits: 3 }],
+		},
+		metrics: [
+			{
+				metricId: "late-night-commit-share",
+				ruleVersion: "metric-rules/v1",
+				value: 0.14,
+				band: { low: 0.05, high: 0.2 },
+				coverage: 1,
+			},
+		],
+		...over,
+	};
+}
+
 function ctx(over: {
 	payload?: Partial<MeasuredPayload>;
 	withKeptPrivateHalf?: boolean;
 	keptPrivate?: Record<NameCategory, KeptPrivateAtom[]>;
 	config?: Partial<SyncConfig>;
 	source?: "fetched" | "bundled";
+	workflow?: PayloadWorkflow;
+	cliVersion?: string;
 }): GateContext {
 	const p = payload(over.payload);
-	const body: SyncBody = over.withKeptPrivateHalf
+	const base: SyncBody = over.withKeptPrivateHalf
 		? { payloads: [p], keptPrivate: over.keptPrivate ?? NO_KEPT_PRIVATE }
 		: { payloads: [p] };
+	const body: SyncBody = {
+		...base,
+		...(over.workflow ? { workflow: over.workflow } : {}),
+		...(over.cliVersion ? { cliVersion: over.cliVersion } : {}),
+	};
 	return {
 		body,
 		keptPrivate: over.keptPrivate ?? NO_KEPT_PRIVATE,
@@ -109,6 +187,7 @@ function ctx(over: {
 				slashCommands: [],
 			},
 			publishCost: true,
+			publishWorkflow: true,
 			autoSync: null,
 			optIns: EMPTY_OPT_INS,
 			reviewKeptPrivate: false,
@@ -343,6 +422,48 @@ describe("beat one - the summary", () => {
 	test("a dollar figure never renders without its pricing table, per model either", () => {
 		const summary = buildGateSummary(ctx({ payload: { pricingTable: null } }));
 		expect(summary).not.toContain("≈$");
+	});
+});
+
+describe("the workflow section at the gate (#213)", () => {
+	test("names the section, its rule versions, and the switch", () => {
+		// The staged bytes ARE what a publish sends, so every field in them gets
+		// a line here. A default-on opt-out that the preview never mentions is
+		// not an opt-out.
+		const out = buildGateSummary(ctx({ workflow: workflow() }));
+		expect(out).toContain("workflow  1 harness · 142 sessions");
+		expect(out).toContain("workflow-aggregates/v1");
+		expect(out).toContain("phase-rules/v1");
+		expect(out).toContain("git       214 commits · 12.4k lines changed");
+		expect(out).toContain("metrics   1 measured · metric-rules/v1");
+		// It NAMES the switch without directing the owner to a control that does
+		// not exist yet - #215 builds the owner controls.
+		expect(out).toContain("Publish workflow is on for aistack.to");
+	});
+
+	test("prints the phase mix the section would publish", () => {
+		const out = buildGateSummary(ctx({ workflow: workflow() }));
+		expect(out).toContain("scout 64.0%");
+		expect(out).toContain("unknown 7.0%");
+	});
+
+	test("says so plainly when the section is not published", () => {
+		// Mirrors `cost not published`: a section the owner declined is a fact
+		// about this send, not an absence the preview can leave out.
+		const out = buildGateSummary(ctx({}));
+		expect(out).toContain("workflow  not published");
+	});
+
+	test("names the publishing CLI, because it is in the bytes", () => {
+		const out = buildGateSummary(ctx({ cliVersion: "0.8.0" }));
+		expect(out).toContain("client    aistack 0.8.0");
+	});
+
+	test("keeps beat two short - the workflow section adds no line", () => {
+		// `Accept` falls below the fold if the dialog grows (#35, 1H).
+		const dialog = buildGateDialog(ctx({ workflow: workflow() }));
+		expect(dialog.split("\n").length).toBeLessThanOrEqual(2);
+		expect(dialog).not.toContain("workflow");
 	});
 });
 

--- a/packages/cli/src/sync/summary.ts
+++ b/packages/cli/src/sync/summary.ts
@@ -18,7 +18,11 @@ import type {
 	SyncConfigSource,
 } from "../harness/shared/allowlist.js";
 import { NAME_CATEGORIES } from "../harness/shared/allowlist.js";
-import type { MeasuredPayload, SyncBody } from "../harness/shared/payload.js";
+import type {
+	MeasuredPayload,
+	PayloadWorkflow,
+	SyncBody,
+} from "../harness/shared/payload.js";
 import type { ScanStats } from "../harness/shared/window.js";
 
 export type GateContext = {
@@ -260,6 +264,62 @@ function payloadBlock(payload: MeasuredPayload, stats?: ScanStats): string[] {
 	return out;
 }
 
+const PHASE_ORDER = ["scout", "build", "verify", "handoff", "unknown"] as const;
+
+/**
+ * The workflow section, as the gate describes it (#213).
+ *
+ * Everything here is read out of `body.workflow` - the exact bytes a publish
+ * sends - for the reason the whole file exists: the person approves a sentence
+ * about the bytes, not a sentence about what the code meant to send.
+ *
+ * The last line names the switch, the way the kept-private block does. A
+ * default-on opt-out has to be visible before the first upload, or it is not an
+ * opt-out.
+ */
+function workflowBlock(workflow: PayloadWorkflow, host: string): string[] {
+	const out: string[] = [];
+	const withPlaybook = workflow.harnesses.filter((h) => h.phase);
+	const sessions = withPlaybook.reduce(
+		(a, h) => a + (h.phase?.sessions ?? 0),
+		0,
+	);
+	const ruleVersions = [
+		...new Set(withPlaybook.map((h) => h.phase?.ruleVersion ?? "")),
+	].filter(Boolean);
+
+	out.push(
+		`workflow  ${workflow.harnesses.length} harness${workflow.harnesses.length === 1 ? "" : "es"} · ${sessions} sessions · ${workflow.aggregateVersion}`,
+	);
+
+	const seconds = PHASE_ORDER.map((phase) =>
+		withPlaybook.reduce((a, h) => a + (h.phase?.phaseSec[phase] ?? 0), 0),
+	);
+	const total = seconds.reduce((a, b) => a + b, 0);
+	if (total > 0) {
+		const mix = PHASE_ORDER.map(
+			(phase, i) => `${phase} ${fmtPct((seconds[i] ?? 0) / total)}`,
+		).join(" · ");
+		out.push(`          ${mix}`);
+		out.push(`          ${ruleVersions.join(", ")}`);
+	}
+
+	const git = workflow.git;
+	out.push(
+		`git       ${git.totalCommits} commits · ${fmtTokens(git.additions + git.removals)} lines changed`,
+	);
+	out.push(
+		`metrics   ${workflow.metrics.length} measured · ${[...new Set(workflow.metrics.map((m) => m.ruleVersion))].join(", ")}`,
+	);
+	// The kept-private block points at a control the owner can click, because
+	// #48 shipped one. This line NAMES the switch and stops there: the owner
+	// control is #215's, and directions to a control that does not exist yet
+	// would be the one false sentence in a preview built to be exact. Extend
+	// this line with the location when #215 lands it.
+	out.push(`          (Publish workflow is on for ${host})`);
+	return out;
+}
+
 export function buildGateSummary(ctx: GateContext): string {
 	const { body, keptPrivate, config, source, baseUrl } = ctx;
 	const { payloads } = body;
@@ -284,6 +344,10 @@ export function buildGateSummary(ctx: GateContext): string {
 		`searched  ${HARNESS_ADAPTERS.map((a) => harnessLabel(a.name).toLowerCase()).join(", ")}`,
 	);
 
+	// Named because it travels (#213). It is one more field in the bytes, and
+	// the rule this file follows is that the preview describes what goes.
+	if (body.cliVersion) out.push(`client    aistack ${body.cliVersion}`);
+
 	// One block per detected harness, each under its own header.
 	for (const payload of payloads) {
 		const stats = ctx.scanStats?.[payload.harness.name];
@@ -291,6 +355,16 @@ export function buildGateSummary(ctx: GateContext): string {
 		out.push(...payloadBlock(payload, stats));
 	}
 	if (out[out.length - 1] === "") out.pop();
+
+	// In the bytes, so it is in the preview (#78's rule, applied to #213). Off
+	// prints as plainly as `cost not published` does, and for the same reason: a
+	// section the owner declined is a fact about this send, not an absence.
+	out.push("");
+	out.push(
+		body.workflow
+			? workflowBlock(body.workflow, host).join("\n")
+			: "workflow  not published",
+	);
 
 	const n = payloads.reduce((a, p) => a + withheldCount(p), 0);
 	if (n > 0) {


### PR DESCRIPTION
Resolves [Task: extend the sync wire with workflow and four pending fields](https://github.com/alp82/aistack/issues/213), on map [Wayfinder: Build the measured workflow surface](https://github.com/alp82/aistack/issues/200).

## The workflow section

One closed section on the sync body, beside the payloads. Two reasons it is not inside a payload: a payload is per harness, while the Git half is per machine and the metric rows are computed across every synced harness at once; and the payload validator's closedness is the privacy claim, which widening would spend.

It carries the per-harness phase reading (including `sessionRows`, which the template lead's session shares and the playbook's medians need), the Git aggregate, and one row per pool metric with value, band, coverage and rule id. The CLI's local `facts` half is stripped: those are the per-session inputs the metric rules already reduced into `metrics`, and shipping them would put finer records on the wire than any surface reads.

Validated and bounded on the way in by `checkWorkflowSection`, the workflow counterpart to `checkPayloadStrings`. **Stored in [#218](https://github.com/alp82/aistack/issues/218)** - until then a section is checked and dropped, so a CLI publishing one is never refused and a malformed one never becomes someone else's problem to discover.

## The `publishWorkflow` gate

Mirrors `publishCost` field for field: a stack-level bit, absent reads as on, applied client-side. Off means `stageSync` skips the extraction entirely (it shells out to `git` per touched repository) and the section never enters the bytes. Fails closed when the config fetch fails, like the two switches beside it.

The gate names the switch. It stops at naming it: the owner control is [#215](https://github.com/alp82/aistack/issues/215)'s, and directing someone to a control that does not exist yet would be the one false sentence in a preview built to be exact.

## The four map #121 items

| Item | Shape |
| --- | --- |
| `cliVersion` | On the sync body, stored on every snapshot row. An untagged row is the answer for a machine older than the field. |
| Cache-write split | `models[].tokens.cacheWriteTtl`, all three or none, summing to `cacheWrite`. `convex/lib/reprice.ts` now charges each tier its own rate. |
| Absolute tool counts | `calls` on every inventory atom, plus `inventory.calls` - the per-category denominator the shares were computed over, withheld calls included. |
| `ResourceInput.scope` | Retired. The tolerance for old CLIs moved to `stripRetiredResourceFields` at the HTTP edge, so the contract no longer names the field and no installed client breaks. |

## Notes

- **No migration.** Every schema change is an optional addition. `ResourceInput` is an argument validator, not a table column.
- `AGENTS.md`'s pricing note is updated: the repricer's cache-write bias is gone for new payloads, and the remaining lower-bound reason is the missing per-response timestamps.
- Verified against the running local Convex backend, not only `convexTest`: the dev push landed and `/api/cli/sync-config` serves `publishWorkflow`, failing closed without a bearer.
- 2,323 tests pass (33 new). CLI bundle builds and carries the new fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fu2UYXr1VCkMiJ4LrABeyz