### PR TITLE
Store the workflow reading and compute fit state (alp82/aistack#218)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,28 @@ components, never the library.
 * Every chart server-renders complete SVG. `ssr.test.tsx` asserts real marks, so
   a library regression fails the build instead of shipping blank charts.
 
+## Measured workflow
+
+The Workflow section on the stack page. Spec:
+[docs/specs/workflow-surface.md](docs/specs/workflow-surface.md).
+
+* **The rules are one package**: `packages/workflow-rules` (`@aistack/workflow-rules`),
+  imported by the CLI, the Convex backend, and the web app. It holds `phase-rules/v1`,
+  `metric-rules/v1`, `component-rules/v1`, `lead-templates/v1`, and the fit and rotation
+  arithmetic. Every function in it is pure, so it is where a rule change gets tested.
+* **Fit splits between the machine and the server.** The CLI measures and ships value,
+  band, coverage and rule id per pool metric. The server computes fit (coverage times
+  surprise), applies the rotation limit, and applies the owner's pins and hides.
+* **A reading is one machine's** (ADR-0009). `measuredWorkflows` holds one row per
+  (stack, machine), REPLACED on every sync rather than appended, and nothing merges two
+  machines. The Git half cannot merge (no commit identity on the wire) and a pool metric
+  has no denominator to merge on.
+* **No LLM anywhere** (ADR-0002). Every sentence the section prints comes from a fixed
+  template over measured numbers.
+* The `publishWorkflow` bit is the consent gate, and it reads at BOTH ends: the CLI skips
+  the extraction when it is off, and `getWorkflowByStackSlug` returns null for a reading
+  already stored. The presence of a stored section is not consent.
+
 ## News
 
 Everything about the news pipeline starts here.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -167,10 +167,25 @@ The opening prose of the workflow section. Fixed sentence forms over measured nu
 versioned with the metric rules. No LLM writes it.
 _Avoid_: workflow draft (the LLM draft was ruled out, see ADR-0002)
 
+**Workflow reading**:
+One machine's stored workflow section: its harness aggregates, its Git aggregate, and its
+pool metric rows. A reading is never merged with another machine's (ADR-0009).
+_Avoid_: workflow snapshot (that names the measured payload's table, not this one)
+
 **Fit**:
 The rank of a workflow row: coverage times surprise. Coverage is the share of synced
 harnesses the metric counts. Surprise is the distance from the typical band its rule
-declares.
+declares, as `distance / (distance + band width)`, so a value inside its band scores zero
+and one band width outside scores a half.
+
+**Component rule**:
+The versioned rule that gives one of the seven components a headline value and a typical
+band, so it can compete for a podium slot beside a pool metric. It derives that value from
+aggregates the machine already shipped and measures nothing new.
+
+**Row override**:
+The owner's pin or hide on one workflow row. A pin puts the row on the podium, a hide takes
+it off the public page, and either wins over the fit thresholds.
 
 **Podium**:
 The workflow section layout. The top three rows by fit render as one horizontal band,

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -48,6 +48,7 @@ import type * as lib_resourceLinks from "../lib/resourceLinks.js";
 import type * as lib_scrapers from "../lib/scrapers.js";
 import type * as lib_sources from "../lib/sources.js";
 import type * as lib_tiers from "../lib/tiers.js";
+import type * as lib_workflow from "../lib/workflow.js";
 import type * as lib_xEmbedSanitizer from "../lib/xEmbedSanitizer.js";
 import type * as lib_xPaste from "../lib/xPaste.js";
 import type * as measured from "../measured.js";
@@ -87,6 +88,7 @@ import type * as tools from "../tools.js";
 import type * as viewAnalytics from "../viewAnalytics.js";
 import type * as views from "../views.js";
 import type * as waitlist from "../waitlist.js";
+import type * as workflow from "../workflow.js";
 
 import type {
   ApiFromModules,
@@ -135,6 +137,7 @@ declare const fullApi: ApiFromModules<{
   "lib/scrapers": typeof lib_scrapers;
   "lib/sources": typeof lib_sources;
   "lib/tiers": typeof lib_tiers;
+  "lib/workflow": typeof lib_workflow;
   "lib/xEmbedSanitizer": typeof lib_xEmbedSanitizer;
   "lib/xPaste": typeof lib_xPaste;
   measured: typeof measured;
@@ -174,6 +177,7 @@ declare const fullApi: ApiFromModules<{
   viewAnalytics: typeof viewAnalytics;
   views: typeof views;
   waitlist: typeof waitlist;
+  workflow: typeof workflow;
 }>;
 
 /**

--- a/convex/lib/workflow.ts
+++ b/convex/lib/workflow.ts
@@ -1,0 +1,289 @@
+/**
+ * The measured workflow layer: what gets stored, and what gets ranked.
+ *
+ * Wayfinder ticket #218 (map #200), spec `docs/specs/workflow-surface.md`.
+ * Ticket #213 put the section on the wire and dropped it; this is where it
+ * lands and where the server's half of fit lives.
+ *
+ * THE SPLIT. "The CLI ships value, coverage, band, and rule id per row, and
+ * stays the only source of measured values. The server computes fit, applies
+ * the rotation limit, and applies the owner pins and hides, because the swap
+ * history and the owner overrides are server state" (spec). The arithmetic of
+ * fit is pure, so it lives in `@aistack/workflow-rules` with its own tests; this
+ * module holds only what needs the database.
+ *
+ * A READING IS ONE MACHINE'S (ADR-0009). Nothing here merges two machines.
+ */
+
+import {
+	buildLeadFacts,
+	buildWorkflowRows,
+	type KitReading,
+	metricRuleVersions,
+	phaseRuleVersions,
+	placeRows,
+	type PlacedRow,
+	rankWorkflowRows,
+	rotateHighlights,
+	type RotationState,
+	type RowOverrides,
+	type WorkflowReading,
+} from '@aistack/workflow-rules'
+import type { Infer } from 'convex/values'
+import type { Doc, Id } from '../_generated/dataModel'
+import type { MutationCtx, QueryCtx } from '../_generated/server'
+import type { WorkflowSection } from '../schema'
+
+export type StoredSection = Infer<typeof WorkflowSection>
+export type RowValue = { rowId: string; value: number; coverage: number }
+
+/**
+ * The size a stored section may reach before detail is dropped.
+ *
+ * Convex documents stop at 1 MiB. `checkWorkflowSection` accepts up to 5,000
+ * session rows per harness and 20,000 commits, which is far above any honest
+ * reading (the `phase-rules/v1` proof saw 464 sessions in a 30-day window) but
+ * not below the document limit. A publish must NEVER fail over section size:
+ * the owner approved a measurement, and losing all of it - the payloads
+ * included, since one mutation lands them together - to save a dot strip would
+ * be the wrong trade in every direction.
+ */
+const MAX_SECTION_BYTES = 700_000
+
+export const utcDayOf = (ms: number): string =>
+	new Date(ms).toISOString().slice(0, 10)
+
+/**
+ * Drop the heaviest detail, heaviest first, until the section fits.
+ *
+ * The commit strip goes first: it is one number per commit and pure display,
+ * and every figure computed from it (`totalCommits`, `additions`, `removals`)
+ * is a separate field that survives. Session rows go second, and that one has a
+ * cost - the lead's session shares and the playbook's medians are per session -
+ * so it drops only when the strip alone was not enough. The harness-level phase
+ * totals survive either way, and the lead drops the sentences it can no longer
+ * fill rather than printing a share over a thinner denominator.
+ */
+export function trimSectionForStorage(section: StoredSection): {
+	section: StoredSection
+	trimmed?: { commitStrip: boolean; sessionRows: boolean }
+} {
+	const size = (value: unknown): number => JSON.stringify(value).length
+	if (size(section) <= MAX_SECTION_BYTES) return { section }
+
+	const withoutStrip: StoredSection = {
+		...section,
+		git: { ...section.git, changedLinesPerCommit: [] },
+	}
+	if (size(withoutStrip) <= MAX_SECTION_BYTES) {
+		return {
+			section: withoutStrip,
+			trimmed: { commitStrip: true, sessionRows: false },
+		}
+	}
+	return {
+		section: {
+			...withoutStrip,
+			harnesses: withoutStrip.harnesses.map((harness) =>
+				harness.phase
+					? { ...harness, phase: { ...harness.phase, sessionRows: [] } }
+					: harness
+			),
+		},
+		trimmed: { commitStrip: true, sessionRows: true },
+	}
+}
+
+/** The owner's pins and hides for one stack, in the shape the rules read. */
+export async function rowOverridesForStack(
+	ctx: QueryCtx | MutationCtx,
+	stackId: Id<'stacks'>
+): Promise<RowOverrides> {
+	const rows = await ctx.db
+		.query('workflowRowOverrides')
+		.withIndex('by_stack', (q) => q.eq('stackId', stackId))
+		.collect()
+	return {
+		pinned: rows.filter((r) => r.state === 'pinned').map((r) => r.rowId),
+		hidden: rows.filter((r) => r.state === 'hidden').map((r) => r.rowId),
+	}
+}
+
+export async function workflowRowFor(
+	ctx: QueryCtx | MutationCtx,
+	stackId: Id<'stacks'>,
+	machine: string | undefined
+): Promise<Doc<'measuredWorkflows'> | null> {
+	return await ctx.db
+		.query('measuredWorkflows')
+		.withIndex('by_stack_machine', (q) =>
+			q.eq('stackId', stackId).eq('machine', machine)
+		)
+		.first()
+}
+
+export async function workflowRowsForStack(
+	ctx: QueryCtx | MutationCtx,
+	stackId: Id<'stacks'>
+): Promise<Doc<'measuredWorkflows'>[]> {
+	return await ctx.db
+		.query('measuredWorkflows')
+		.withIndex('by_stack', (q) => q.eq('stackId', stackId))
+		.collect()
+}
+
+/**
+ * The kit's inputs for one machine: skills and MCP servers, per harness.
+ *
+ * The one component fact that does not travel in the workflow section, because
+ * inventory belongs to the payload. Names here were filtered on the machine
+ * before they were sent, so nothing new is exposed by reading them.
+ */
+export function kitFromSnapshots(
+	snapshots: readonly Doc<'measuredSnapshots'>[]
+): KitReading {
+	return snapshots.map((snapshot) => ({
+		harness: snapshot.harness,
+		skills: snapshot.payload.inventory.skills,
+		mcpServers: snapshot.payload.inventory.mcpServers,
+	}))
+}
+
+export type StoreWorkflowArgs = {
+	stackId: Id<'stacks'>
+	machine: string | undefined
+	section: StoredSection
+	capturedAt: number
+	receivedAt: number
+	cliVersion: string | undefined
+	kit: KitReading
+}
+
+/**
+ * Store one machine's reading and recompute its podium.
+ *
+ * REPLACE, NOT APPEND. One row per (stack, machine), for the reasons the schema
+ * gives: the section has no trail in version 1, and it carries the finest
+ * records the wire holds.
+ *
+ * The rotation runs HERE rather than at read time because two of its three
+ * rules are about history - "at most one slot swaps per sync day" and the 25%
+ * challenger margin both compare against the last sync, not against this
+ * reading. Fit itself is recomputed on every read from the stored section, so
+ * the two never drift.
+ */
+export async function storeWorkflowSection(
+	ctx: MutationCtx,
+	args: StoreWorkflowArgs
+): Promise<Id<'measuredWorkflows'>> {
+	const existing = await workflowRowFor(ctx, args.stackId, args.machine)
+	const { section, trimmed } = trimSectionForStorage(args.section)
+
+	const previousRowValues: RowValue[] = existing?.rowValues ?? []
+	const priorValues = new Map(previousRowValues.map((r) => [r.rowId, r.value]))
+	const priorCoverage = new Map(
+		previousRowValues.map((r) => [r.rowId, r.coverage])
+	)
+
+	const { rows } = buildWorkflowRows({
+		reading: section as WorkflowReading,
+		kit: args.kit,
+	})
+	const ranked = rankWorkflowRows(rows, priorValues)
+	const rotation = rotateHighlights({
+		ranked,
+		previous: {
+			highlightRowIds: existing?.highlightRowIds ?? [],
+			...(existing?.lastSwapDayUtc === undefined
+				? {}
+				: { lastSwapDayUtc: existing.lastSwapDayUtc }),
+		},
+		overrides: await rowOverridesForStack(ctx, args.stackId),
+		today: utcDayOf(args.receivedAt),
+		priorCoverage,
+	})
+
+	const doc = {
+		stackId: args.stackId,
+		...(args.machine === undefined ? {} : { machine: args.machine }),
+		capturedAt: args.capturedAt,
+		receivedAt: args.receivedAt,
+		...(args.cliVersion === undefined ? {} : { cliVersion: args.cliVersion }),
+		section,
+		...(trimmed === undefined ? {} : { trimmed }),
+		rowValues: ranked.map((row) => ({
+			rowId: row.rowId,
+			value: row.value,
+			coverage: row.coverage,
+		})),
+		previousRowValues,
+		highlightRowIds: [...rotation.highlightRowIds],
+		...(rotation.lastSwapDayUtc === undefined
+			? {}
+			: { lastSwapDayUtc: rotation.lastSwapDayUtc }),
+	}
+
+	if (existing) {
+		await ctx.db.replace(existing._id, doc)
+		return existing._id
+	}
+	return await ctx.db.insert('measuredWorkflows', doc)
+}
+
+export type ReadWorkflowArgs = {
+	row: Doc<'measuredWorkflows'>
+	kit: KitReading
+	overrides: RowOverrides
+	/** Every synced session on this machine, gate-held harnesses included. */
+	sessionCount: number
+	/** Every synced harness on this machine, for the same reason. */
+	harnessCount: number
+}
+
+export type WorkflowReadingView = {
+	rows: PlacedRow[]
+	unknownMetricIds: string[]
+	lead: ReturnType<typeof buildLeadFacts>
+	phaseRuleVersions: string[]
+	metricRuleVersions: string[]
+	mixedRuleVersions: boolean
+}
+
+/**
+ * Everything the page derives from one stored reading.
+ *
+ * Fit is recomputed on every read rather than stored. It is a pure function of
+ * the section and the previous window's values, both of which are on the row, so
+ * a stored copy could only ever disagree with the section beside it.
+ */
+export function readWorkflowReading(args: ReadWorkflowArgs): WorkflowReadingView {
+	const reading = args.row.section as WorkflowReading
+	const { rows, unknownMetricIds } = buildWorkflowRows({
+		reading,
+		kit: args.kit,
+	})
+	const ranked = rankWorkflowRows(
+		rows,
+		new Map(args.row.previousRowValues.map((r) => [r.rowId, r.value]))
+	)
+	const state: RotationState = {
+		highlightRowIds: args.row.highlightRowIds,
+		...(args.row.lastSwapDayUtc === undefined
+			? {}
+			: { lastSwapDayUtc: args.row.lastSwapDayUtc }),
+	}
+	const phase = phaseRuleVersions(reading)
+	const metric = metricRuleVersions(reading)
+	return {
+		rows: placeRows(ranked, state, args.overrides),
+		unknownMetricIds,
+		lead: buildLeadFacts({
+			reading,
+			sessionCount: args.sessionCount,
+			harnessCount: args.harnessCount,
+		}),
+		phaseRuleVersions: phase,
+		metricRuleVersions: metric,
+		mixedRuleVersions: phase.length > 1 || metric.length > 1,
+	}
+}

--- a/convex/measured.ts
+++ b/convex/measured.ts
@@ -27,6 +27,7 @@ import {
   visibleSources,
 } from './lib/sources'
 import { extractShortId } from './lib/ids'
+import { kitFromSnapshots, storeWorkflowSection } from './lib/workflow'
 import { firstSeenMachines } from './lib/machineOrdinals'
 import { type RepricedModel, repriceSnapshot, round2 } from './lib/reprice'
 import {
@@ -418,6 +419,8 @@ export const publishSnapshot = internalMutation({
     payload: MeasuredPayload,
     /** Optional here and required nowhere: see `machine` in the schema. */
     machine: v.optional(v.string()),
+    /** The workflow section this publish carries, if any (#218). */
+    workflow: v.optional(WorkflowSection),
   },
   returns: v.object({
     snapshotId: v.id('measuredSnapshots'),
@@ -426,7 +429,28 @@ export const publishSnapshot = internalMutation({
   handler: async (ctx, args) => {
     const stack = await ctx.db.get(args.stackId)
     if (!stack) throw new Error('Stack not found')
-    return await insertSnapshot(ctx, args.stackId, args.payload, args.machine)
+    const inserted = await insertSnapshot(
+      ctx,
+      args.stackId,
+      args.payload,
+      args.machine
+    )
+    if (args.workflow) {
+      checkWorkflowSection(args.workflow)
+      const machineSnapshots = newestBySource(
+        await snapshotsForStack(ctx, args.stackId)
+      ).filter((row) => row.machine === args.machine)
+      await storeWorkflowSection(ctx, {
+        stackId: args.stackId,
+        machine: args.machine,
+        section: args.workflow,
+        capturedAt: args.payload.capturedAt,
+        receivedAt: inserted.receivedAt,
+        cliVersion: undefined,
+        kit: kitFromSnapshots(machineSnapshots),
+      })
+    }
+    return inserted
   },
 })
 
@@ -556,7 +580,7 @@ function resolveModels(
  * retention policy bounds a stack to roughly one row per source per day - the
  * collect is small by construction.
  */
-async function snapshotsForStack(
+export async function snapshotsForStack(
   ctx: QueryCtx | MutationCtx,
   stackId: Id<'stacks'>
 ): Promise<Doc<'measuredSnapshots'>[]> {
@@ -871,7 +895,7 @@ function mergedUSD(merged: {
 }
 
 /** The published stack behind a public slug, or null. */
-async function publishedStackBySlug(ctx: QueryCtx, slug: string) {
+export async function publishedStackBySlug(ctx: QueryCtx, slug: string) {
   const stack = await ctx.db
     .query('stacks')
     .withIndex('by_shortId', (q) => q.eq('shortId', extractShortId(slug)))
@@ -956,7 +980,7 @@ type MachinePublication = {
   ordinals: Map<string, number>
 }
 
-async function machinePublication(
+export async function machinePublication(
   ctx: QueryCtx,
   stack: Doc<'stacks'>
 ): Promise<MachinePublication> {
@@ -967,7 +991,7 @@ async function machinePublication(
   }
 }
 
-function publicMachine(
+export function publicMachine(
   machine: string | null,
   publication: MachinePublication
 ): { machine: string | null; machineOrdinal: number | null } {
@@ -2597,9 +2621,10 @@ export const publishForToken = internalMutation({
       .first()
     const isFirstSync = priorSnapshot === null
 
-    // Bounded on the way in, the way the payloads are (#213). It is dropped
-    // after this until #218 stores it, and a section that could not have landed
-    // must not read as accepted.
+    // Bounded on the way in, the way the payloads are (#213). Checked here
+    // rather than only inside `storeWorkflowSection` so a malformed section
+    // refuses the publish before any row is written - the same fail-fast the
+    // payload bound gets.
     if (args.workflow) checkWorkflowSection(args.workflow)
 
     // Same bar as any other name the wire carries: it is a string a client
@@ -2626,6 +2651,28 @@ export const publishForToken = internalMutation({
       )
       snapshotIds.push(inserted.snapshotId)
       receivedAt = inserted.receivedAt
+    }
+
+    // The workflow section, stored against the MACHINE (#218). One reading per
+    // machine, replaced rather than appended, and its podium recomputed here
+    // because the rotation limit compares against the last sync.
+    //
+    // After the payload inserts, deliberately: the kit component reads skills
+    // and MCP servers out of the inventory, so the reading must be ranked
+    // against the payloads that arrived with it, not the ones they replaced.
+    if (args.workflow) {
+      const machineSnapshots = newestBySource(
+        await snapshotsForStack(ctx, stack._id)
+      ).filter((row) => row.machine === token.name)
+      await storeWorkflowSection(ctx, {
+        stackId: stack._id,
+        machine: token.name,
+        section: args.workflow,
+        capturedAt: Math.max(...payloads.map((p) => p.capturedAt)),
+        receivedAt,
+        cliVersion,
+        kit: kitFromSnapshots(machineSnapshots),
+      })
     }
 
     // ONE event per approved sync, never one per snapshot: this mutation lands

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -364,6 +364,21 @@ export const WorkflowSection = v.object({
   harnesses: v.array(HarnessWorkflow),
   git: GitWorkflow,
   metrics: v.array(WorkflowMetric),
+  /**
+   * The publishing machine's offset from UTC, in minutes east (#218).
+   *
+   * Session hours travel in UTC, and the locked lead renders them in the
+   * OWNER's local time, labeled as such: "most start around 23:00 local"
+   * (spec, "The template lead"). Nothing else on the wire carries a clock, so
+   * without this the rhythm clause has nothing to convert with and drops.
+   *
+   * A single offset, not a zone name. It is what the machine's own clock said
+   * at extraction time, so a window that straddles a daylight-saving change
+   * renders every hour at the current offset. That is one hour of drift on two
+   * days a year against a figure the lead already prints as "around", and a
+   * zone name would be a second identifying string leaving the machine.
+   */
+  utcOffsetMinutes: v.optional(v.number()),
 })
 
 // The authored<->measured overlap is catalog slugs only (#33 decision 2), but
@@ -1110,6 +1125,99 @@ export default defineSchema({
   })
     .index('by_stack_capturedAt', ['stackId', 'capturedAt'])
     .index('by_stack_harness_capturedAt', ['stackId', 'harness', 'capturedAt']),
+
+  // The measured WORKFLOW layer (#218). One row per (stack, machine), REPLACED
+  // on every publish - the one place in the measured layer that is not
+  // append-only, and deliberately so.
+  //
+  // `measuredSnapshots` is append-only because the headline has a trail: a
+  // reading in March must still read the way it read in March. The workflow
+  // section has no trail in version 1 (spec, "The section"), and it carries the
+  // finest records the wire holds - one row per session, one entry per commit.
+  // Keeping every publish would grow the finest data fastest, for a surface
+  // nothing reads backwards. Replacing means a session that left the rolling
+  // window also leaves the database.
+  //
+  // ONE ROW PER MACHINE, and a reading is one machine's (ADR-0009). The Git
+  // half cannot be merged across machines - the wire carries no commit
+  // identity, so two clones of one repository would count their shared commits
+  // twice - and a pool metric's value has no denominator to merge on.
+  measuredWorkflows: defineTable({
+    stackId: v.id('stacks'),
+    // The publishing token's name, exactly like `measuredSnapshots.machine`.
+    // Absent when the token predates naming, which is one bucket of its own.
+    machine: v.optional(v.string()),
+    /** Client clock: the newest `capturedAt` among the payloads of this publish. */
+    capturedAt: v.number(),
+    /** Server clock. Freshness is judged on this one, for the #33 reason. */
+    receivedAt: v.number(),
+    cliVersion: v.optional(v.string()),
+    section: WorkflowSection,
+    /**
+     * Detail dropped to keep the row inside the document limit, and which half
+     * went. A publish must never fail over section size: the owner approved a
+     * measurement, and losing all of it to save the dot strip would be the
+     * wrong trade. Absent on every honest reading.
+     */
+    trimmed: v.optional(
+      v.object({ commitStrip: v.boolean(), sessionRows: v.boolean() })
+    ),
+    /**
+     * This reading's sixteen rows, as values only. Written so the NEXT publish
+     * has a prior window to compare against without re-deriving one from a
+     * section it has already replaced.
+     */
+    rowValues: v.array(
+      v.object({
+        rowId: v.string(),
+        value: v.number(),
+        coverage: v.number(),
+      })
+    ),
+    /**
+     * The same list from the reading before this one. Two rules need it and
+     * neither can recompute it: the fit tie-break is "movement against the
+     * prior window", and an incumbent leaves the podium at once when its
+     * coverage drops.
+     */
+    previousRowValues: v.array(
+      v.object({
+        rowId: v.string(),
+        value: v.number(),
+        coverage: v.number(),
+      })
+    ),
+    /**
+     * The podium, as the rotation limit left it at the last sync. Server state
+     * by definition: "at most one slot swaps per sync day" is a fact about the
+     * swap history, not about this reading (spec, "Fit and rotation").
+     */
+    highlightRowIds: v.array(v.string()),
+    /** UTC day of the last challenger swap. Absent until one happens. */
+    lastSwapDayUtc: v.optional(v.string()),
+  })
+    .index('by_stack', ['stackId'])
+    .index('by_stack_machine', ['stackId', 'machine']),
+
+  // The owner's pins and hides on workflow rows (#218). "The owner can pin or
+  // hide any row, and that override wins over both thresholds" (spec).
+  //
+  // KEYED ON THE STACK, NOT THE MACHINE. The choice is about the row - a number
+  // the owner wants on the podium, or one they would rather not publish - and
+  // that judgment does not change when the machine dropdown does.
+  //
+  // A TABLE AND NOT A FIELD ON `stacks`, for the #42 reason: the set is
+  // unbounded in principle (one row per rule in either pool, and both pools
+  // grow), and a hide must not ride along on every public stack read.
+  workflowRowOverrides: defineTable({
+    stackId: v.id('stacks'),
+    /** `metric:late-night-commits`, `component:git-ledger`. */
+    rowId: v.string(),
+    state: v.union(v.literal('pinned'), v.literal('hidden')),
+    setAt: v.number(),
+  })
+    .index('by_stack', ['stackId'])
+    .index('by_stack_row', ['stackId', 'rowId']),
 
   // Private registry for the public machine position (#250). The machine name
   // remains the source key on snapshots. This table only preserves the first

--- a/convex/workflow.test.ts
+++ b/convex/workflow.test.ts
@@ -1,0 +1,651 @@
+/// <reference types="vite/client" />
+import { convexTest } from 'convex-test'
+import { describe, expect, test } from 'vitest'
+import { api, internal } from './_generated/api'
+import type { Doc } from './_generated/dataModel'
+import schema from './schema'
+
+const modules = import.meta.glob('./**/*.{js,ts}')
+
+const USER = 'user_owner'
+const IDENTITY = { tokenIdentifier: `convex|${USER}`, subject: USER }
+const STRANGER = {
+  tokenIdentifier: 'convex|user_stranger',
+  subject: 'user_stranger',
+}
+
+type Ctx = Awaited<ReturnType<typeof convexTest>>
+type StoredPayload = Doc<'measuredSnapshots'>['payload']
+type Section = Doc<'measuredWorkflows'>['section']
+
+function payload(over: Record<string, unknown> = {}): StoredPayload {
+  return {
+    schemaVersion: 1,
+    capturedAt: Date.now(),
+    window: { days: 30, from: '2026-07-26', to: '2026-08-25' },
+    harness: { name: 'claude-code', version: '2.1.220' },
+    pricingTable: 'anthropic-list-2026-08-25',
+    activity: {
+      sessions: 142,
+      activeDays: 22,
+      projects: 4,
+      totalTokens: 1_000_000,
+      cacheHitShare: 0.9,
+      subagentShare: 0.3,
+    },
+    models: [
+      {
+        id: 'claude-opus-5',
+        tokenShare: 1,
+        tokens: { input: 10, output: 20, cacheWrite: 30, cacheRead: 40 },
+      },
+    ],
+    inventory: {
+      builtinTools: [{ name: 'Bash', callShare: 0.5 }],
+      mcpServers: [],
+      skills: [],
+      subagents: [],
+      slashCommands: [],
+      withheld: {
+        builtinTools: 0,
+        mcpServers: 0,
+        skills: 0,
+        subagents: 0,
+        slashCommands: 0,
+      },
+    },
+    coverage: {
+      filesScanned: 100,
+      filesUnreadable: 0,
+      linesParsed: 9_999,
+      linesFailed: 1,
+    },
+    excludedTokens: { unpriced: 0, synthetic: 0 },
+    ...over,
+  } as StoredPayload
+}
+
+const PHASE_TOTALS = {
+  scout: 640,
+  build: 180,
+  verify: 60,
+  handoff: 50,
+  unknown: 70,
+}
+
+function sessionRow(over: Record<string, unknown> = {}) {
+  return {
+    startHourUtc: 21,
+    eventCount: 40,
+    phaseSec: { ...PHASE_TOTALS },
+    phaseEvents: { scout: 30, build: 10, verify: 2, handoff: 1, unknown: 1 },
+    waitingSec: 20,
+    idleSec: 5,
+    merged: false,
+    verifyRuns: 1,
+    reviewRounds: 1,
+    openedWithScout: true,
+    ...over,
+  }
+}
+
+/** A section shaped exactly like the wire's, with one measured pool metric. */
+function section(over: Partial<Section> = {}): Section {
+  return {
+    aggregateVersion: 'workflow-aggregates/v1',
+    utcOffsetMinutes: 120,
+    harnesses: [
+      {
+        harness: 'claude-code',
+        phase: {
+          ruleVersion: 'phase-rules/v1',
+          publishable: true,
+          sessions: 2,
+          phaseSec: { ...PHASE_TOTALS },
+          phaseEvents: {
+            scout: 60,
+            build: 20,
+            verify: 6,
+            handoff: 5,
+            unknown: 7,
+          },
+          waitingSec: 30,
+          idleSec: 10,
+          unknownShare: 0.07,
+          sessionRows: [sessionRow(), sessionRow()],
+        },
+        activity: [{ weekdayUtc: 1, hourUtc: 21, events: 40 }],
+      },
+    ],
+    git: {
+      testFileRuleVersion: 'test-file-rules/v1',
+      fileTypeRuleVersion: 'file-type-rules/v1',
+      totalCommits: 20,
+      lateNightCommits: 9,
+      additions: 800,
+      removals: 200,
+      changedLinesPerCommit: [50, 50],
+      testFileCommits: 4,
+      changedLinesByExtension: [{ extension: '.ts', changedLines: 900 }],
+      withheldExtensionLines: 100,
+      weekdayHourCells: [{ weekday: 1, hour: 23, commits: 9 }],
+    },
+    metrics: [
+      {
+        metricId: 'late-night-commits',
+        ruleVersion: 'metric-rules/v1',
+        value: 0.45,
+        band: { low: 0, high: 0.15 },
+        coverage: 1,
+      },
+    ],
+    ...over,
+  } as Section
+}
+
+async function seedStack(
+  t: Ctx,
+  opts: { published?: boolean; publishWorkflow?: boolean } = {},
+) {
+  return await t.run(async (ctx) => {
+    const creatorId = await ctx.db.insert('creators', {
+      name: 'Owner',
+      slug: `owner-${Math.random().toString(36).slice(2, 8)}`,
+      userId: USER,
+      verified: false,
+      personalPages: [],
+      projectPages: [],
+      createdAt: Date.now(),
+    })
+    const stackId = await ctx.db.insert('stacks', {
+      name: 'My Stack',
+      slug: 'my-stack',
+      shortId: `sid${Math.random().toString(36).slice(2, 8)}`,
+      creatorId,
+      oneLiner: 'A stack',
+      toolSubscriptions: [],
+      hasUsageComponent: false,
+      published: opts.published ?? true,
+      ...(opts.publishWorkflow === undefined
+        ? {}
+        : { publishWorkflow: opts.publishWorkflow }),
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    })
+    const stack = await ctx.db.get(stackId)
+    return { stackId, slug: `${stack?.slug}-${stack?.shortId}` }
+  })
+}
+
+async function publish(
+  t: Ctx,
+  stackId: Doc<'stacks'>['_id'],
+  opts: {
+    machine?: string
+    workflow?: Section
+    payload?: StoredPayload
+  } = {},
+) {
+  await t.mutation(internal.measured.publishSnapshot, {
+    stackId,
+    payload: opts.payload ?? payload(),
+    ...(opts.machine === undefined ? {} : { machine: opts.machine }),
+    workflow: opts.workflow ?? section(),
+  })
+}
+
+describe('storing a workflow section', () => {
+  test('a publish stores one reading against the machine that sent it', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    await publish(t, stackId, { machine: 'laptop' })
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query('measuredWorkflows').collect(),
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      machine: 'laptop',
+      section: expect.objectContaining({
+        aggregateVersion: 'workflow-aggregates/v1',
+      }),
+    })
+  })
+
+  test('a second sync replaces the reading rather than appending one', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    await publish(t, stackId, { machine: 'laptop' })
+    await publish(t, stackId, {
+      machine: 'laptop',
+      workflow: section({
+        metrics: [
+          {
+            metricId: 'late-night-commits',
+            ruleVersion: 'metric-rules/v1',
+            value: 0.6,
+            band: { low: 0, high: 0.15 },
+            coverage: 1,
+          },
+        ],
+      }),
+    })
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query('measuredWorkflows').collect(),
+    )
+    expect(rows).toHaveLength(1)
+    // The replaced reading survives only as the values the movement tie-break
+    // compares against.
+    expect(rows[0]?.previousRowValues).toContainEqual({
+      rowId: 'metric:late-night-commits',
+      value: 0.45,
+      coverage: 1,
+    })
+    expect(rows[0]?.rowValues).toContainEqual({
+      rowId: 'metric:late-night-commits',
+      value: 0.6,
+      coverage: 1,
+    })
+  })
+
+  test('two machines keep two readings, because a reading is one machine’s', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    await publish(t, stackId, { machine: 'laptop' })
+    await publish(t, stackId, { machine: 'vps' })
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query('measuredWorkflows').collect(),
+    )
+    expect(rows.map((row) => row.machine).sort()).toEqual(['laptop', 'vps'])
+  })
+
+  test('the podium is computed at the sync and stored', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    await publish(t, stackId, { machine: 'laptop' })
+
+    const row = await t.run(async (ctx) =>
+      ctx.db.query('measuredWorkflows').first(),
+    )
+    expect(row?.highlightRowIds).toHaveLength(3)
+    // Nothing has been displaced yet, so no swap has been spent.
+    expect(row?.lastSwapDayUtc).toBeUndefined()
+  })
+
+  test('a section too large to store drops its heaviest detail instead of failing the sync', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    const heavy = section()
+    const harness = heavy.harnesses[0]
+    if (harness?.phase) {
+      harness.phase.sessionRows = Array.from({ length: 4_000 }, () =>
+        sessionRow(),
+      )
+    }
+
+    await publish(t, stackId, { machine: 'laptop', workflow: heavy })
+
+    const row = await t.run(async (ctx) =>
+      ctx.db.query('measuredWorkflows').first(),
+    )
+    expect(row?.trimmed).toEqual({ commitStrip: true, sessionRows: true })
+    expect(row?.section.harnesses[0]?.phase?.sessionRows).toEqual([])
+    // The harness-level totals are what the trim protects.
+    expect(row?.section.harnesses[0]?.phase?.phaseSec.scout).toBe(640)
+  })
+
+  test('a malformed section refuses the publish, and nothing lands', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+
+    await expect(
+      publish(t, stackId, {
+        machine: 'laptop',
+        workflow: section({ aggregateVersion: '' }),
+      }),
+    ).rejects.toThrow(/aggregateVersion/)
+    expect(
+      await t.run(async (ctx) => ctx.db.query('measuredSnapshots').collect()),
+    ).toHaveLength(0)
+  })
+})
+
+describe('reading the section', () => {
+  test('a stack that never synced a workflow has no section', async () => {
+    const t = convexTest(schema, modules)
+    const { slug, stackId } = await seedStack(t)
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payload(),
+    })
+    expect(
+      await t.query(api.workflow.getWorkflowByStackSlug, { slug }),
+    ).toBeNull()
+  })
+
+  test('the reading ranks sixteen rows into the podium, the rest, and the fold', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, slug } = await seedStack(t)
+    await publish(t, stackId, { machine: 'laptop' })
+
+    const view = await t.query(api.workflow.getWorkflowByStackSlug, { slug })
+    expect(view?.rows.filter((r) => r.placement === 'highlight')).toHaveLength(3)
+    // Fit falls monotonically down the row order.
+    const fits = view?.rows.map((r) => r.fit) ?? []
+    expect([...fits].sort((a, b) => b - a)).toEqual(fits)
+    // The one measured pool metric is on the podium: 0.45 against a 0 to 0.15
+    // band is far outside it, at full coverage.
+    const nightly = view?.rows.find(
+      (r) => r.rowId === 'metric:late-night-commits',
+    )
+    expect(nightly?.surprise).toBeCloseTo(0.3 / 0.45, 10)
+    expect(nightly?.fit).toBeCloseTo(0.3 / 0.45, 10)
+    expect(nightly?.movement).toBeNull()
+  })
+
+  test('the lead facts count every synced session, gate-held harnesses included', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, slug } = await seedStack(t)
+    await publish(t, stackId, { machine: 'laptop' })
+
+    const view = await t.query(api.workflow.getWorkflowByStackSlug, { slug })
+    expect(view?.lead).toMatchObject({
+      sessionCount: 142,
+      harnessCount: 1,
+      playbookHarnessCount: 1,
+      // 21:00 UTC on a machine two hours east.
+      modalStartHourOwnerLocal: 23,
+      ruleVersion: 'phase-rules/v1',
+    })
+    expect(view?.lead.phaseShare?.scout).toBeCloseTo(0.64, 10)
+    expect(view?.mixedRuleVersions).toBe(false)
+  })
+
+  test('a reading classified by two rule sets is tagged as mixed', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, slug } = await seedStack(t)
+    const twoVersions = section()
+    const first = twoVersions.harnesses[0]
+    twoVersions.harnesses = [
+      first,
+      {
+        ...first,
+        harness: 'codex',
+        phase: { ...first?.phase, ruleVersion: 'phase-rules/v2' },
+      },
+    ] as Section['harnesses']
+
+    await publish(t, stackId, { machine: 'laptop', workflow: twoVersions })
+    const view = await t.query(api.workflow.getWorkflowByStackSlug, { slug })
+    expect(view?.mixedRuleVersions).toBe(true)
+    expect(view?.phaseRuleVersions).toEqual([
+      'phase-rules/v1',
+      'phase-rules/v2',
+    ])
+    expect(view?.lead.ruleVersion).toBe('phase-rules/v1 · phase-rules/v2')
+  })
+
+  test('an unpublished machine name is withheld, and its position still addresses it', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, slug } = await seedStack(t)
+    await publish(t, stackId, { machine: 'laptop' })
+
+    const view = await t.query(api.workflow.getWorkflowByStackSlug, { slug })
+    expect(view?.machine).toBeNull()
+    expect(view?.machineOrdinal).toBe(1)
+
+    const byOrdinal = await t.query(api.workflow.getWorkflowByStackSlug, {
+      slug,
+      machineOrdinal: 1,
+    })
+    expect(byOrdinal?.receivedAt).toBe(view?.receivedAt)
+    expect(
+      await t.query(api.workflow.getWorkflowByStackSlug, {
+        slug,
+        machineOrdinal: 9,
+      }),
+    ).toBeNull()
+  })
+
+  test('the owner sees the machine name the public read withholds', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, slug } = await seedStack(t)
+    await publish(t, stackId, { machine: 'laptop' })
+
+    const view = await t
+      .withIdentity(IDENTITY)
+      .query(api.workflow.getWorkflowByStackSlug, { slug })
+    expect(view?.machine).toBe('laptop')
+    expect(view?.isOwner).toBe(true)
+  })
+
+  test('the default reading is the machine that synced last, and the rest are listed', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, slug } = await seedStack(t)
+    await publish(t, stackId, { machine: 'laptop' })
+    await publish(t, stackId, { machine: 'vps' })
+    // Both landed inside one millisecond here, which no pair of real syncs does.
+    await t.run(async (ctx) => {
+      const vps = (await ctx.db.query('measuredWorkflows').collect()).find(
+        (row) => row.machine === 'vps',
+      )
+      if (vps) await ctx.db.patch(vps._id, { receivedAt: vps.receivedAt + 1_000 })
+    })
+
+    const view = await t
+      .withIdentity(IDENTITY)
+      .query(api.workflow.getWorkflowByStackSlug, { slug })
+    expect(view?.machine).toBe('vps')
+    expect(view?.machines.map((m) => m.machine)).toEqual(['vps', 'laptop'])
+    expect(view?.machines.filter((m) => m.isCurrent)).toHaveLength(1)
+  })
+
+  test('turning the workflow switch off hides the reading already sent', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, slug } = await seedStack(t)
+    await publish(t, stackId, { machine: 'laptop' })
+    await t.run(async (ctx) =>
+      ctx.db.patch(stackId, { publishWorkflow: false }),
+    )
+
+    expect(
+      await t.query(api.workflow.getWorkflowByStackSlug, { slug }),
+    ).toBeNull()
+    expect(
+      await t
+        .withIdentity(IDENTITY)
+        .query(api.workflow.getWorkflowByStackSlug, { slug }),
+    ).toBeNull()
+  })
+
+  test('a draft stack publishes no reading', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, slug } = await seedStack(t, { published: false })
+    await publish(t, stackId, { machine: 'laptop' })
+    expect(
+      await t.query(api.workflow.getWorkflowByStackSlug, { slug }),
+    ).toBeNull()
+  })
+
+  test('the kit reads skills out of the payload inventory', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, slug } = await seedStack(t)
+    await publish(t, stackId, {
+      machine: 'laptop',
+      payload: payload({
+        inventory: {
+          ...(payload().inventory as Record<string, unknown>),
+          skills: [
+            { name: 'grilling', callShare: 0.24 },
+            { name: 'tdd', callShare: 0.16 },
+          ],
+        },
+      }),
+    })
+
+    const view = await t.query(api.workflow.getWorkflowByStackSlug, { slug })
+    const kit = view?.rows.find((r) => r.rowId === 'component:kit')
+    expect(kit?.value).toBeCloseTo(0.6, 10)
+    expect(kit?.coverage).toBe(1)
+  })
+})
+
+describe('the owner controls', () => {
+  test('a pin puts a low-fit row on the podium', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, slug } = await seedStack(t)
+    await publish(t, stackId, { machine: 'laptop' })
+
+    const before = await t.query(api.workflow.getWorkflowByStackSlug, { slug })
+    const folded = before?.rows.find((r) => r.placement !== 'highlight')
+    expect(folded).toBeDefined()
+
+    await t.withIdentity(IDENTITY).mutation(api.workflow.setWorkflowRowOverride, {
+      stackId,
+      rowId: folded?.rowId as string,
+      state: 'pinned',
+    })
+
+    const after = await t.query(api.workflow.getWorkflowByStackSlug, { slug })
+    const pinned = after?.rows.find((r) => r.rowId === folded?.rowId)
+    expect(pinned?.placement).toBe('highlight')
+    expect(pinned?.pinned).toBe(true)
+    expect(after?.rows.filter((r) => r.placement === 'highlight')).toHaveLength(
+      3,
+    )
+  })
+
+  test('a hidden row leaves the public page and stays in the owner’s own view', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, slug } = await seedStack(t)
+    await publish(t, stackId, { machine: 'laptop' })
+
+    await t.withIdentity(IDENTITY).mutation(api.workflow.setWorkflowRowOverride, {
+      stackId,
+      rowId: 'component:git-ledger',
+      state: 'hidden',
+    })
+
+    const publicView = await t.query(api.workflow.getWorkflowByStackSlug, {
+      slug,
+    })
+    expect(
+      publicView?.rows.some((r) => r.rowId === 'component:git-ledger'),
+    ).toBe(false)
+
+    const ownerView = await t
+      .withIdentity(IDENTITY)
+      .query(api.workflow.getWorkflowByStackSlug, { slug })
+    expect(
+      ownerView?.rows.find((r) => r.rowId === 'component:git-ledger')?.hidden,
+    ).toBe(true)
+  })
+
+  test('clearing an override puts the row back', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, slug } = await seedStack(t)
+    await publish(t, stackId, { machine: 'laptop' })
+    const as = t.withIdentity(IDENTITY)
+
+    await as.mutation(api.workflow.setWorkflowRowOverride, {
+      stackId,
+      rowId: 'component:git-ledger',
+      state: 'hidden',
+    })
+    const cleared = await as.mutation(api.workflow.setWorkflowRowOverride, {
+      stackId,
+      rowId: 'component:git-ledger',
+      state: null,
+    })
+    expect(cleared).toEqual({ pinned: [], hidden: [] })
+
+    const view = await t.query(api.workflow.getWorkflowByStackSlug, { slug })
+    expect(view?.rows.some((r) => r.rowId === 'component:git-ledger')).toBe(true)
+  })
+
+  test('a fourth pin is refused, because there is no fourth slot to promise', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    await publish(t, stackId, { machine: 'laptop' })
+    const as = t.withIdentity(IDENTITY)
+
+    for (const rowId of [
+      'component:git-ledger',
+      'component:delegation',
+      'component:kit',
+    ]) {
+      await as.mutation(api.workflow.setWorkflowRowOverride, {
+        stackId,
+        rowId,
+        state: 'pinned',
+      })
+    }
+    await expect(
+      as.mutation(api.workflow.setWorkflowRowOverride, {
+        stackId,
+        rowId: 'component:phase-playbook',
+        state: 'pinned',
+      }),
+    ).rejects.toThrow(/podium holds 3 rows/)
+  })
+
+  test('a row id no rule pool declares is refused', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    await publish(t, stackId, { machine: 'laptop' })
+
+    await expect(
+      t.withIdentity(IDENTITY).mutation(api.workflow.setWorkflowRowOverride, {
+        stackId,
+        rowId: 'metric:whatever-i-like',
+        state: 'hidden',
+      }),
+    ).rejects.toThrow(/Unknown workflow row/)
+  })
+
+  test('a stranger cannot pin or hide anything', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    await publish(t, stackId, { machine: 'laptop' })
+
+    await expect(
+      t.withIdentity(STRANGER).mutation(api.workflow.setWorkflowRowOverride, {
+        stackId,
+        rowId: 'component:git-ledger',
+        state: 'hidden',
+      }),
+    ).rejects.toThrow(/Not authorized/)
+    await expect(
+      t.mutation(api.workflow.setWorkflowRowOverride, {
+        stackId,
+        rowId: 'component:git-ledger',
+        state: 'hidden',
+      }),
+    ).rejects.toThrow(/Not authenticated/)
+  })
+
+  test('a hidden incumbent leaves the podium at the next sync too', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    await publish(t, stackId, { machine: 'laptop' })
+
+    const before = await t.run(async (ctx) =>
+      ctx.db.query('measuredWorkflows').first(),
+    )
+    const incumbent = before?.highlightRowIds[0] as string
+    await t.withIdentity(IDENTITY).mutation(api.workflow.setWorkflowRowOverride, {
+      stackId,
+      rowId: incumbent,
+      state: 'hidden',
+    })
+    await publish(t, stackId, { machine: 'laptop' })
+
+    const after = await t.run(async (ctx) =>
+      ctx.db.query('measuredWorkflows').first(),
+    )
+    expect(after?.highlightRowIds).not.toContain(incumbent)
+    expect(after?.highlightRowIds).toHaveLength(3)
+  })
+})

--- a/convex/workflow.ts
+++ b/convex/workflow.ts
@@ -1,0 +1,329 @@
+/**
+ * The measured Workflow section: one read, one owner control.
+ *
+ * Wayfinder ticket #218 (map #200), spec `docs/specs/workflow-surface.md`. The
+ * storage and the ranking live in `convex/lib/workflow.ts`; this file is the
+ * public surface over them.
+ *
+ * WHAT THE PAGE GETS. One machine's reading, ranked into the podium the spec
+ * describes, plus the stored aggregates the seven components draw. The section
+ * on the page (#215) renders this answer and computes nothing of its own except
+ * the template lead's sentences, which it builds from `lead` through
+ * `renderLeadSentences` in `@aistack/workflow-rules`.
+ */
+
+import {
+	COMPONENT_RULES,
+	componentRowId,
+	MAX_PINS,
+	METRIC_RULES,
+	metricRowId,
+} from '@aistack/workflow-rules'
+import { v } from 'convex/values'
+import type { Doc } from './_generated/dataModel'
+import { mutation, query } from './_generated/server'
+import {
+	machinePublication,
+	publicMachine,
+	publishedStackBySlug,
+	requireStackOwner,
+	snapshotsForStack,
+} from './measured'
+import { newestPerSource } from './lib/sources'
+import {
+	kitFromSnapshots,
+	readWorkflowReading,
+	rowOverridesForStack,
+	workflowRowsForStack,
+} from './lib/workflow'
+import { WorkflowSection } from './schema'
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
+
+/** Every row id either rule pool can produce. A pin or a hide must name one. */
+const KNOWN_ROW_IDS: ReadonlySet<string> = new Set([
+	...METRIC_RULES.map((rule) => metricRowId(rule.id)),
+	...COMPONENT_RULES.map((rule) => componentRowId(rule.id)),
+])
+
+const PhaseShare = v.object({
+	scout: v.number(),
+	build: v.number(),
+	verify: v.number(),
+	handoff: v.number(),
+	unknown: v.number(),
+})
+
+/**
+ * The five figures the template lead prints.
+ *
+ * OPTIONAL RATHER THAN NULLABLE, unlike the rest of this file's read shapes:
+ * this object is `PhaseLeadFacts` from `@aistack/workflow-rules`, and the lead
+ * drops a sentence whose fact is ABSENT. A null would have to be mapped back to
+ * absent by every caller, and the first one to forget prints a sentence about a
+ * measurement nobody made.
+ */
+const LeadFacts = v.object({
+	sessionCount: v.number(),
+	harnessCount: v.number(),
+	playbookHarnessCount: v.number(),
+	phaseShare: v.optional(PhaseShare),
+	verifySessionShare: v.optional(v.number()),
+	handoffSessionShare: v.optional(v.number()),
+	modalStartHourOwnerLocal: v.optional(v.number()),
+	ruleVersion: v.optional(v.string()),
+})
+
+const WorkflowRow = v.object({
+	rowId: v.string(),
+	kind: v.union(v.literal('metric'), v.literal('component')),
+	ruleId: v.string(),
+	ruleVersion: v.string(),
+	label: v.string(),
+	unit: v.union(
+		v.literal('share'),
+		v.literal('count'),
+		v.literal('minutes')
+	),
+	value: v.number(),
+	band: v.object({ low: v.number(), high: v.number() }),
+	coverage: v.number(),
+	coverageTag: v.union(v.string(), v.null()),
+	/** Distance outside the typical band, 0..1. */
+	surprise: v.number(),
+	/** Coverage times surprise. */
+	fit: v.number(),
+	/** Distance travelled since the previous reading. Null on a first sync. */
+	movement: v.union(v.number(), v.null()),
+	placement: v.union(
+		v.literal('highlight'),
+		v.literal('normal'),
+		v.literal('low')
+	),
+	pinned: v.boolean(),
+	/** Only ever true in the owner's own view: a public read drops hidden rows. */
+	hidden: v.boolean(),
+})
+
+const WorkflowView = v.object({
+	/** The published machine name, null when withheld or untagged. */
+	machine: v.union(v.string(), v.null()),
+	machineOrdinal: v.union(v.number(), v.null()),
+	/** Every machine with a stored reading, for the section's own selector. */
+	machines: v.array(
+		v.object({
+			machine: v.union(v.string(), v.null()),
+			machineOrdinal: v.union(v.number(), v.null()),
+			receivedAt: v.number(),
+			isCurrent: v.boolean(),
+		})
+	),
+	capturedAt: v.number(),
+	receivedAt: v.number(),
+	isFresh: v.boolean(),
+	cliVersion: v.union(v.string(), v.null()),
+	aggregateVersion: v.string(),
+	/** Minutes east of UTC on the publishing machine. Null on a reading without one. */
+	utcOffsetMinutes: v.union(v.number(), v.null()),
+	/** Detail dropped at store time to stay inside the document limit. */
+	trimmed: v.union(
+		v.object({ commitStrip: v.boolean(), sessionRows: v.boolean() }),
+		v.null()
+	),
+	phaseRuleVersions: v.array(v.string()),
+	metricRuleVersions: v.array(v.string()),
+	/** True when this reading carries aggregates from more than one rule set. */
+	mixedRuleVersions: v.boolean(),
+	lead: LeadFacts,
+	rows: v.array(WorkflowRow),
+	/** Metric ids this build has no rule for, dropped rather than printed bare. */
+	unknownMetricIds: v.array(v.string()),
+	/** UTC day of the last challenger swap. Null until one happens. */
+	lastSwapDayUtc: v.union(v.string(), v.null()),
+	/** True when the caller owns the stack, so hidden rows are in `rows`. */
+	isOwner: v.boolean(),
+	/** The stored aggregates the seven components render. */
+	section: WorkflowSection,
+})
+
+/**
+ * One published stack's measured workflow reading, by public slug.
+ *
+ * A READING IS ONE MACHINE'S (ADR-0009). Without `machineOrdinal` the answer is
+ * the machine that synced most recently; with it, that machine's own reading.
+ * Nothing merges: the Git half cannot (the wire carries no commit identity, so
+ * two clones of one repository would count their shared commits twice) and a
+ * pool metric has no denominator to merge on.
+ */
+export const getWorkflowByStackSlug = query({
+	args: { slug: v.string(), machineOrdinal: v.optional(v.number()) },
+	returns: v.union(WorkflowView, v.null()),
+	handler: async (ctx, args) => {
+		const stack = await publishedStackBySlug(ctx, args.slug)
+		if (!stack) return null
+
+		// The flag is the gate, not the presence of a stored section (#93's rule,
+		// applied to this switch). An owner who turned the workflow off after a
+		// sync has turned it off for the reading already sent.
+		if (stack.publishWorkflow === false) return null
+
+		const rows = await workflowRowsForStack(ctx, stack._id)
+		if (rows.length === 0) return null
+
+		const publication = await machinePublication(ctx, stack)
+		if (
+			args.machineOrdinal !== undefined &&
+			(!Number.isInteger(args.machineOrdinal) || args.machineOrdinal <= 0)
+		) {
+			return null
+		}
+		const ordinalOf = (row: Doc<'measuredWorkflows'>): number | null =>
+			row.machine === undefined
+				? null
+				: (publication.ordinals.get(row.machine) ?? null)
+
+		// Newest first, so the default reading is the machine that spoke last.
+		const ordered = [...rows].sort(
+			(a, b) =>
+				b.receivedAt - a.receivedAt || (ordinalOf(a) ?? 0) - (ordinalOf(b) ?? 0)
+		)
+		const selected =
+			args.machineOrdinal === undefined
+				? ordered[0]
+				: ordered.find((row) => ordinalOf(row) === args.machineOrdinal)
+		if (!selected) return null
+
+		const snapshots = newestPerSource(
+			await snapshotsForStack(ctx, stack._id)
+		).filter((row) => row.machine === selected.machine)
+		const view = readWorkflowReading({
+			row: selected,
+			kit: kitFromSnapshots(snapshots),
+			overrides: await rowOverridesForStack(ctx, stack._id),
+			// Every synced session and harness on this machine, INCLUDING one the
+			// playbook gate held back: "the count covers every synced harness
+			// including one held back by the playbook gate" (spec, the lead).
+			sessionCount: snapshots.reduce(
+				(sum, snapshot) => sum + snapshot.payload.activity.sessions,
+				0
+			),
+			harnessCount: snapshots.length,
+		})
+
+		const isOwner = publication.owner
+		return {
+			...publicMachine(selected.machine ?? null, publication),
+			machines: ordered.map((row) => ({
+				...publicMachine(row.machine ?? null, publication),
+				receivedAt: row.receivedAt,
+				isCurrent: row._id === selected._id,
+			})),
+			capturedAt: selected.capturedAt,
+			receivedAt: selected.receivedAt,
+			isFresh: Date.now() - selected.receivedAt <= SEVEN_DAYS_MS,
+			cliVersion: selected.cliVersion ?? null,
+			aggregateVersion: selected.section.aggregateVersion,
+			utcOffsetMinutes: selected.section.utcOffsetMinutes ?? null,
+			trimmed: selected.trimmed ?? null,
+			phaseRuleVersions: view.phaseRuleVersions,
+			metricRuleVersions: view.metricRuleVersions,
+			mixedRuleVersions: view.mixedRuleVersions,
+			lead: view.lead,
+			rows: view.rows
+				.filter((row) => isOwner || !row.hidden)
+				.map((row) => ({
+					rowId: row.rowId,
+					kind: row.kind,
+					ruleId: row.ruleId,
+					ruleVersion: row.ruleVersion,
+					label: row.label,
+					unit: row.unit,
+					value: row.value,
+					band: row.band,
+					coverage: row.coverage,
+					coverageTag: row.coverageTag ?? null,
+					surprise: row.surprise,
+					fit: row.fit,
+					movement: row.movement ?? null,
+					placement: row.placement,
+					pinned: row.pinned,
+					hidden: row.hidden,
+				})),
+			unknownMetricIds: view.unknownMetricIds,
+			lastSwapDayUtc: selected.lastSwapDayUtc ?? null,
+			isOwner,
+			section: selected.section,
+		}
+	},
+})
+
+/**
+ * Pin a row to the podium, hide it from the page, or clear either.
+ *
+ * "The owner can pin or hide any row, and that override wins over both
+ * thresholds" (spec). A pin outranks the fit order and the rotation limit; a
+ * hide takes the row off the public page entirely rather than pushing it behind
+ * the expander, because an expander is still published.
+ *
+ * THE OVERRIDE IS PER STACK, not per machine. The judgment is about the row -
+ * a number worth the podium, or one the owner would rather not publish - and it
+ * does not change when the machine selector does.
+ *
+ * At most three pins, one per podium slot. A fourth pin would promise a place
+ * that does not exist, so it is refused rather than silently ranked.
+ */
+export const setWorkflowRowOverride = mutation({
+	args: {
+		stackId: v.id('stacks'),
+		rowId: v.string(),
+		state: v.union(v.literal('pinned'), v.literal('hidden'), v.null()),
+	},
+	returns: v.object({
+		pinned: v.array(v.string()),
+		hidden: v.array(v.string()),
+	}),
+	handler: async (ctx, args) => {
+		const stack = await requireStackOwner(ctx, args.stackId)
+		if (!KNOWN_ROW_IDS.has(args.rowId)) {
+			throw new Error(`Unknown workflow row ${args.rowId}`)
+		}
+
+		const existing = await ctx.db
+			.query('workflowRowOverrides')
+			.withIndex('by_stack_row', (q) =>
+				q.eq('stackId', stack._id).eq('rowId', args.rowId)
+			)
+			.first()
+
+		if (args.state === null) {
+			if (existing) await ctx.db.delete(existing._id)
+		} else {
+			if (args.state === 'pinned') {
+				const pins = (
+					await ctx.db
+						.query('workflowRowOverrides')
+						.withIndex('by_stack', (q) => q.eq('stackId', stack._id))
+						.collect()
+				).filter(
+					(row) => row.state === 'pinned' && row.rowId !== args.rowId
+				)
+				if (pins.length >= MAX_PINS) {
+					throw new Error(
+						`The podium holds ${MAX_PINS} rows. Unpin one before pinning another.`
+					)
+				}
+			}
+			const doc = {
+				stackId: stack._id,
+				rowId: args.rowId,
+				state: args.state,
+				setAt: Date.now(),
+			}
+			if (existing) await ctx.db.replace(existing._id, doc)
+			else await ctx.db.insert('workflowRowOverrides', doc)
+		}
+
+		const after = await rowOverridesForStack(ctx, stack._id)
+		return { pinned: [...after.pinned], hidden: [...after.hidden] }
+	},
+})

--- a/docs/adr/0009-a-workflow-reading-is-one-machines.md
+++ b/docs/adr/0009-a-workflow-reading-is-one-machines.md
@@ -1,0 +1,42 @@
+# A workflow reading is one machine's
+
+The measured Workflow section shows one machine's reading at a time. `measuredWorkflows`
+holds one row per `(stack, machine)`, the page defaults to the machine that synced last,
+and the machine selector switches between them. Nothing merges.
+
+This is the opposite of what ADR-0006 does for the headline, and the difference is in the
+data, not in the taste. Sessions are disjoint per machine, so token counts and session
+counts sum honestly. The workflow section carries two kinds of number that do not:
+
+The **Git half** counts commits, and the wire carries no commit identity. The CLI dedupes
+by hash inside one machine, but hashes never leave the machine, so the server cannot tell
+one machine's commits from another's. A repository cloned on a laptop and a server would
+have its shared commits counted twice, and the additions and removals with them.
+
+A **pool metric** is a value with a band, and no denominator. "42% of commits land between
+23:00 and 03:00" cannot be averaged with another machine's 8% without the commit counts
+behind both, and a weighted mean of two medians means nothing at all. Coverage is already
+per machine: it is the share of THAT machine's synced harnesses the rule counts.
+
+So the reading, the podium, the template lead, and the pins all describe one coherent
+machine. A reader who wants the other machine picks it, the way they already pick one in
+the Actual Usage section.
+
+## Consequences
+
+A stack that splits its work across two machines shows the more recent one by default, and
+its lead says so in the scope line: the session and harness counts are that machine's.
+Neither figure is a lower bound, because neither claims to cover the stack.
+
+The pins and hides are keyed on the stack, not the machine. The judgment is about the row,
+and it does not change when the selector does.
+
+A cross-machine merge stays possible later, and it needs two things on the wire that are
+not there today: an opaque per-commit identity so Git can dedupe, and a denominator per
+pool metric so shares can combine. Both are wire bumps, and neither is worth spending
+before a stack exists that needs them.
+
+Decided in [alp82/aistack#218](https://github.com/alp82/aistack/issues/218), part of
+[map #200](https://github.com/alp82/aistack/issues/200). Spec:
+[docs/specs/workflow-surface.md](../specs/workflow-surface.md). See also ADR-0006, which
+settles the same question for the measured headline and answers it the other way.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@aistack/pricing": "workspace:*",
+    "@aistack/workflow-rules": "workspace:*",
     "@convex-dev/better-auth": "^0.10.9",
     "@convex-dev/react-query": "0.1.0",
     "@radix-ui/react-label": "^2.1.8",

--- a/packages/cli/src/harness/shared/payload.test.ts
+++ b/packages/cli/src/harness/shared/payload.test.ts
@@ -424,6 +424,7 @@ describe("the workflow section on the wire (#213)", () => {
 
 	const extraction = (): WorkflowExtraction => ({
 		aggregateVersion: "workflow-aggregates/v1",
+		utcOffsetMinutes: 120,
 		harnesses: [
 			{
 				aggregateVersion: "workflow-aggregates/v1",

--- a/packages/cli/src/harness/shared/payload.ts
+++ b/packages/cli/src/harness/shared/payload.ts
@@ -598,6 +598,7 @@ export type PayloadWorkflow = {
 	harnesses: Array<Omit<PublishableHarnessWorkflow, "facts">>;
 	git: WorkflowExtraction["git"];
 	metrics: PayloadWorkflowMetric[];
+	utcOffsetMinutes: number;
 };
 
 /**
@@ -642,6 +643,7 @@ export function toPayloadWorkflow(
 				? {}
 				: { coverageTag: row.coverageTag }),
 		})),
+		utcOffsetMinutes: extraction.utcOffsetMinutes,
 	};
 }
 

--- a/packages/cli/src/sync/summary.test.ts
+++ b/packages/cli/src/sync/summary.test.ts
@@ -102,6 +102,7 @@ function payload(over: Partial<MeasuredPayload> = {}): MeasuredPayload {
 function workflow(over: Partial<PayloadWorkflow> = {}): PayloadWorkflow {
 	return {
 		aggregateVersion: "workflow-aggregates/v1",
+		utcOffsetMinutes: 120,
 		harnesses: [
 			{
 				aggregateVersion: "workflow-aggregates/v1",

--- a/packages/cli/src/workflow/extract.test.ts
+++ b/packages/cli/src/workflow/extract.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildWorkflowExtraction, extractLocalWorkflow } from "./extract.js";
+import {
+	buildWorkflowExtraction,
+	extractLocalWorkflow,
+	machineUtcOffsetMinutes,
+} from "./extract.js";
 import type { GitWorkflowResult, GitWorkflowRunner } from "./git.js";
 import {
 	createHarnessWorkflowReducer,
@@ -54,6 +58,9 @@ describe("buildWorkflowExtraction", () => {
 			]),
 		);
 		expect(extraction.harnesses[0]?.phase?.ruleVersion).toBe("phase-rules/v1");
+		// The machine clock ships so the page can render start hours in the
+		// owner's local time (#218). Nothing else on the wire carries one.
+		expect(extraction.utcOffsetMinutes).toBe(machineUtcOffsetMinutes());
 		expect(JSON.stringify(extraction)).not.toContain("/secret/repository");
 		expect(JSON.stringify(extraction)).not.toContain("secret-session");
 		expect(JSON.stringify(extraction)).not.toContain("/secret/repository");

--- a/packages/cli/src/workflow/extract.ts
+++ b/packages/cli/src/workflow/extract.ts
@@ -32,6 +32,12 @@ export type WorkflowExtraction = {
 	harnesses: PublishableHarnessWorkflow[];
 	git: GitWorkflowResult;
 	metricInputs: FitInputRow[];
+	/**
+	 * This machine's offset from UTC, in minutes east (#218). Session hours ship
+	 * in UTC, and the page renders them in the owner's local time. The machine is
+	 * the only end of the wire that knows which clock the owner reads.
+	 */
+	utcOffsetMinutes: number;
 };
 
 export type ExtractLocalWorkflowOptions = {
@@ -39,6 +45,8 @@ export type ExtractLocalWorkflowOptions = {
 	fromMs: number;
 	toMs: number;
 	run?: GitWorkflowRunner;
+	/** Tests only: pin the machine clock so a fixture does not move with the runner's zone. */
+	utcOffsetMinutes?: number;
 };
 
 /** Read only repositories touched by windowed sessions, then return safe aggregates. */
@@ -53,7 +61,11 @@ export function extractLocalWorkflow(
 		toMs: options.toMs,
 		...(options.run ? { run: options.run } : {}),
 	});
-	return buildWorkflowExtraction(options.harnesses, git);
+	return buildWorkflowExtraction(
+		options.harnesses,
+		git,
+		options.utcOffsetMinutes ?? machineUtcOffsetMinutes(),
+	);
 }
 
 /**
@@ -61,9 +73,15 @@ export function extractLocalWorkflow(
  * rules. Local session keys, project paths, event arguments, and timestamps do
  * not enter the returned value.
  */
+/** Minutes EAST of UTC, the sign convention the wire and the page both read. */
+export function machineUtcOffsetMinutes(now: Date = new Date()): number {
+	return -now.getTimezoneOffset();
+}
+
 export function buildWorkflowExtraction(
 	harnessWorkflows: readonly LocalHarnessWorkflow[],
 	git: GitWorkflowResult,
+	utcOffsetMinutes: number = machineUtcOffsetMinutes(),
 ): WorkflowExtraction {
 	const projectDays = new Map<string, Set<string>>();
 	const webSearches = new Map<string, number>();
@@ -115,5 +133,6 @@ export function buildWorkflowExtraction(
 		}),
 		git,
 		metricInputs: buildFitInputs(facts, syncedHarnesses),
+		utcOffsetMinutes,
 	};
 }

--- a/packages/workflow-rules/src/componentRules.ts
+++ b/packages/workflow-rules/src/componentRules.ts
@@ -1,0 +1,229 @@
+// The versioned component rule pool: `component-rules/v1`.
+//
+// Wayfinder ticket #218 (map #200). The spec's row set is sixteen rows: "nine
+// pool metrics and seven components". `metric-rules/v1` covers the nine, and
+// their values are measured on the machine. The seven components are already on
+// the wire as aggregates, but a component cannot compete for a podium slot
+// without the same three things a metric has: one headline value, the typical
+// band that value is surprising against, and the coverage it was measured over.
+// This module declares them.
+//
+// A COMPONENT RULE MEASURES NOTHING NEW. Every value below is arithmetic over
+// aggregates the machine already shipped, which is what keeps the CLI "the only
+// source of measured values" (spec, "Fit and rotation") while still letting the
+// server rank a component against a metric.
+//
+// BAND VALUES ARE V1 DEFAULTS, NOT PROVEN DATA - the same caveat
+// `metric-rules/v1` carries. No calibration run has happened for either pool,
+// and prod has four living stacks to calibrate against. A rule version bump
+// corrects a band once real synced readings are in.
+
+import type { MetricUnit } from "./metricRules.js";
+import type { KitReading, WorkflowReading } from "./reading.js";
+import { playbookHarnesses, totalPhaseSec } from "./reading.js";
+import type { PhaseId } from "./types.js";
+
+export const COMPONENT_RULES_V1 = "component-rules/v1";
+
+export type ComponentInput = {
+	reading: WorkflowReading;
+	/** Inventory for the same machine. Absent when no payload carried one. */
+	kit?: KitReading;
+};
+
+export type ComponentRule = {
+	id: string;
+	version: string;
+	/** Sentence fragment completing "<value> <label>", like a metric rule's. */
+	label: string;
+	unit: MetricUnit;
+	band: { low: number; high: number };
+	/** The measurement, or `undefined` when this reading cannot support the row. */
+	evaluate: (input: ComponentInput) => number | undefined;
+	/** Share of the machine's synced harnesses the row counts, 0..1. */
+	coverage: (input: ComponentInput) => number;
+};
+
+/** Git history counts every synced harness, whatever the harness itself records (spec). */
+const gitCoverage = (): number => 1;
+
+function harnessShare(
+	input: ComponentInput,
+	counts: (input: ComponentInput) => number,
+): number {
+	const synced = input.reading.harnesses.length;
+	if (synced === 0) return 0;
+	return counts(input) / synced;
+}
+
+function topShare(entries: readonly { value: number }[]): number | undefined {
+	const total = entries.reduce((sum, entry) => sum + entry.value, 0);
+	if (total <= 0) return undefined;
+	const top = Math.max(...entries.map((entry) => entry.value));
+	return top / total;
+}
+
+export const COMPONENT_RULES: readonly ComponentRule[] = [
+	{
+		id: "phase-playbook",
+		version: COMPONENT_RULES_V1,
+		label: "of measured time goes to a single phase",
+		unit: "share",
+		// An even mix across four phases sits near a quarter each. A run where one
+		// phase takes most of the time is the reading worth the podium.
+		band: { low: 0.25, high: 0.45 },
+		evaluate: ({ reading }) => {
+			const totals = totalPhaseSec(reading);
+			const measured = Object.values(totals).reduce((sum, sec) => sum + sec, 0);
+			if (measured <= 0) return undefined;
+			const named: PhaseId[] = ["scout", "build", "verify", "handoff"];
+			return Math.max(...named.map((phase) => totals[phase])) / measured;
+		},
+		coverage: (input) =>
+			harnessShare(input, ({ reading }) => playbookHarnesses(reading).length),
+	},
+	{
+		id: "model-routing",
+		version: COMPONENT_RULES_V1,
+		label: "of main-loop tokens run on one model",
+		unit: "share",
+		band: { low: 0.4, high: 0.85 },
+		evaluate: ({ reading }) => {
+			const main = reading.harnesses.flatMap((harness) => [
+				...(harness.routing?.main ?? []),
+			]);
+			const byModel = new Map<string, number>();
+			for (const row of main) {
+				byModel.set(row.model, (byModel.get(row.model) ?? 0) + row.tokens);
+			}
+			return topShare(
+				[...byModel.values()].map((tokens) => ({ value: tokens })),
+			);
+		},
+		coverage: (input) =>
+			harnessShare(
+				input,
+				({ reading }) =>
+					reading.harnesses.filter((harness) => harness.routing).length,
+			),
+	},
+	{
+		id: "delegation",
+		version: COMPONENT_RULES_V1,
+		label: "of tool calls run inside a subagent",
+		unit: "share",
+		band: { low: 0, high: 0.3 },
+		evaluate: ({ reading }) => {
+			let main = 0;
+			let subagents = 0;
+			for (const harness of reading.harnesses) {
+				main += harness.delegation?.mainToolCalls ?? 0;
+				subagents += harness.delegation?.subagentToolCalls ?? 0;
+			}
+			const total = main + subagents;
+			return total > 0 ? subagents / total : undefined;
+		},
+		coverage: (input) =>
+			harnessShare(
+				input,
+				({ reading }) =>
+					reading.harnesses.filter((harness) => harness.delegation).length,
+			),
+	},
+	{
+		id: "git-ledger",
+		version: COMPONENT_RULES_V1,
+		label: "of changed lines are removals",
+		unit: "share",
+		// Most work adds more than it takes away. A ledger that removes as much as
+		// it adds is the surprising one, and so is one that never removes.
+		band: { low: 0.15, high: 0.35 },
+		evaluate: ({ reading }) => {
+			const changed = reading.git.additions + reading.git.removals;
+			return changed > 0 ? reading.git.removals / changed : undefined;
+		},
+		coverage: gitCoverage,
+	},
+	{
+		id: "coding-languages",
+		version: COMPONENT_RULES_V1,
+		label: "of changed lines are one file type",
+		unit: "share",
+		band: { low: 0.35, high: 0.7 },
+		evaluate: ({ reading }) => {
+			// The withheld lines are a real bucket, not a rounding loss: they belong
+			// in the denominator, or a stack whose top language is unapproved would
+			// read as more concentrated than it is.
+			const named = reading.git.changedLinesByExtension.map((row) => ({
+				value: row.changedLines,
+			}));
+			const total =
+				named.reduce((sum, row) => sum + row.value, 0) +
+				reading.git.withheldExtensionLines;
+			if (total <= 0 || named.length === 0) return undefined;
+			return Math.max(...named.map((row) => row.value)) / total;
+		},
+		coverage: gitCoverage,
+	},
+	{
+		id: "activity-heatmap",
+		version: COMPONENT_RULES_V1,
+		label: "of events fall in the three busiest hours of the day",
+		unit: "share",
+		// Three of twenty-four hours is an eighth of the clock. A day spread evenly
+		// lands near it; a night owl runs far above it.
+		band: { low: 0.125, high: 0.35 },
+		evaluate: ({ reading }) => {
+			const byHour = new Map<number, number>();
+			for (const harness of reading.harnesses) {
+				for (const cell of harness.activity) {
+					byHour.set(
+						cell.hourUtc,
+						(byHour.get(cell.hourUtc) ?? 0) + cell.events,
+					);
+				}
+			}
+			const total = [...byHour.values()].reduce((sum, n) => sum + n, 0);
+			if (total <= 0) return undefined;
+			const busiest = [...byHour.values()].sort((a, b) => b - a).slice(0, 3);
+			return busiest.reduce((sum, n) => sum + n, 0) / total;
+		},
+		coverage: (input) =>
+			harnessShare(
+				input,
+				({ reading }) =>
+					reading.harnesses.filter((harness) => harness.activity.length > 0)
+						.length,
+			),
+	},
+	{
+		id: "kit",
+		version: COMPONENT_RULES_V1,
+		label: "of skill and MCP calls go to one artifact",
+		unit: "share",
+		band: { low: 0.15, high: 0.4 },
+		evaluate: ({ kit }) => {
+			if (!kit) return undefined;
+			const byName = new Map<string, number>();
+			for (const harness of kit) {
+				for (const atom of [...harness.skills, ...harness.mcpServers]) {
+					byName.set(atom.name, (byName.get(atom.name) ?? 0) + atom.callShare);
+				}
+			}
+			return topShare([...byName.values()].map((share) => ({ value: share })));
+		},
+		coverage: (input) =>
+			harnessShare(
+				input,
+				({ kit }) =>
+					(kit ?? []).filter(
+						(harness) =>
+							harness.skills.length > 0 || harness.mcpServers.length > 0,
+					).length,
+			),
+	},
+];
+
+export function componentRule(id: string): ComponentRule | undefined {
+	return COMPONENT_RULES.find((rule) => rule.id === id);
+}

--- a/packages/workflow-rules/src/fitRanking.test.ts
+++ b/packages/workflow-rules/src/fitRanking.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, test } from "vitest";
+import {
+	CHALLENGER_MARGIN,
+	fitOf,
+	HIGHLIGHT_SLOTS,
+	LOW_FIT_LINE,
+	movementOf,
+	placeRows,
+	rankWorkflowRows,
+	rotateHighlights,
+	surpriseOf,
+	type WorkflowRowInput,
+} from "./fitRanking.js";
+
+function row(over: Partial<WorkflowRowInput> = {}): WorkflowRowInput {
+	return {
+		rowId: "metric:late-night-commits",
+		kind: "metric",
+		ruleId: "late-night-commits",
+		ruleVersion: "metric-rules/v1",
+		label: "of commits land between 23:00 and 03:00",
+		unit: "share",
+		value: 0.42,
+		band: { low: 0, high: 0.15 },
+		coverage: 1,
+		...over,
+	};
+}
+
+describe("surprise", () => {
+	test("a value inside the typical band is not surprising", () => {
+		expect(surpriseOf(0.1, { low: 0, high: 0.15 })).toBe(0);
+		expect(surpriseOf(0, { low: 0, high: 0.15 })).toBe(0);
+		expect(surpriseOf(0.15, { low: 0, high: 0.15 })).toBe(0);
+	});
+
+	test("a value one band width outside sits at half surprise", () => {
+		// width 0.15, value 0.30 -> d = 0.15 -> 0.15 / (0.15 + 0.15)
+		expect(surpriseOf(0.3, { low: 0, high: 0.15 })).toBeCloseTo(0.5, 10);
+	});
+
+	test("distance below the band counts the same as distance above it", () => {
+		// width 0.5, value 0.5 -> d = 0.5 -> 0.5 / (0.5 + 0.5)
+		expect(surpriseOf(0.5, { low: 1, high: 1.5 })).toBeCloseTo(0.5, 10);
+	});
+
+	test("a far value approaches but never reaches 1, so extremes still order", () => {
+		const near = surpriseOf(0.42, { low: 0, high: 0.15 });
+		const far = surpriseOf(4.2, { low: 0, high: 0.15 });
+		// d = 0.27, width 0.15 -> 0.27 / 0.42
+		expect(near).toBeCloseTo(0.642857, 5);
+		expect(far).toBeGreaterThan(near);
+		expect(far).toBeLessThan(1);
+	});
+});
+
+describe("fit", () => {
+	test("fit is coverage times surprise", () => {
+		expect(fitOf(0.5, 0.642857)).toBeCloseTo(0.3214285, 6);
+	});
+
+	test("a metric no synced harness records cannot compete", () => {
+		expect(fitOf(0, 0.9)).toBe(0);
+	});
+});
+
+describe("movement", () => {
+	test("no prior reading means no movement", () => {
+		expect(movementOf(0.42, undefined, { low: 0, high: 0.15 })).toBeUndefined();
+	});
+
+	test("a move of one band width reads as half", () => {
+		expect(movementOf(0.42, 0.27, { low: 0, high: 0.15 })).toBeCloseTo(0.5, 10);
+	});
+
+	test("an unchanged value has not moved", () => {
+		expect(movementOf(0.42, 0.42, { low: 0, high: 0.15 })).toBe(0);
+	});
+});
+
+describe("ranking", () => {
+	test("rows order by fit, highest first", () => {
+		const ranked = rankWorkflowRows(
+			[
+				row({ rowId: "a", value: 0.16 }),
+				row({ rowId: "b", value: 0.42 }),
+				row({ rowId: "c", value: 0.1 }),
+			],
+			new Map(),
+		);
+		expect(ranked.map((r) => r.rowId)).toEqual(["b", "a", "c"]);
+	});
+
+	test("a tie breaks on movement against the prior window", () => {
+		const ranked = rankWorkflowRows(
+			[
+				row({ rowId: "still", value: 0.42 }),
+				row({ rowId: "moved", value: 0.42 }),
+			],
+			new Map([
+				["still", 0.42],
+				["moved", 0.2],
+			]),
+		);
+		expect(ranked.map((r) => r.rowId)).toEqual(["moved", "still"]);
+	});
+
+	test("a tie with no movement to compare breaks on the row id, so the order is stable", () => {
+		const ranked = rankWorkflowRows(
+			[row({ rowId: "zulu" }), row({ rowId: "alpha" })],
+			new Map(),
+		);
+		expect(ranked.map((r) => r.rowId)).toEqual(["alpha", "zulu"]);
+	});
+});
+
+const TODAY = "2026-08-25";
+const YESTERDAY = "2026-08-24";
+const NO_OVERRIDES = { pinned: [], hidden: [] };
+
+/** Six rows whose fit falls from 0.9 to 0.4 in even steps. */
+function ladder() {
+	return ["r1", "r2", "r3", "r4", "r5", "r6"].map((rowId, i) =>
+		row({ rowId, band: { low: 0, high: 1 }, value: 1 + (6 - i) }),
+	);
+}
+
+describe("rotation", () => {
+	test("an empty podium fills from the top of the fit order", () => {
+		const ranked = rankWorkflowRows(ladder(), new Map());
+		const state = rotateHighlights({
+			ranked,
+			previous: { highlightRowIds: [] },
+			overrides: NO_OVERRIDES,
+			today: TODAY,
+			priorCoverage: new Map(),
+		});
+		expect(state.highlightRowIds).toEqual(["r1", "r2", "r3"]);
+		expect(state.lastSwapDayUtc).toBeUndefined();
+	});
+
+	test("a challenger under the margin does not take a slot", () => {
+		// r3 holds a slot at fit 0.8; the challenger r4 sits at 0.75.
+		const rows = [
+			row({ rowId: "r1", band: { low: 0, high: 1 }, value: 10 }),
+			row({ rowId: "r2", band: { low: 0, high: 1 }, value: 9 }),
+			row({ rowId: "r3", band: { low: 0, high: 1 }, value: 5 }),
+			row({ rowId: "r4", band: { low: 0, high: 1 }, value: 5.2 }),
+		];
+		const state = rotateHighlights({
+			ranked: rankWorkflowRows(rows, new Map()),
+			previous: { highlightRowIds: ["r1", "r2", "r3"] },
+			overrides: NO_OVERRIDES,
+			today: TODAY,
+			priorCoverage: new Map(),
+		});
+		expect(state.highlightRowIds).toEqual(["r1", "r2", "r3"]);
+	});
+
+	test("a challenger clearing the margin takes one slot and spends the day's swap", () => {
+		const rows = [
+			row({ rowId: "r1", band: { low: 0, high: 1 }, value: 10 }),
+			row({ rowId: "r2", band: { low: 0, high: 1 }, value: 9 }),
+			row({ rowId: "r3", band: { low: 0, high: 1 }, value: 1.5 }),
+			row({ rowId: "r4", band: { low: 0, high: 1 }, value: 8 }),
+			row({ rowId: "r5", band: { low: 0, high: 1 }, value: 7 }),
+		];
+		const ranked = rankWorkflowRows(rows, new Map());
+		const state = rotateHighlights({
+			ranked,
+			previous: { highlightRowIds: ["r1", "r2", "r3"] },
+			overrides: NO_OVERRIDES,
+			today: TODAY,
+			priorCoverage: new Map(),
+		});
+		expect(state.highlightRowIds).toContain("r4");
+		expect(state.highlightRowIds).not.toContain("r5");
+		expect(state.highlightRowIds).not.toContain("r3");
+		expect(state.lastSwapDayUtc).toBe(TODAY);
+
+		// A second sync on the same day changes nothing more.
+		const again = rotateHighlights({
+			ranked,
+			previous: state,
+			overrides: NO_OVERRIDES,
+			today: TODAY,
+			priorCoverage: new Map(),
+		});
+		expect(again.highlightRowIds).toEqual(state.highlightRowIds);
+	});
+
+	test("the next sync day allows the next swap", () => {
+		const rows = [
+			row({ rowId: "r1", band: { low: 0, high: 1 }, value: 10 }),
+			row({ rowId: "r2", band: { low: 0, high: 1 }, value: 1.5 }),
+			row({ rowId: "r3", band: { low: 0, high: 1 }, value: 1.4 }),
+			row({ rowId: "r4", band: { low: 0, high: 1 }, value: 8 }),
+		];
+		const state = rotateHighlights({
+			ranked: rankWorkflowRows(rows, new Map()),
+			previous: {
+				highlightRowIds: ["r1", "r2", "r3"],
+				lastSwapDayUtc: YESTERDAY,
+			},
+			overrides: NO_OVERRIDES,
+			today: TODAY,
+			priorCoverage: new Map(),
+		});
+		expect(state.highlightRowIds).toContain("r4");
+		expect(state.lastSwapDayUtc).toBe(TODAY);
+	});
+
+	test("an incumbent whose measurement is gone leaves at once, and the fill is not a swap", () => {
+		const rows = [
+			row({ rowId: "r1", band: { low: 0, high: 1 }, value: 10 }),
+			row({ rowId: "r2", band: { low: 0, high: 1 }, value: 9 }),
+			row({ rowId: "r4", band: { low: 0, high: 1 }, value: 8 }),
+		];
+		const state = rotateHighlights({
+			ranked: rankWorkflowRows(rows, new Map()),
+			previous: { highlightRowIds: ["r1", "r2", "r3"] },
+			overrides: NO_OVERRIDES,
+			today: TODAY,
+			priorCoverage: new Map(),
+		});
+		expect(state.highlightRowIds).toEqual(["r1", "r2", "r4"]);
+		expect(state.lastSwapDayUtc).toBeUndefined();
+	});
+
+	test("an incumbent whose coverage dropped leaves at once", () => {
+		const rows = [
+			row({ rowId: "r1", band: { low: 0, high: 1 }, value: 10 }),
+			row({ rowId: "r2", band: { low: 0, high: 1 }, value: 9 }),
+			row({ rowId: "r3", band: { low: 0, high: 1 }, value: 8, coverage: 0.5 }),
+			row({ rowId: "r4", band: { low: 0, high: 1 }, value: 3 }),
+		];
+		const state = rotateHighlights({
+			ranked: rankWorkflowRows(rows, new Map()),
+			previous: { highlightRowIds: ["r1", "r2", "r3"] },
+			overrides: NO_OVERRIDES,
+			today: TODAY,
+			priorCoverage: new Map([["r3", 1]]),
+		});
+		expect(state.highlightRowIds).toEqual(["r1", "r2", "r4"]);
+		expect(state.lastSwapDayUtc).toBeUndefined();
+	});
+
+	test("a pin takes a slot immediately, whatever its fit and whatever day it is", () => {
+		const ranked = rankWorkflowRows(ladder(), new Map());
+		const state = rotateHighlights({
+			ranked,
+			previous: { highlightRowIds: ["r1", "r2", "r3"], lastSwapDayUtc: TODAY },
+			overrides: { pinned: ["r6"], hidden: [] },
+			today: TODAY,
+			priorCoverage: new Map(),
+		});
+		expect(state.highlightRowIds).toContain("r6");
+		expect(state.highlightRowIds).toHaveLength(HIGHLIGHT_SLOTS);
+	});
+
+	test("a hidden incumbent leaves at once", () => {
+		const ranked = rankWorkflowRows(ladder(), new Map());
+		const state = rotateHighlights({
+			ranked,
+			previous: { highlightRowIds: ["r1", "r2", "r3"] },
+			overrides: { pinned: [], hidden: ["r2"] },
+			today: TODAY,
+			priorCoverage: new Map(),
+		});
+		expect(state.highlightRowIds).toEqual(["r1", "r3", "r4"]);
+	});
+});
+
+describe("placement", () => {
+	test("the podium is the highlight, the rest fall either side of the fit line", () => {
+		const rows = [
+			row({ rowId: "r1", band: { low: 0, high: 1 }, value: 10 }),
+			row({ rowId: "r2", band: { low: 0, high: 1 }, value: 9 }),
+			row({ rowId: "r3", band: { low: 0, high: 1 }, value: 8 }),
+			// fit 0.5: above the 0.40 line.
+			row({ rowId: "r4", band: { low: 0, high: 1 }, value: 2 }),
+			// fit 0.2: below it.
+			row({ rowId: "r5", band: { low: 0, high: 1 }, value: 1.25 }),
+		];
+		const placed = placeRows(
+			rankWorkflowRows(rows, new Map()),
+			{ highlightRowIds: ["r1", "r2", "r3"] },
+			NO_OVERRIDES,
+		);
+		expect(placed.map((p) => [p.rowId, p.placement])).toEqual([
+			["r1", "highlight"],
+			["r2", "highlight"],
+			["r3", "highlight"],
+			["r4", "normal"],
+			["r5", "low"],
+		]);
+		expect(placed.every((p) => !p.pinned && !p.hidden)).toBe(true);
+	});
+
+	test("a pinned row is on the podium and says so", () => {
+		const placed = placeRows(
+			rankWorkflowRows(ladder(), new Map()),
+			{ highlightRowIds: ["r1", "r2", "r6"] },
+			{ pinned: ["r6"], hidden: [] },
+		);
+		const pinned = placed.find((p) => p.rowId === "r6");
+		expect(pinned?.placement).toBe("highlight");
+		expect(pinned?.pinned).toBe(true);
+	});
+
+	test("a hidden row is marked, so a public caller can drop it and the owner can restore it", () => {
+		const placed = placeRows(
+			rankWorkflowRows(ladder(), new Map()),
+			{ highlightRowIds: ["r1", "r2", "r3"] },
+			{ pinned: [], hidden: ["r2"] },
+		);
+		expect(placed.find((p) => p.rowId === "r2")?.hidden).toBe(true);
+		// The slot the hidden row held refills on this read, not on the next sync.
+		expect(
+			placed
+				.filter((p) => !p.hidden && p.placement === "highlight")
+				.map((p) => p.rowId),
+		).toEqual(["r1", "r3", "r4"]);
+	});
+});
+
+describe("the constants the surface is specified in", () => {
+	test("three podium slots, a 0.40 fit line, and a 25% challenger margin", () => {
+		expect(HIGHLIGHT_SLOTS).toBe(3);
+		expect(LOW_FIT_LINE).toBe(0.4);
+		expect(CHALLENGER_MARGIN).toBe(0.25);
+	});
+});

--- a/packages/workflow-rules/src/fitRanking.ts
+++ b/packages/workflow-rules/src/fitRanking.ts
@@ -1,0 +1,285 @@
+// Fit, the podium, and the rotation limit.
+//
+// Wayfinder ticket #218 (map #200). Ticket #214 stopped at the fit INPUTS -
+// value, band, coverage and rule id, all measured on the machine. This module
+// is the other half named in the spec ("Fit and rotation"): "The server
+// computes fit, applies the rotation limit, and applies the owner pins and
+// hides, because the swap history and the owner overrides are server state."
+//
+// It lives in the shared package rather than in `convex/` because every line
+// here is a pure function of its arguments, and the web renders the same rows
+// it ranks (#215). Convex holds only what needs the database: the stored
+// reading, the previous window's values, the podium slots, and the overrides.
+
+import type { Band, MetricUnit } from "./metricRules.js";
+
+/** The podium: "The top three rows by fit render as one horizontal band" (spec). */
+export const HIGHLIGHT_SLOTS = 3;
+
+/** "Rows under fit 0.40 wait behind one expander row" (spec). */
+export const LOW_FIT_LINE = 0.4;
+
+/** "A challenger takes a highlight slot only with a fit win of 25% or more" (spec). */
+export const CHALLENGER_MARGIN = 0.25;
+
+/** One pin per podium slot. A fourth pin has no slot to promise. */
+export const MAX_PINS = HIGHLIGHT_SLOTS;
+
+export type RowKind = "metric" | "component";
+
+/**
+ * One row of the sixteen: nine pool metrics and seven components.
+ *
+ * A metric row's value comes off the wire, measured on the machine. A component
+ * row's value is derived from the same stored reading by `component-rules/v1`
+ * (see `componentRules.ts`), which is arithmetic over shipped aggregates rather
+ * than a second measurement.
+ */
+export type WorkflowRowInput = {
+	/** Stable across syncs and rule versions: what a pin or a hide is keyed on. */
+	rowId: string;
+	kind: RowKind;
+	ruleId: string;
+	ruleVersion: string;
+	label: string;
+	unit: MetricUnit;
+	value: number;
+	band: Band;
+	/** Share of this reading's synced harnesses the row counts, 0..1. */
+	coverage: number;
+	coverageTag?: string;
+};
+
+export type RankedRow = WorkflowRowInput & {
+	surprise: number;
+	fit: number;
+	/** Distance travelled since the previous reading, `undefined` on a first sync. */
+	movement: number | undefined;
+};
+
+/**
+ * How far outside its typical band a value sits, as 0..1.
+ *
+ * `d / (d + width)`, so one band width outside reads as 0.5 and the scale never
+ * reaches 1. A clamped `min(1, d / width)` was rejected for exactly that: every
+ * wildly out-of-band row would tie at 1.00, and the podium needs a strict order
+ * far more than it needs a top end.
+ *
+ * A value inside the band is not surprising, so it scores 0 and sinks behind the
+ * expander. That is the point of a typical band: a typical number is a true
+ * number nobody needs on the podium.
+ */
+export function surpriseOf(value: number, band: Band): number {
+	const width = Math.max(band.high - band.low, Number.EPSILON);
+	const distance =
+		value < band.low
+			? band.low - value
+			: value > band.high
+				? value - band.high
+				: 0;
+	if (distance === 0) return 0;
+	return distance / (distance + width);
+}
+
+/** Fit is coverage times surprise (spec, CONTEXT.md). */
+export function fitOf(coverage: number, surprise: number): number {
+	return coverage * surprise;
+}
+
+/**
+ * "Ties break on movement against the prior window" (spec). Measured on the same
+ * scale as surprise, so a move of one band width reads as 0.5.
+ */
+export function movementOf(
+	value: number,
+	prior: number | undefined,
+	band: Band,
+): number | undefined {
+	if (prior === undefined) return undefined;
+	const width = Math.max(band.high - band.low, Number.EPSILON);
+	const distance = Math.abs(value - prior);
+	if (distance === 0) return 0;
+	return distance / (distance + width);
+}
+
+/** Fit descending, then movement descending, then the row id so the order is stable. */
+export function rankWorkflowRows(
+	rows: readonly WorkflowRowInput[],
+	priorValues: ReadonlyMap<string, number>,
+): RankedRow[] {
+	const ranked = rows.map((row) => {
+		const surprise = surpriseOf(row.value, row.band);
+		return {
+			...row,
+			surprise,
+			fit: fitOf(row.coverage, surprise),
+			movement: movementOf(row.value, priorValues.get(row.rowId), row.band),
+		};
+	});
+	return ranked.sort(
+		(a, b) =>
+			b.fit - a.fit ||
+			(b.movement ?? -1) - (a.movement ?? -1) ||
+			a.rowId.localeCompare(b.rowId),
+	);
+}
+
+/**
+ * What the podium held after the last sync, and when a challenger last took a
+ * slot. Both are server state: neither can be recomputed from one reading.
+ */
+export type RotationState = {
+	highlightRowIds: readonly string[];
+	/** UTC day of the last challenger swap, `undefined` until one happens. */
+	lastSwapDayUtc?: string;
+};
+
+export type RowOverrides = {
+	pinned: readonly string[];
+	hidden: readonly string[];
+};
+
+export type RotateArgs = {
+	ranked: readonly RankedRow[];
+	previous: RotationState;
+	overrides: RowOverrides;
+	/** The UTC day of the sync being applied, as `YYYY-MM-DD`. */
+	today: string;
+	/** Coverage per row at the previous reading, for the departure rule. */
+	priorCoverage: ReadonlyMap<string, number>;
+};
+
+/**
+ * Recompute the podium for one sync.
+ *
+ * Three rules, in the order the spec states them:
+ *
+ *  1. **An incumbent leaves at once** when the owner removes it, when its
+ *     coverage drops, or when its signal goes stale. A row absent from this
+ *     reading has no measurement left, which is what stale means here.
+ *  2. **A vacated slot is refilled** from the top of the fit order. A fill is
+ *     not a swap: nobody was displaced, so it does not spend the day's swap.
+ *  3. **A challenger displaces a healthy incumbent** only with a fit win of 25%
+ *     or more, and at most one slot swaps per sync day.
+ *
+ * A pin skips all three. It is an owner acting on their own page, and the spec
+ * puts that override above both thresholds.
+ */
+export function rotateHighlights(args: RotateArgs): RotationState {
+	const { ranked, previous, overrides, today, priorCoverage } = args;
+	const byId = new Map(ranked.map((row) => [row.rowId, row]));
+	const hidden = new Set(overrides.hidden);
+
+	const pinned = overrides.pinned
+		.filter((rowId) => byId.has(rowId) && !hidden.has(rowId))
+		.map((rowId) => byId.get(rowId) as RankedRow)
+		.sort((a, b) => b.fit - a.fit)
+		.slice(0, HIGHLIGHT_SLOTS)
+		.map((row) => row.rowId);
+
+	const slots: string[] = [...pinned];
+	const held: string[] = [];
+	for (const rowId of previous.highlightRowIds) {
+		const row = byId.get(rowId);
+		if (!row || hidden.has(rowId)) continue;
+		const before = priorCoverage.get(rowId);
+		if (before !== undefined && row.coverage < before) continue;
+		held.push(rowId);
+	}
+	for (const rowId of held) {
+		if (slots.length >= HIGHLIGHT_SLOTS) break;
+		if (!slots.includes(rowId)) slots.push(rowId);
+	}
+	const healthy = slots.length;
+	for (const row of ranked) {
+		if (slots.length >= HIGHLIGHT_SLOTS) break;
+		if (hidden.has(row.rowId) || slots.includes(row.rowId)) continue;
+		slots.push(row.rowId);
+	}
+
+	// The challenger step. Only a slot held by a healthy, unpinned incumbent can
+	// be taken: a slot filled from a vacancy this sync already holds the best
+	// available row, and a pinned slot is not the rotation's to give away.
+	let lastSwapDayUtc = previous.lastSwapDayUtc;
+	if (previous.lastSwapDayUtc !== today && healthy === HIGHLIGHT_SLOTS) {
+		const contenders = slots
+			.filter((rowId) => !pinned.includes(rowId))
+			.map((rowId) => byId.get(rowId) as RankedRow)
+			.sort((a, b) => a.fit - b.fit);
+		const weakest = contenders[0];
+		const challenger = ranked.find(
+			(row) => !slots.includes(row.rowId) && !hidden.has(row.rowId),
+		);
+		if (
+			weakest &&
+			challenger &&
+			challenger.fit > 0 &&
+			// A zero-fit incumbent has no fit to win 25% of. Any real fit beats it,
+			// and the guard above keeps two zeroes from trading places forever.
+			(weakest.fit === 0 ||
+				challenger.fit >= weakest.fit * (1 + CHALLENGER_MARGIN))
+		) {
+			slots[slots.indexOf(weakest.rowId)] = challenger.rowId;
+			lastSwapDayUtc = today;
+		}
+	}
+
+	return lastSwapDayUtc === undefined
+		? { highlightRowIds: slots }
+		: { highlightRowIds: slots, lastSwapDayUtc };
+}
+
+export type Placement = "highlight" | "normal" | "low";
+
+export type PlacedRow = RankedRow & {
+	placement: Placement;
+	pinned: boolean;
+	hidden: boolean;
+};
+
+/**
+ * Sort one reading's rows into the three podium states, in fit order.
+ *
+ * Hidden rows are MARKED rather than dropped, because the two callers need
+ * different things from them: a public read drops them, and the owner's own view
+ * lists them so the hide can be undone.
+ *
+ * The podium set comes from `rotateHighlights` at sync time, but a hidden or
+ * missing incumbent is resolved again here. An owner who hides a row sees it
+ * leave the podium on the next page load, not on the next sync.
+ */
+export function placeRows(
+	ranked: readonly RankedRow[],
+	state: RotationState,
+	overrides: RowOverrides,
+): PlacedRow[] {
+	const hidden = new Set(overrides.hidden);
+	const pinned = new Set(overrides.pinned);
+	const byId = new Map(ranked.map((row) => [row.rowId, row]));
+
+	const highlight: string[] = [];
+	for (const rowId of [...overrides.pinned, ...state.highlightRowIds]) {
+		if (highlight.length >= HIGHLIGHT_SLOTS) break;
+		if (!byId.has(rowId) || hidden.has(rowId) || highlight.includes(rowId)) {
+			continue;
+		}
+		highlight.push(rowId);
+	}
+	for (const row of ranked) {
+		if (highlight.length >= HIGHLIGHT_SLOTS) break;
+		if (hidden.has(row.rowId) || highlight.includes(row.rowId)) continue;
+		highlight.push(row.rowId);
+	}
+
+	const onPodium = new Set(highlight);
+	return ranked.map((row) => ({
+		...row,
+		placement: onPodium.has(row.rowId)
+			? "highlight"
+			: row.fit >= LOW_FIT_LINE
+				? "normal"
+				: "low",
+		pinned: pinned.has(row.rowId),
+		hidden: hidden.has(row.rowId),
+	}));
+}

--- a/packages/workflow-rules/src/index.ts
+++ b/packages/workflow-rules/src/index.ts
@@ -1,8 +1,12 @@
 // Public surface of @aistack/workflow-rules. See each module for its own
 // wayfinder-ticket provenance; this file just re-exports.
 
+export * from "./componentRules.js";
 export * from "./fit.js";
+export * from "./fitRanking.js";
 export * from "./metricRules.js";
 export * from "./phaseRules.js";
+export * from "./reading.js";
 export * from "./templateLead.js";
 export * from "./types.js";
+export * from "./workflowRows.js";

--- a/packages/workflow-rules/src/reading.ts
+++ b/packages/workflow-rules/src/reading.ts
@@ -1,0 +1,276 @@
+// One stored workflow reading, and the facts derived from it.
+//
+// Wayfinder ticket #218 (map #200). The types here mirror the wire section that
+// ticket #213 put on the sync body and ticket #218 stores, structurally rather
+// than by import: this package must not depend on Convex, and the server passes
+// its `Infer<typeof WorkflowSection>` value straight in.
+//
+// A READING IS ONE MACHINE'S (ADR-0009). Every derivation below is scoped to a
+// single machine's section, so nothing here has to answer what two machines'
+// medians would mean together.
+
+import type { PhaseId } from "./types.js";
+
+export type PhaseTotals = Record<PhaseId, number>;
+
+export type WorkflowSessionRow = {
+	startHourUtc: number;
+	eventCount: number;
+	phaseSec: PhaseTotals;
+	phaseEvents: PhaseTotals;
+	waitingSec: number;
+	idleSec: number;
+	merged: boolean;
+	verifyRuns: number;
+	reviewRounds: number;
+	openedWithScout: boolean;
+};
+
+export type WorkflowHarnessReading = {
+	harness: string;
+	/** Absent when the harness failed its own playbook gate, so the CLI stripped it. */
+	phase?: {
+		ruleVersion: string;
+		publishable: boolean;
+		sessions: number;
+		phaseSec: PhaseTotals;
+		phaseEvents: PhaseTotals;
+		waitingSec: number;
+		idleSec: number;
+		unknownShare: number;
+		sessionRows: readonly WorkflowSessionRow[];
+	};
+	routing?: {
+		main: readonly { model: string; tokens: number }[];
+		subagents: readonly { model: string; tokens: number }[];
+	};
+	delegation?: {
+		mainToolCalls: number;
+		subagentToolCalls: number;
+		widestFanOut: number;
+		mostSubagents: number;
+	};
+	activity: readonly { weekdayUtc: number; hourUtc: number; events: number }[];
+};
+
+export type WorkflowGitReading = {
+	testFileRuleVersion: string;
+	fileTypeRuleVersion: string;
+	totalCommits: number;
+	lateNightCommits: number;
+	additions: number;
+	removals: number;
+	changedLinesPerCommit: readonly number[];
+	testFileCommits: number;
+	changedLinesByExtension: readonly {
+		extension: string;
+		changedLines: number;
+	}[];
+	withheldExtensionLines: number;
+	weekdayHourCells: readonly {
+		weekday: number;
+		hour: number;
+		commits: number;
+	}[];
+};
+
+export type WorkflowMetricReading = {
+	metricId: string;
+	ruleVersion: string;
+	value: number;
+	band: { low: number; high: number };
+	coverage: number;
+	coverageTag?: string;
+};
+
+export type WorkflowReading = {
+	aggregateVersion: string;
+	harnesses: readonly WorkflowHarnessReading[];
+	git: WorkflowGitReading;
+	metrics: readonly WorkflowMetricReading[];
+	/**
+	 * The publishing machine's offset from UTC, in minutes east. Session hours
+	 * travel in UTC, and the lead renders them in the OWNER's local time, so
+	 * without this the rhythm clause has nothing to convert with.
+	 */
+	utcOffsetMinutes?: number;
+};
+
+/**
+ * The kit's inputs, which are the only component fact that does NOT live in the
+ * workflow section: skills and MCP servers are inventory, and inventory travels
+ * in the measured payload. One entry per harness, already name-filtered on the
+ * machine.
+ */
+export type KitReading = readonly {
+	harness: string;
+	skills: readonly { name: string; callShare: number }[];
+	mcpServers: readonly { name: string; callShare: number }[];
+}[];
+
+const EMPTY_TOTALS: PhaseTotals = {
+	scout: 0,
+	build: 0,
+	verify: 0,
+	handoff: 0,
+	unknown: 0,
+};
+
+/** Every harness reading that shipped a playbook, i.e. passed its own gate. */
+export function playbookHarnesses(
+	reading: WorkflowReading,
+): WorkflowHarnessReading[] {
+	return reading.harnesses.filter((harness) => harness.phase !== undefined);
+}
+
+/** Measured seconds per phase, summed over the harnesses that shipped a playbook. */
+export function totalPhaseSec(reading: WorkflowReading): PhaseTotals {
+	const totals = { ...EMPTY_TOTALS };
+	for (const harness of playbookHarnesses(reading)) {
+		for (const phase of Object.keys(totals) as PhaseId[]) {
+			totals[phase] += harness.phase?.phaseSec[phase] ?? 0;
+		}
+	}
+	return totals;
+}
+
+/** Share of TOTAL measured time per phase, `unknown` included, summing to 1. */
+export function phaseShare(reading: WorkflowReading): PhaseTotals | undefined {
+	const totals = totalPhaseSec(reading);
+	const measured = Object.values(totals).reduce((sum, sec) => sum + sec, 0);
+	if (measured <= 0) return undefined;
+	const shares = { ...totals };
+	for (const phase of Object.keys(totals) as PhaseId[]) {
+		shares[phase] = totals[phase] / measured;
+	}
+	return shares;
+}
+
+/** Every session row of every harness that shipped a playbook. */
+export function sessionRows(reading: WorkflowReading): WorkflowSessionRow[] {
+	return playbookHarnesses(reading).flatMap((harness) => [
+		...(harness.phase?.sessionRows ?? []),
+	]);
+}
+
+/**
+ * Share of sessions holding at least one event of `phase`.
+ *
+ * The denominator is the PLAYBOOK sessions, not every synced session: a harness
+ * held back by the gate ships no session rows at all, so it can neither raise
+ * nor lower this share. The scope line above it counts every session, which is
+ * the number a reader doing arithmetic would use, and the two denominators are
+ * why the lead names its scope before it prints a share.
+ */
+export function sessionShareWith(
+	reading: WorkflowReading,
+	phase: PhaseId,
+): number | undefined {
+	const rows = sessionRows(reading);
+	if (rows.length === 0) return undefined;
+	return rows.filter((row) => row.phaseEvents[phase] > 0).length / rows.length;
+}
+
+/**
+ * The hour most sessions start, in the OWNER's local time.
+ *
+ * Undefined without an offset. A reader's own clock would put a stranger's habit
+ * at the wrong hour and describe nobody (spec), and UTC would do the same to
+ * every owner outside London.
+ */
+export function modalStartHour(reading: WorkflowReading): number | undefined {
+	const offsetMinutes = reading.utcOffsetMinutes;
+	if (offsetMinutes === undefined) return undefined;
+	const rows = sessionRows(reading);
+	if (rows.length === 0) return undefined;
+	const counts = new Map<number, number>();
+	for (const row of rows) {
+		const local =
+			((((row.startHourUtc * 60 + offsetMinutes) / 60) % 24) + 24) % 24;
+		const hour = Math.floor(local);
+		counts.set(hour, (counts.get(hour) ?? 0) + 1);
+	}
+	// Ties go to the earlier hour, so the same reading always names the same one.
+	return [...counts.entries()].sort(
+		(a, b) => b[1] - a[1] || a[0] - b[0],
+	)[0]?.[0];
+}
+
+/** Distinct phase rule versions in this reading, in the order the page should print them. */
+export function phaseRuleVersions(reading: WorkflowReading): string[] {
+	return [
+		...new Set(
+			playbookHarnesses(reading).map(
+				(harness) => harness.phase?.ruleVersion as string,
+			),
+		),
+	].sort();
+}
+
+/** Distinct metric rule versions in this reading. */
+export function metricRuleVersions(reading: WorkflowReading): string[] {
+	return [
+		...new Set(reading.metrics.map((metric) => metric.ruleVersion)),
+	].sort();
+}
+
+/**
+ * True when one reading carries aggregates from more than one rule set.
+ *
+ * "A rule-set bump reclassifies old sessions from local raw records at the next
+ * sync. A session whose raw records are gone keeps its old aggregate, and the
+ * page shows a mixed-version tag" (spec). The tag is a fact about the reading,
+ * so it is computed here rather than stored: a later bump makes it true without
+ * a migration.
+ */
+export function hasMixedRuleVersions(reading: WorkflowReading): boolean {
+	return (
+		phaseRuleVersions(reading).length > 1 ||
+		metricRuleVersions(reading).length > 1
+	);
+}
+
+export type LeadFactsInput = {
+	reading: WorkflowReading;
+	/** Every synced session on this machine, including harnesses held back by the gate. */
+	sessionCount: number;
+	/** Every synced harness on this machine, for the same reason. */
+	harnessCount: number;
+};
+
+/**
+ * The five figures `lead-templates/v1` prints, derived from one stored reading.
+ *
+ * Absent inputs stay absent: the lead drops a sentence it cannot fill, and this
+ * function never substitutes a default for a measurement that does not exist.
+ */
+export function buildLeadFacts(input: LeadFactsInput): {
+	sessionCount: number;
+	harnessCount: number;
+	playbookHarnessCount: number;
+	phaseShare?: PhaseTotals;
+	verifySessionShare?: number;
+	handoffSessionShare?: number;
+	modalStartHourOwnerLocal?: number;
+	ruleVersion?: string;
+} {
+	const { reading, sessionCount, harnessCount } = input;
+	const versions = phaseRuleVersions(reading);
+	const shares = phaseShare(reading);
+	const verify = sessionShareWith(reading, "verify");
+	const handoff = sessionShareWith(reading, "handoff");
+	const hour = modalStartHour(reading);
+	return {
+		sessionCount,
+		harnessCount,
+		playbookHarnessCount: playbookHarnesses(reading).length,
+		...(shares ? { phaseShare: shares } : {}),
+		...(verify === undefined ? {} : { verifySessionShare: verify }),
+		...(handoff === undefined ? {} : { handoffSessionShare: handoff }),
+		...(hour === undefined ? {} : { modalStartHourOwnerLocal: hour }),
+		// Mixed versions print as the set. One reading classified by two rule sets
+		// has no single rule id to cite, and citing the newer one would claim the
+		// older sessions were reclassified when they were not.
+		...(versions.length === 0 ? {} : { ruleVersion: versions.join(" · ") }),
+	};
+}

--- a/packages/workflow-rules/src/workflowRows.test.ts
+++ b/packages/workflow-rules/src/workflowRows.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, test } from "vitest";
+import { COMPONENT_RULES_V1, componentRule } from "./componentRules.js";
+import { METRIC_RULES } from "./metricRules.js";
+import {
+	buildLeadFacts,
+	hasMixedRuleVersions,
+	modalStartHour,
+	phaseShare,
+	sessionShareWith,
+	type WorkflowHarnessReading,
+	type WorkflowReading,
+	type WorkflowSessionRow,
+} from "./reading.js";
+import { renderLeadMarkdown, renderLeadSentences } from "./templateLead.js";
+import { buildWorkflowRows } from "./workflowRows.js";
+
+const NO_TOTALS = {
+	scout: 0,
+	build: 0,
+	verify: 0,
+	handoff: 0,
+	unknown: 0,
+};
+
+function sessionRow(
+	over: Partial<WorkflowSessionRow> = {},
+): WorkflowSessionRow {
+	return {
+		startHourUtc: 21,
+		eventCount: 40,
+		phaseSec: { ...NO_TOTALS, scout: 600, build: 200 },
+		phaseEvents: { ...NO_TOTALS, scout: 30, build: 10 },
+		waitingSec: 0,
+		idleSec: 0,
+		merged: false,
+		verifyRuns: 0,
+		reviewRounds: 0,
+		openedWithScout: true,
+		...over,
+	};
+}
+
+function harness(
+	over: Partial<WorkflowHarnessReading> = {},
+): WorkflowHarnessReading {
+	return {
+		harness: "claude-code",
+		phase: {
+			ruleVersion: "phase-rules/v1",
+			publishable: true,
+			sessions: 2,
+			phaseSec: {
+				scout: 640,
+				build: 180,
+				verify: 60,
+				handoff: 50,
+				unknown: 70,
+			},
+			phaseEvents: { scout: 60, build: 20, verify: 6, handoff: 5, unknown: 7 },
+			waitingSec: 30,
+			idleSec: 10,
+			unknownShare: 0.07,
+			sessionRows: [sessionRow(), sessionRow()],
+		},
+		activity: [{ weekdayUtc: 1, hourUtc: 21, events: 40 }],
+		...over,
+	};
+}
+
+function reading(over: Partial<WorkflowReading> = {}): WorkflowReading {
+	return {
+		aggregateVersion: "workflow-aggregates/v1",
+		harnesses: [harness()],
+		git: {
+			testFileRuleVersion: "test-file-rules/v1",
+			fileTypeRuleVersion: "file-type-rules/v1",
+			totalCommits: 20,
+			lateNightCommits: 9,
+			additions: 800,
+			removals: 200,
+			changedLinesPerCommit: [50, 50],
+			testFileCommits: 4,
+			changedLinesByExtension: [
+				{ extension: ".ts", changedLines: 700 },
+				{ extension: ".css", changedLines: 200 },
+			],
+			withheldExtensionLines: 100,
+			weekdayHourCells: [{ weekday: 1, hour: 23, commits: 9 }],
+		},
+		metrics: [
+			{
+				metricId: "late-night-commits",
+				ruleVersion: "metric-rules/v1",
+				value: 0.45,
+				band: { low: 0, high: 0.15 },
+				coverage: 1,
+			},
+		],
+		...over,
+	};
+}
+
+describe("the row set", () => {
+	test("a measured metric becomes a row with its rule's own words", () => {
+		const { rows } = buildWorkflowRows({ reading: reading() });
+		const row = rows.find((r) => r.rowId === "metric:late-night-commits");
+		expect(row).toMatchObject({
+			kind: "metric",
+			ruleId: "late-night-commits",
+			ruleVersion: "metric-rules/v1",
+			label: "of commits land between 23:00 and 03:00",
+			value: 0.45,
+			coverage: 1,
+		});
+	});
+
+	test("a metric id this build has no rule for is dropped and counted, never printed bare", () => {
+		const { rows, unknownMetricIds } = buildWorkflowRows({
+			reading: reading({
+				metrics: [
+					{
+						metricId: "sessions-per-moon-phase",
+						ruleVersion: "metric-rules/v9",
+						value: 3,
+						band: { low: 0, high: 1 },
+						coverage: 1,
+					},
+				],
+			}),
+		});
+		expect(rows.some((r) => r.kind === "metric")).toBe(false);
+		expect(unknownMetricIds).toEqual(["sessions-per-moon-phase"]);
+	});
+
+	test("every pool metric and every component can produce a row", () => {
+		expect(METRIC_RULES).toHaveLength(9);
+		const { rows } = buildWorkflowRows({ reading: reading() });
+		// One metric was measured in this fixture; the components derive from it.
+		expect(rows.filter((r) => r.kind === "component").length).toBeGreaterThan(
+			0,
+		);
+	});
+});
+
+describe("component rules", () => {
+	test("the Git ledger reads the removal share of changed lines", () => {
+		const { rows } = buildWorkflowRows({ reading: reading() });
+		const ledger = rows.find((r) => r.rowId === "component:git-ledger");
+		// 200 removals of 1,000 changed lines.
+		expect(ledger?.value).toBeCloseTo(0.2, 10);
+		expect(ledger?.ruleVersion).toBe(COMPONENT_RULES_V1);
+		// Git history counts every synced harness, whatever the harness records.
+		expect(ledger?.coverage).toBe(1);
+	});
+
+	test("coding languages counts withheld lines in the denominator", () => {
+		const { rows } = buildWorkflowRows({ reading: reading() });
+		// 700 of 700 + 200 + 100 withheld.
+		expect(
+			rows.find((r) => r.rowId === "component:coding-languages")?.value,
+		).toBeCloseTo(0.7, 10);
+	});
+
+	test("the playbook reads the largest named phase's share of measured time", () => {
+		const { rows } = buildWorkflowRows({ reading: reading() });
+		// scout 640 of 1,000 measured seconds, unknown included.
+		expect(
+			rows.find((r) => r.rowId === "component:phase-playbook")?.value,
+		).toBeCloseTo(0.64, 10);
+	});
+
+	test("a component with no data on this reading ships no row", () => {
+		const { rows } = buildWorkflowRows({ reading: reading() });
+		expect(rows.some((r) => r.rowId === "component:model-routing")).toBe(false);
+		expect(rows.some((r) => r.rowId === "component:kit")).toBe(false);
+	});
+
+	test("delegation counts subagent tool calls against every tool call", () => {
+		const { rows } = buildWorkflowRows({
+			reading: reading({
+				harnesses: [
+					harness({
+						delegation: {
+							mainToolCalls: 300,
+							subagentToolCalls: 100,
+							widestFanOut: 4,
+							mostSubagents: 6,
+						},
+					}),
+				],
+			}),
+		});
+		expect(
+			rows.find((r) => r.rowId === "component:delegation")?.value,
+		).toBeCloseTo(0.25, 10);
+	});
+
+	test("a component measured on one of two harnesses carries half coverage", () => {
+		const { rows } = buildWorkflowRows({
+			reading: reading({
+				harnesses: [
+					harness({
+						routing: {
+							main: [{ model: "claude-opus-5", tokens: 900 }],
+							subagents: [{ model: "claude-haiku-4-5", tokens: 100 }],
+						},
+					}),
+					harness({ harness: "codex" }),
+				],
+			}),
+		});
+		const routing = rows.find((r) => r.rowId === "component:model-routing");
+		expect(routing?.value).toBe(1);
+		expect(routing?.coverage).toBe(0.5);
+	});
+
+	test("the kit reads inventory, which travels in the payload rather than the section", () => {
+		const { rows } = buildWorkflowRows({
+			reading: reading(),
+			kit: [
+				{
+					harness: "claude-code",
+					skills: [
+						{ name: "grilling", callShare: 0.24 },
+						{ name: "tdd", callShare: 0.12 },
+					],
+					mcpServers: [{ name: "aistack", callShare: 0.04 }],
+				},
+			],
+		});
+		const kit = rows.find((r) => r.rowId === "component:kit");
+		expect(kit?.value).toBeCloseTo(0.24 / 0.4, 10);
+		expect(kit?.coverage).toBe(1);
+	});
+
+	test("there are seven components", () => {
+		expect(
+			[
+				"phase-playbook",
+				"model-routing",
+				"delegation",
+				"git-ledger",
+				"coding-languages",
+				"activity-heatmap",
+				"kit",
+			].map((id) => componentRule(id)?.id),
+		).toEqual([
+			"phase-playbook",
+			"model-routing",
+			"delegation",
+			"git-ledger",
+			"coding-languages",
+			"activity-heatmap",
+			"kit",
+		]);
+	});
+});
+
+describe("lead facts", () => {
+	test("phase shares are shares of total measured time, unknown included", () => {
+		const shares = phaseShare(reading());
+		expect(shares?.scout).toBeCloseTo(0.64, 10);
+		expect(shares?.unknown).toBeCloseTo(0.07, 10);
+		expect(
+			Object.values(shares ?? {}).reduce((sum, share) => sum + share, 0),
+		).toBeCloseTo(1, 10);
+	});
+
+	test("a session share counts sessions holding at least one event of the phase", () => {
+		const withVerify = reading({
+			harnesses: [
+				harness({
+					phase: {
+						...(harness().phase as NonNullable<
+							WorkflowHarnessReading["phase"]
+						>),
+						sessionRows: [
+							sessionRow(),
+							sessionRow({
+								phaseEvents: { ...NO_TOTALS, scout: 10, verify: 2 },
+							}),
+						],
+					},
+				}),
+			],
+		});
+		expect(sessionShareWith(withVerify, "verify")).toBe(0.5);
+	});
+
+	test("start hours render in the owner's local time, and stay absent without an offset", () => {
+		expect(modalStartHour(reading())).toBeUndefined();
+		// 21:00 UTC on a machine two hours east is 23:00 for the owner.
+		expect(modalStartHour(reading({ utcOffsetMinutes: 120 }))).toBe(23);
+		// And one hour west of midnight wraps back into the previous day.
+		expect(modalStartHour(reading({ utcOffsetMinutes: -22 * 60 }))).toBe(23);
+	});
+
+	test("a reading classified by two rule sets prints both and tags as mixed", () => {
+		const mixed = reading({
+			harnesses: [
+				harness(),
+				harness({
+					harness: "codex",
+					phase: {
+						...(harness().phase as NonNullable<
+							WorkflowHarnessReading["phase"]
+						>),
+						ruleVersion: "phase-rules/v2",
+					},
+				}),
+			],
+		});
+		expect(hasMixedRuleVersions(mixed)).toBe(true);
+		expect(
+			buildLeadFacts({ reading: mixed, sessionCount: 40, harnessCount: 2 })
+				.ruleVersion,
+		).toBe("phase-rules/v1 · phase-rules/v2");
+	});
+
+	test("the facts fill the locked four-line lead", () => {
+		const facts = buildLeadFacts({
+			reading: reading({ utcOffsetMinutes: 120 }),
+			sessionCount: 142,
+			harnessCount: 3,
+		});
+		const lines = renderLeadSentences(facts).map(renderLeadMarkdown);
+		expect(lines[0]).toBe("**142** sessions · **3** harnesses · last 30 days");
+		expect(lines[1]).toBe(
+			"Most measured time in these sessions goes to **scout** (**64%**), then **build** (**18%**).",
+		);
+		expect(lines[3]).toBe(
+			"**7%** of measured time unclassified · `phase-rules/v1`",
+		);
+	});
+
+	test("a stack under twenty sessions gets no lead at all", () => {
+		const facts = buildLeadFacts({
+			reading: reading({ utcOffsetMinutes: 120 }),
+			sessionCount: 4,
+			harnessCount: 1,
+		});
+		expect(renderLeadSentences(facts)).toEqual([]);
+	});
+});

--- a/packages/workflow-rules/src/workflowRows.ts
+++ b/packages/workflow-rules/src/workflowRows.ts
@@ -1,0 +1,88 @@
+// The sixteen rows of one reading: nine pool metrics and seven components.
+//
+// Wayfinder ticket #218 (map #200). This is the join between the two rule pools
+// and the ranking: `metric-rules/v1` values arrive measured on the wire,
+// `component-rules/v1` values are derived from the same reading here, and both
+// enter `rankWorkflowRows` as the same shape.
+
+import type { ComponentInput } from "./componentRules.js";
+import { COMPONENT_RULES } from "./componentRules.js";
+import type { WorkflowRowInput } from "./fitRanking.js";
+import { metricRule } from "./metricRules.js";
+
+/** `metric:late-night-commits`, `component:git-ledger`. Stable: a pin is keyed on it. */
+export function metricRowId(metricId: string): string {
+	return `metric:${metricId}`;
+}
+
+export function componentRowId(componentId: string): string {
+	return `component:${componentId}`;
+}
+
+export type WorkflowRowSet = {
+	rows: WorkflowRowInput[];
+	/**
+	 * Metric ids this build has no rule for, so no row could describe them.
+	 *
+	 * A CLI newer than the server can ship one. The value is real, but the label
+	 * and the band that make it a row are the SERVER's half of the rule, so the
+	 * row is dropped rather than printed as a bare number - and counted here, so
+	 * a drop is visible rather than silent.
+	 */
+	unknownMetricIds: string[];
+};
+
+/**
+ * Build the row set for one reading.
+ *
+ * "A row ships when its measurement exists. A missing measurement stays absent,
+ * so no separate first-ship list exists" (spec). Both pools follow it: the CLI
+ * omits a metric it could not measure, and a component rule returns undefined
+ * for a reading that cannot support it.
+ */
+export function buildWorkflowRows(input: ComponentInput): WorkflowRowSet {
+	const rows: WorkflowRowInput[] = [];
+	const unknownMetricIds: string[] = [];
+
+	for (const metric of input.reading.metrics) {
+		const rule = metricRule(metric.metricId);
+		if (!rule) {
+			unknownMetricIds.push(metric.metricId);
+			continue;
+		}
+		rows.push({
+			rowId: metricRowId(metric.metricId),
+			kind: "metric",
+			ruleId: metric.metricId,
+			// The version the MACHINE used, not this build's. A bumped rule that
+			// changed its band is why the band travels with the value.
+			ruleVersion: metric.ruleVersion,
+			label: rule.label,
+			unit: rule.unit,
+			value: metric.value,
+			band: metric.band,
+			coverage: metric.coverage,
+			...(metric.coverageTag === undefined
+				? {}
+				: { coverageTag: metric.coverageTag }),
+		});
+	}
+
+	for (const rule of COMPONENT_RULES) {
+		const value = rule.evaluate(input);
+		if (value === undefined) continue;
+		rows.push({
+			rowId: componentRowId(rule.id),
+			kind: "component",
+			ruleId: rule.id,
+			ruleVersion: rule.version,
+			label: rule.label,
+			unit: rule.unit,
+			value,
+			band: rule.band,
+			coverage: rule.coverage(input),
+		});
+	}
+
+	return { rows, unknownMetricIds };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@aistack/pricing':
         specifier: workspace:*
         version: link:packages/pricing
+      '@aistack/workflow-rules':
+        specifier: workspace:*
+        version: link:packages/workflow-rules
       '@convex-dev/better-auth':
         specifier: ^0.10.9
         version: 0.10.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.4))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@standard-schema/spec@1.1.0)(better-auth@1.4.10(@tanstack/react-start@1.145.3(crossws@0.4.10(srvx@0.11.16))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.13.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@24.13.0)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(better-call@1.1.7(zod@4.3.4))(convex@1.32.0(react@19.2.3))(nanostores@1.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
@@ -2298,7 +2301,6 @@ packages:
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@takumi-rs/core-linux-x64-musl@0.70.4':
     resolution: {integrity: sha512-OLrZXkz9/H37vuHihmQlrJBgsNd0vXbGMFc+Vec+mZoIB3oF9WShI9nyAULUldF+vM6Z+OrXm23dGB/DOoDykg==}
@@ -4965,6 +4967,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0


### PR DESCRIPTION
Closes the storage and ranking half of the measured workflow surface, ticket [#218](https://github.com/alp82/aistack/issues/218) on [map #200](https://github.com/alp82/aistack/issues/200).

## What lands

- **`measuredWorkflows`**: one row per (stack, machine), replaced on every sync. It holds the section, the podium, the previous window's row values, and any detail dropped to stay inside the document limit.
- **`workflowRowOverrides`**: the owner's pins and hides, keyed on the stack.
- **`@aistack/workflow-rules`** gains the pure half: `fitRanking.ts` (surprise, fit, movement, rotation, placement), `componentRules.ts` (`component-rules/v1`, the seven components), `reading.ts` (lead facts, rule versions, mixed-version tag), and `workflowRows.ts` (the sixteen rows).
- **`convex/workflow.ts`**: `getWorkflowByStackSlug` for the section (#215 renders it) and `setWorkflowRowOverride` for the pin and hide controls.
- **`utcOffsetMinutes`** joins the wire section, so the locked lead can render start hours in the owner's local time.
- **[ADR-0009](https://github.com/alp82/aistack/blob/218-store-workflow-and-fit-state/docs/adr/0009-a-workflow-reading-is-one-machines.md)**: a workflow reading is one machine's, and why that is the opposite answer to ADR-0006's.

## The decisions worth reading

**Fit.** Surprise is `d / (d + band width)`. A value inside its band scores zero and sinks behind the expander, one band width outside scores a half, and the scale never reaches 1, so two wildly out-of-band rows still order against each other. Ties break on movement against the prior window.

**Rotation at the sync, fit at the read.** Two of the three rotation rules compare against the last sync, so the podium is server state. Fit is recomputed from the stored section on every read, so no stored copy can disagree with the section beside it.

**Components had to become rankable.** The spec's row set is sixteen rows and only nine could compete. `component-rules/v1` derives a headline value and a band for each component from aggregates the machine already shipped, so the CLI stays the only source of measured values. The bands are v1 defaults, uncalibrated, exactly like `metric-rules/v1`.

**A publish never fails over section size.** The commit strip drops first, session rows second, and the row records which went.

## Tests

2,387 pass, 64 of them new: 41 in the rules package, 23 against the Convex functions through `convexTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fu2UYXr1VCkMiJ4LrABeyz