### PR TITLE
Build the Workflow section and owner controls (alp82/aistack#215)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,8 +113,9 @@ The Workflow section on the stack page. Spec:
 
 * **The rules are one package**: `packages/workflow-rules` (`@aistack/workflow-rules`),
   imported by the CLI, the Convex backend, and the web app. It holds `phase-rules/v1`,
-  `metric-rules/v1`, `component-rules/v1`, `lead-templates/v1`, and the fit and rotation
-  arithmetic. Every function in it is pure, so it is where a rule change gets tested.
+  `metric-rules/v1`, `component-rules/v1`, `lead-templates/v1`, `playbook-rules/v1`, and
+  the fit and rotation arithmetic. Every function in it is pure, so it is where a rule
+  change gets tested.
 * **Fit splits between the machine and the server.** The CLI measures and ships value,
   band, coverage and rule id per pool metric. The server computes fit (coverage times
   surprise), applies the rotation limit, and applies the owner's pins and hides.
@@ -127,6 +128,13 @@ The Workflow section on the stack page. Spec:
 * The `publishWorkflow` bit is the consent gate, and it reads at BOTH ends: the CLI skips
   the extraction when it is off, and `getWorkflowByStackSlug` returns null for a reading
   already stored. The presence of a stored section is not consent.
+* **The section is `src/features/workflow`.** It renders what the server hands it and ranks
+  nothing: `placement`, `pinned` and `hidden` arrive computed, and a second ranking on the
+  page could disagree with the first. The two owner controls are pin and hide per row,
+  through `setWorkflowRowOverride`.
+* **The playbook's tracks split on the median measured session, never on intent.** Nothing
+  records what a session was for, so `playbook-rules/v1` names its two tracks the shorter
+  and the longer sessions. A receipt card's head names both sides and claims no direction.
 
 ## News
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -198,10 +198,18 @@ _Avoid_: orient (now scout), gate as a phase name (now handoff)
 
 **Playbook**:
 The public phase surface: two measured shipping tracks with median figures, plus
-receipt cards.
+receipt cards. `playbook-rules/v1` computes it from one reading's session rows.
+
+**Shipping track**:
+One half of the playbook's session set. The split is the median measured session, so the
+two tracks are the shorter sessions and the longer ones. Nothing recorded what a session
+was for, so a track never names an intent.
+_Avoid_: quick fixes, feature work (both name an intent no rule computed)
 
 **Receipt card**:
-One card that pairs a habit with its measured payoff.
+One card that pairs a habit with its measured payoff. Its head names both sides and claims
+no direction: which side is larger is the reading's answer, and the card says the two were
+measured together with no cause claimed.
 
 **Owner mirror**:
 A private local view that names the owner's biggest measured time sink and its lever.

--- a/convex/workflow.ts
+++ b/convex/workflow.ts
@@ -40,6 +40,17 @@ import { WorkflowSection } from './schema'
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
 
+/** One inventory atom, with the optional absolute count normalized to null. */
+const publicAtom = (atom: {
+	name: string
+	callShare: number
+	calls?: number
+}) => ({
+	name: atom.name,
+	callShare: atom.callShare,
+	calls: atom.calls ?? null,
+})
+
 /** Every row id either rule pool can produce. A pin or a hide must name one. */
 const KNOWN_ROW_IDS: ReadonlySet<string> = new Set([
 	...METRIC_RULES.map((rule) => metricRowId(rule.id)),
@@ -105,6 +116,43 @@ const WorkflowRow = v.object({
 	hidden: v.boolean(),
 })
 
+/**
+ * One published inventory name and its share of the category's calls.
+ *
+ * The names are filtered on the PUBLISHING machine (#33 decisions 2-4), so
+ * nothing is gated here. `calls` is null on a payload from before #213, which
+ * shipped the share alone.
+ */
+const KitAtom = v.object({
+	name: v.string(),
+	callShare: v.number(),
+	calls: v.union(v.number(), v.null()),
+})
+
+/**
+ * The inventory the kit and delegation components draw, per harness.
+ *
+ * IT IS NOT IN THE WORKFLOW SECTION. Skills, MCP servers and subagents are
+ * inventory, and inventory travels in the measured payload, so the two rows
+ * that render them need the payload beside the reading. `component-rules/v1`
+ * already reads it for the kit row's value; this carries the same rows on to
+ * the page so the row's body shows what the value was computed from.
+ *
+ * `withheld` is the count of distinct names the machine filtered out, so the
+ * gap under the published shares is explained rather than silently absent.
+ */
+const KitHarness = v.object({
+	harness: v.string(),
+	skills: v.array(KitAtom),
+	mcpServers: v.array(KitAtom),
+	subagents: v.array(KitAtom),
+	withheld: v.object({
+		skills: v.number(),
+		mcpServers: v.number(),
+		subagents: v.number(),
+	}),
+})
+
 const WorkflowView = v.object({
 	/** The published machine name, null when withheld or untagged. */
 	machine: v.union(v.string(), v.null()),
@@ -144,6 +192,8 @@ const WorkflowView = v.object({
 	isOwner: v.boolean(),
 	/** The stored aggregates the seven components render. */
 	section: WorkflowSection,
+	/** The inventory two of those seven need, which lives in the payload. */
+	kit: v.array(KitHarness),
 })
 
 /**
@@ -253,6 +303,17 @@ export const getWorkflowByStackSlug = query({
 			lastSwapDayUtc: selected.lastSwapDayUtc ?? null,
 			isOwner,
 			section: selected.section,
+			kit: snapshots.map((snapshot) => ({
+				harness: snapshot.harness,
+				skills: snapshot.payload.inventory.skills.map(publicAtom),
+				mcpServers: snapshot.payload.inventory.mcpServers.map(publicAtom),
+				subagents: snapshot.payload.inventory.subagents.map(publicAtom),
+				withheld: {
+					skills: snapshot.payload.inventory.withheld.skills,
+					mcpServers: snapshot.payload.inventory.withheld.mcpServers,
+					subagents: snapshot.payload.inventory.withheld.subagents,
+				},
+			})),
 		}
 	},
 })

--- a/docs/specs/workflow-surface.md
+++ b/docs/specs/workflow-surface.md
@@ -136,6 +136,15 @@ The public phase surface is the playbook: two measured shipping tracks with medi
 figures, plus receipt cards that pair a habit with its measured payoff. The unknown
 bucket never hides: it prints as small print under the lead, with the rule id.
 
+**The tracks split on the median measured session** (`playbook-rules/v1`, built in
+[#215](https://github.com/alp82/aistack/issues/215)). Nothing on the wire records what a
+session was for, so "quick fix" and "feature work" would be labels no rule computed, and
+the two tracks are named the shorter sessions and the longer ones. The playbook withholds
+itself below 20 sessions, the same floor the lead carries, and when the split leaves one
+track under five sessions. **A receipt card's head names both sides and claims no
+direction**: which side is larger is the reading's answer, and a card ships only when both
+sides clear the same five-session floor.
+
 **The proof ran** ([#196](https://github.com/alp82/aistack/issues/196),
 `prototypes/phase-extraction/`). Across 464 real sessions on three harnesses,
 `phase-rules/v1` leaves **7% of measured time unknown** with no LLM anywhere. The

--- a/packages/workflow-rules/src/index.ts
+++ b/packages/workflow-rules/src/index.ts
@@ -6,6 +6,7 @@ export * from "./fit.js";
 export * from "./fitRanking.js";
 export * from "./metricRules.js";
 export * from "./phaseRules.js";
+export * from "./playbook.js";
 export * from "./reading.js";
 export * from "./templateLead.js";
 export * from "./types.js";

--- a/packages/workflow-rules/src/playbook.test.ts
+++ b/packages/workflow-rules/src/playbook.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildPlaybook,
+	buildReceipts,
+	MIN_PLAYBOOK_SESSIONS,
+	MIN_RECEIPT_SIDE_SESSIONS,
+	measuredSec,
+	PLAYBOOK_RULES_V1,
+} from "./playbook.js";
+import type { WorkflowReading, WorkflowSessionRow } from "./reading.js";
+
+const MIN = 60;
+
+function session(over: Partial<WorkflowSessionRow> = {}): WorkflowSessionRow {
+	return {
+		startHourUtc: 10,
+		eventCount: 40,
+		phaseSec: {
+			scout: 6 * MIN,
+			build: 3 * MIN,
+			verify: 0,
+			handoff: 0,
+			unknown: MIN,
+		},
+		phaseEvents: { scout: 20, build: 10, verify: 0, handoff: 0, unknown: 2 },
+		waitingSec: 0,
+		idleSec: 0,
+		merged: false,
+		verifyRuns: 0,
+		reviewRounds: 0,
+		openedWithScout: true,
+		...over,
+	};
+}
+
+/** One harness that passed its own playbook gate, holding `rows`. */
+function reading(rows: readonly WorkflowSessionRow[]): WorkflowReading {
+	return {
+		aggregateVersion: "workflow-aggregates/v1",
+		harnesses: [
+			{
+				harness: "claude-code",
+				phase: {
+					ruleVersion: "phase-rules/v1",
+					publishable: true,
+					sessions: rows.length,
+					phaseSec: { scout: 0, build: 0, verify: 0, handoff: 0, unknown: 0 },
+					phaseEvents: {
+						scout: 0,
+						build: 0,
+						verify: 0,
+						handoff: 0,
+						unknown: 0,
+					},
+					waitingSec: 0,
+					idleSec: 0,
+					unknownShare: 0.07,
+					sessionRows: rows,
+				},
+				activity: [],
+			},
+		],
+		git: {
+			testFileRuleVersion: "test-file-rules/v1",
+			fileTypeRuleVersion: "file-type-rules/v1",
+			totalCommits: 0,
+			lateNightCommits: 0,
+			additions: 0,
+			removals: 0,
+			changedLinesPerCommit: [],
+			testFileCommits: 0,
+			changedLinesByExtension: [],
+			withheldExtensionLines: 0,
+			weekdayHourCells: [],
+		},
+		metrics: [],
+	};
+}
+
+/** 20 sessions: ten of 10 measured minutes, ten of 50. The median is 50. */
+function twoSizes(): WorkflowSessionRow[] {
+	return [
+		...Array.from({ length: 10 }, () =>
+			session({
+				phaseSec: {
+					scout: 6 * MIN,
+					build: 3 * MIN,
+					verify: 0,
+					handoff: 0,
+					unknown: MIN,
+				},
+			}),
+		),
+		...Array.from({ length: 10 }, () =>
+			session({
+				phaseSec: {
+					scout: 20 * MIN,
+					build: 20 * MIN,
+					verify: 5 * MIN,
+					handoff: 2 * MIN,
+					unknown: 3 * MIN,
+				},
+			}),
+		),
+	];
+}
+
+describe("buildPlaybook: two tracks split on the median measured session", () => {
+	it("splits the sessions and reports each track's median figures", () => {
+		const playbook = buildPlaybook(reading(twoSizes()));
+		if (!playbook) throw new Error("expected a playbook");
+
+		expect(playbook.ruleVersion).toBe(PLAYBOOK_RULES_V1);
+		expect(playbook.sessions).toBe(20);
+		// Ten sessions of 10 minutes and ten of 50: the median is 30.
+		expect(playbook.splitMinutes).toBe(30);
+
+		const [shorter, longer] = playbook.tracks;
+		expect(shorter.sessions).toBe(10);
+		expect(longer.sessions).toBe(10);
+		expect(shorter.medianMinutes).toBe(10);
+		expect(longer.medianMinutes).toBe(50);
+		expect(shorter.scope).toBe("under 30 min of measured time");
+		expect(longer.scope).toBe("30 min and over");
+	});
+
+	it("names the split rather than an intent nobody recorded", () => {
+		const playbook = buildPlaybook(reading(twoSizes()));
+		const labels = playbook?.tracks.map((track) => track.label);
+		expect(labels).toEqual(["Shorter sessions", "Longer sessions"]);
+	});
+
+	it("gives each track its own phase mix, summing to one", () => {
+		const playbook = buildPlaybook(reading(twoSizes()));
+		if (!playbook) throw new Error("expected a playbook");
+		const [shorter, longer] = playbook.tracks;
+
+		// Every shorter session is 6 min scout, 3 build, 1 unknown.
+		expect(shorter.phaseShare.scout).toBeCloseTo(0.6, 10);
+		expect(shorter.phaseShare.verify).toBe(0);
+		expect(longer.phaseShare.verify).toBeCloseTo(0.1, 10);
+		for (const track of playbook.tracks) {
+			const total = Object.values(track.phaseShare).reduce((a, b) => a + b, 0);
+			expect(total).toBeCloseTo(1, 10);
+		}
+	});
+
+	it("withholds the playbook below the session floor", () => {
+		const rows = twoSizes().slice(0, MIN_PLAYBOOK_SESSIONS - 1);
+		expect(buildPlaybook(reading(rows))).toBeUndefined();
+	});
+
+	it("withholds the playbook when the split leaves one track too thin", () => {
+		// Twenty sessions of one size: every row lands in `longer`.
+		const rows = Array.from({ length: 20 }, () => session());
+		expect(buildPlaybook(reading(rows))).toBeUndefined();
+	});
+
+	it("counts unknown time as measured time", () => {
+		const row = session({
+			phaseSec: { scout: MIN, build: 0, verify: 0, handoff: 0, unknown: MIN },
+		});
+		expect(measuredSec(row)).toBe(2 * MIN);
+	});
+});
+
+describe("buildReceipts: a habit beside its measured figure", () => {
+	const withVerify = Array.from({ length: 8 }, () =>
+		session({ verifyRuns: 2, reviewRounds: 1 }),
+	);
+	const withoutVerify = Array.from({ length: 8 }, () =>
+		session({ verifyRuns: 0, reviewRounds: 3 }),
+	);
+
+	it("pairs the two sides on one median figure", () => {
+		const cards = buildReceipts([...withVerify, ...withoutVerify]);
+		const card = cards.find((c) => c.id === "verify-review-rounds");
+		if (!card) throw new Error("expected the verify receipt");
+
+		expect(card.sides[0]).toEqual({
+			label: "with a verify step",
+			value: 1,
+			sessions: 8,
+		});
+		expect(card.sides[1]).toEqual({
+			label: "without",
+			value: 3,
+			sessions: 8,
+		});
+		expect(card.ruleVersion).toBe(PLAYBOOK_RULES_V1);
+	});
+
+	it("claims no direction in the head", () => {
+		const cards = buildReceipts([...withVerify, ...withoutVerify]);
+		for (const card of cards) {
+			expect(card.head).not.toMatch(/save|fewer|more|better|faster|worse/i);
+		}
+	});
+
+	it("drops a card whose weaker side is below the floor", () => {
+		const thin = [
+			...withVerify,
+			...withoutVerify.slice(0, MIN_RECEIPT_SIDE_SESSIONS - 1),
+		];
+		const cards = buildReceipts(thin);
+		expect(cards.some((card) => card.id === "verify-review-rounds")).toBe(
+			false,
+		);
+	});
+
+	it("drops a card when every session holds the habit", () => {
+		expect(buildReceipts(withVerify)).toEqual([]);
+	});
+});

--- a/packages/workflow-rules/src/playbook.ts
+++ b/packages/workflow-rules/src/playbook.ts
@@ -1,0 +1,260 @@
+// The public phase surface: `playbook-rules/v1`.
+//
+// Wayfinder ticket #215 (map #200). CONTEXT.md defines the playbook as "two
+// measured shipping tracks with median figures, plus receipt cards", and a
+// receipt card as "one card that pairs a habit with its measured payoff".
+// This module is the rule that produces both, from the session rows one
+// machine's reading already carries.
+//
+// NO LLM ANYWHERE (ADR-0002). Every sentence below is a fixed string and every
+// number is a median or a share over measured seconds. The card heads name the
+// two sides and claim no direction between them: which side is larger is the
+// reading's answer, not the template's.
+//
+// THE TRACKS SPLIT ON MEASURED TIME, not on intent. A session's purpose is not
+// recorded anywhere, so "quick fix" and "feature work" would be labels no rule
+// computed. The split is the median measured session, and both track names say
+// exactly that.
+//
+// THRESHOLDS ARE V1 DEFAULTS, the same caveat `metric-rules/v1` and
+// `component-rules/v1` carry: no calibration run has happened, and prod has
+// four living stacks to calibrate against.
+
+import type { WorkflowSessionRow } from "./reading.js";
+import { sessionRows, type WorkflowReading } from "./reading.js";
+import { PHASES, type PhaseId } from "./types.js";
+
+export const PLAYBOOK_RULES_V1 = "playbook-rules/v1";
+
+/**
+ * Sessions a reading needs before the playbook prints at all.
+ *
+ * The same floor the lead uses (`MIN_LEAD_SESSION_COUNT`), for the same reason:
+ * a median over four sessions is true and meaningless.
+ */
+export const MIN_PLAYBOOK_SESSIONS = 20;
+
+/** Sessions each track needs. Below it the split has no two halves to compare. */
+export const MIN_TRACK_SESSIONS = 5;
+
+/** Sessions each side of a receipt card needs before the card ships. */
+export const MIN_RECEIPT_SIDE_SESSIONS = 5;
+
+export type PlaybookTrackId = "shorter" | "longer";
+
+export type PlaybookTrack = {
+	id: PlaybookTrackId;
+	/** Fixed label. Names the measured split, never an intent. */
+	label: string;
+	/** How the split placed this track, in the reader's words. */
+	scope: string;
+	sessions: number;
+	/** Share of this track's measured time per phase, `unknown` included. */
+	phaseShare: Record<PhaseId, number>;
+	medianMinutes: number;
+	medianReviewRounds: number;
+	mergedShare: number;
+};
+
+export type PlaybookReceipt = {
+	id: string;
+	ruleVersion: string;
+	/** A fixed sentence naming both sides. It claims no direction. */
+	head: string;
+	/** What the two figures are counted in. */
+	unit: string;
+	sides: readonly [PlaybookReceiptSide, PlaybookReceiptSide];
+};
+
+export type PlaybookReceiptSide = {
+	label: string;
+	value: number;
+	sessions: number;
+};
+
+export type Playbook = {
+	ruleVersion: string;
+	sessions: number;
+	/** The median measured session, in minutes. It is what split the tracks. */
+	splitMinutes: number;
+	tracks: readonly [PlaybookTrack, PlaybookTrack];
+	receipts: readonly PlaybookReceipt[];
+};
+
+const MIN_PER_SEC = 1 / 60;
+
+function median(values: readonly number[]): number | undefined {
+	if (values.length === 0) return undefined;
+	const sorted = [...values].sort((a, b) => a - b);
+	const mid = Math.floor(sorted.length / 2);
+	const midValue = sorted[mid];
+	if (midValue === undefined) return undefined;
+	return sorted.length % 2 === 0
+		? ((sorted[mid - 1] as number) + midValue) / 2
+		: midValue;
+}
+
+/** Measured seconds in one session: every phase bucket, `unknown` included. */
+export function measuredSec(row: WorkflowSessionRow): number {
+	return PHASES.reduce((sum, phase) => sum + row.phaseSec[phase], 0);
+}
+
+function shareOfPhases(
+	rows: readonly WorkflowSessionRow[],
+): Record<PhaseId, number> {
+	const totals = {} as Record<PhaseId, number>;
+	for (const phase of PHASES) {
+		totals[phase] = rows.reduce((sum, row) => sum + row.phaseSec[phase], 0);
+	}
+	const measured = PHASES.reduce((sum, phase) => sum + totals[phase], 0);
+	if (measured <= 0) return totals;
+	for (const phase of PHASES) totals[phase] = totals[phase] / measured;
+	return totals;
+}
+
+function buildTrack(
+	id: PlaybookTrackId,
+	label: string,
+	scope: string,
+	rows: readonly WorkflowSessionRow[],
+): PlaybookTrack {
+	return {
+		id,
+		label,
+		scope,
+		sessions: rows.length,
+		phaseShare: shareOfPhases(rows),
+		medianMinutes: (median(rows.map(measuredSec)) ?? 0) * MIN_PER_SEC,
+		medianReviewRounds: median(rows.map((row) => row.reviewRounds)) ?? 0,
+		mergedShare:
+			rows.length === 0
+				? 0
+				: rows.filter((row) => row.merged).length / rows.length,
+	};
+}
+
+/**
+ * The two tracks and their receipt cards, or undefined when the reading is too
+ * thin to carry either.
+ *
+ * "A row ships when its measurement exists" (spec). The playbook follows the
+ * same rule: too few sessions, or a split that leaves one track nearly empty,
+ * and nothing prints rather than a median over a handful of runs.
+ */
+export function buildPlaybook(reading: WorkflowReading): Playbook | undefined {
+	const rows = sessionRows(reading);
+	if (rows.length < MIN_PLAYBOOK_SESSIONS) return undefined;
+
+	const splitSec = median(rows.map(measuredSec));
+	if (splitSec === undefined || splitSec <= 0) return undefined;
+	const splitMinutes = splitSec * MIN_PER_SEC;
+
+	const shorter = rows.filter((row) => measuredSec(row) < splitSec);
+	const longer = rows.filter((row) => measuredSec(row) >= splitSec);
+	if (
+		shorter.length < MIN_TRACK_SESSIONS ||
+		longer.length < MIN_TRACK_SESSIONS
+	) {
+		return undefined;
+	}
+
+	const bound = `${Math.round(splitMinutes)} min`;
+	return {
+		ruleVersion: PLAYBOOK_RULES_V1,
+		sessions: rows.length,
+		splitMinutes,
+		tracks: [
+			buildTrack(
+				"shorter",
+				"Shorter sessions",
+				`under ${bound} of measured time`,
+				shorter,
+			),
+			buildTrack("longer", "Longer sessions", `${bound} and over`, longer),
+		],
+		receipts: buildReceipts(rows),
+	};
+}
+
+type ReceiptRule = {
+	id: string;
+	head: string;
+	unit: string;
+	withLabel: string;
+	withoutLabel: string;
+	/** True for the sessions that hold the habit. */
+	holds: (row: WorkflowSessionRow) => boolean;
+	/** The figure both sides are compared on. */
+	figure: (row: WorkflowSessionRow) => number;
+};
+
+/**
+ * The receipt pool.
+ *
+ * A HEAD NAMES BOTH SIDES AND CLAIMS NO DIRECTION. "Tests before the gate save
+ * review rounds" is a claim no rule computed, and on a stack where the numbers
+ * run the other way the card would print a sentence its own figures refute.
+ * The footnote every card carries says the rest: measured together, no cause
+ * claimed.
+ */
+const RECEIPT_RULES: readonly ReceiptRule[] = [
+	{
+		id: "verify-review-rounds",
+		head: "Review rounds, with and without a verify step.",
+		unit: "median review rounds per session",
+		withLabel: "with a verify step",
+		withoutLabel: "without",
+		holds: (row) => row.verifyRuns > 0,
+		figure: (row) => row.reviewRounds,
+	},
+	{
+		id: "scout-session-length",
+		head: "Measured session length, opened with scout or not.",
+		unit: "median minutes of measured time",
+		withLabel: "opened with scout",
+		withoutLabel: "opened otherwise",
+		holds: (row) => row.openedWithScout,
+		figure: (row) => measuredSec(row) * MIN_PER_SEC,
+	},
+];
+
+/**
+ * Every receipt card the session rows can support.
+ *
+ * A card ships only when BOTH sides clear the floor. One side of five sessions
+ * and one of a hundred is a comparison in shape only, and printing it would
+ * give a median over five runs the same weight as a median over a hundred.
+ */
+export function buildReceipts(
+	rows: readonly WorkflowSessionRow[],
+): PlaybookReceipt[] {
+	const cards: PlaybookReceipt[] = [];
+	for (const rule of RECEIPT_RULES) {
+		const held = rows.filter(rule.holds);
+		const rest = rows.filter((row) => !rule.holds(row));
+		if (
+			held.length < MIN_RECEIPT_SIDE_SESSIONS ||
+			rest.length < MIN_RECEIPT_SIDE_SESSIONS
+		) {
+			continue;
+		}
+		const withValue = median(held.map(rule.figure));
+		const withoutValue = median(rest.map(rule.figure));
+		if (withValue === undefined || withoutValue === undefined) continue;
+		cards.push({
+			id: rule.id,
+			ruleVersion: PLAYBOOK_RULES_V1,
+			head: rule.head,
+			unit: rule.unit,
+			sides: [
+				{ label: rule.withLabel, value: withValue, sessions: held.length },
+				{
+					label: rule.withoutLabel,
+					value: withoutValue,
+					sessions: rest.length,
+				},
+			],
+		});
+	}
+	return cards;
+}

--- a/src/features/workflow/Lead.tsx
+++ b/src/features/workflow/Lead.tsx
@@ -1,0 +1,206 @@
+import {
+	type LeadPart,
+	type LeadSentence,
+	renderLeadSentences,
+} from "@aistack/workflow-rules";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+	MEASURED_TIME_NOTE,
+	MONO_LABEL,
+	PHASE_GLOSSARY,
+	PHASE_PAINT,
+	type WorkflowView,
+} from "./copy";
+
+/**
+ * The deterministic template lead: `lead-templates/v1`, wording locked in #220.
+ *
+ * THIS COMPONENT OWNS THE MARKUP AND NOTHING ELSE. The words and the numbers
+ * come from `renderLeadSentences`, which returns typed parts precisely so that
+ * "which part the reader sees highlighted" stays a styling decision here rather
+ * than a baked string there. The lead withholds itself below 20 sessions and
+ * when no harness passed the playbook gate; both floors live in the rule, so an
+ * empty list is the answer and this renders nothing.
+ *
+ * TWO `?` MARKERS, NO MORE (#220). One on the first phase name, opening one
+ * card that defines all four phases. One on "measured time", which a reader
+ * would otherwise take for wall-clock time. Six dashed underlines in a short
+ * paragraph read as a minefield.
+ */
+export function Lead({ lead }: { lead: WorkflowView["lead"] }) {
+	const [open, setOpen] = useState<"phases" | "measured-time" | null>(null);
+	const sentences = renderLeadSentences(lead);
+	if (sentences.length === 0) return null;
+
+	const toggle = (card: "phases" | "measured-time") =>
+		setOpen((held) => (held === card ? null : card));
+
+	return (
+		<div className="mb-10 max-w-3xl">
+			{sentences.map((sentence) => (
+				<LeadLine
+					key={sentence.id}
+					sentence={sentence}
+					open={open}
+					onToggle={toggle}
+				/>
+			))}
+			{open === "phases" && <PhaseCard onClose={() => setOpen(null)} />}
+			{open === "measured-time" && (
+				<NoteCard text={MEASURED_TIME_NOTE} onClose={() => setOpen(null)} />
+			)}
+		</div>
+	);
+}
+
+const LINE_CLASS: Record<string, string> = {
+	scope: cn(MONO_LABEL, "text-fg-muted"),
+	"phase-mix": "mt-3 text-xl leading-relaxed text-fg-primary md:text-2xl",
+	stats: "mt-4 font-mono text-xs text-fg-secondary md:text-sm",
+	"unknown-share": "mt-3 font-mono text-[11px] text-fg-muted",
+};
+
+function LeadLine({
+	sentence,
+	open,
+	onToggle,
+}: {
+	sentence: LeadSentence;
+	open: string | null;
+	onToggle: (card: "phases" | "measured-time") => void;
+}) {
+	// The phase name is the FIRST value part of the mix sentence in both of its
+	// forms, the ranked one and the even-split one. Keying on the position keeps
+	// this renderer out of the business of parsing the template's words.
+	let phaseMarkerUsed = sentence.id !== "phase-mix";
+	let timeMarkerUsed = sentence.id !== "phase-mix";
+
+	return (
+		<p className={LINE_CLASS[sentence.id] ?? "text-fg-primary"}>
+			{sentence.parts.map((part, index) => {
+				const key = `${sentence.id}-${index}`;
+				if (part.kind === "value" && !phaseMarkerUsed) {
+					phaseMarkerUsed = true;
+					return (
+						<span key={key}>
+							<Value part={part} />
+							<Marker
+								label="What the phases mean"
+								open={open === "phases"}
+								onClick={() => onToggle("phases")}
+							/>
+						</span>
+					);
+				}
+				if (part.kind === "text" && !timeMarkerUsed) {
+					const at = part.text.indexOf("measured time");
+					if (at >= 0) {
+						timeMarkerUsed = true;
+						const end = at + "measured time".length;
+						return (
+							<span key={key}>
+								{part.text.slice(0, end)}
+								<Marker
+									label="What measured time means"
+									open={open === "measured-time"}
+									onClick={() => onToggle("measured-time")}
+								/>
+								{part.text.slice(end)}
+							</span>
+						);
+					}
+				}
+				if (part.kind === "value") return <Value key={key} part={part} />;
+				if (part.kind === "code") {
+					return (
+						<code key={key} className="font-mono text-fg-secondary">
+							{part.text}
+						</code>
+					);
+				}
+				return <span key={key}>{part.text}</span>;
+			})}
+		</p>
+	);
+}
+
+function Value({ part }: { part: LeadPart }) {
+	return <span className="font-bold text-fg-primary">{part.text}</span>;
+}
+
+function Marker({
+	label,
+	open,
+	onClick,
+}: {
+	label: string;
+	open: boolean;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			aria-label={label}
+			aria-expanded={open}
+			className={cn(
+				"ml-0.5 align-super font-mono text-[10px] leading-none",
+				open ? "text-accent-lime" : "text-fg-muted hover:text-accent-lime",
+			)}
+		>
+			?
+		</button>
+	);
+}
+
+function PhaseCard({ onClose }: { onClose: () => void }) {
+	return (
+		<NoteShell onClose={onClose}>
+			<dl className="grid gap-2">
+				{PHASE_GLOSSARY.map((entry) => (
+					<div key={entry.phase} className="flex items-baseline gap-3">
+						<span
+							aria-hidden="true"
+							className="mt-1 size-2 shrink-0 self-start"
+							style={{ background: PHASE_PAINT[entry.phase] }}
+						/>
+						<dt className={cn(MONO_LABEL, "w-20 shrink-0 text-fg-primary")}>
+							{entry.phase}
+						</dt>
+						<dd className="text-sm text-fg-secondary">{entry.text}</dd>
+					</div>
+				))}
+			</dl>
+		</NoteShell>
+	);
+}
+
+function NoteCard({ text, onClose }: { text: string; onClose: () => void }) {
+	return (
+		<NoteShell onClose={onClose}>
+			<p className="text-sm text-fg-secondary">{text}</p>
+		</NoteShell>
+	);
+}
+
+function NoteShell({
+	children,
+	onClose,
+}: {
+	children: React.ReactNode;
+	onClose: () => void;
+}) {
+	return (
+		<div className="mt-4 border border-stroke-subtle bg-bg-panel/50 p-4">
+			{children}
+			<button
+				type="button"
+				onClick={onClose}
+				className={cn(MONO_LABEL, "mt-3 text-fg-muted hover:text-accent-lime")}
+			>
+				close
+			</button>
+		</div>
+	);
+}

--- a/src/features/workflow/Playbook.tsx
+++ b/src/features/workflow/Playbook.tsx
@@ -1,0 +1,165 @@
+import {
+	buildPlaybook,
+	type PlaybookReceipt,
+	type PlaybookTrack,
+	type WorkflowReading,
+} from "@aistack/workflow-rules";
+import { cn } from "@/lib/utils";
+import {
+	BODY_KICKERS,
+	fmtMinutes,
+	fmtNumber,
+	fmtPercent,
+	harnessLabelOf,
+	MONO_LABEL,
+	NO_CAUSE_CLAIMED,
+	PHASE_ORDER,
+	PHASE_PAINT,
+	type WorkflowView,
+} from "./copy";
+import { BodyFootnote, BodyKicker, Legend, type Segment, Strip } from "./parts";
+
+/**
+ * The phase playbook: two measured shipping tracks plus receipt cards.
+ *
+ * Wayfinder ticket #215 (map #200). CONTEXT.md defines the playbook and the
+ * receipt card; `playbook-rules/v1` computes both, and this renders them.
+ *
+ * THE TRACKS ARE A MEASURED SPLIT, NOT AN INTENT. Nothing recorded what a
+ * session was for, so the rule splits on the median measured session and both
+ * track names say exactly that. A reader who wants "quick fix" versus "feature
+ * work" is reading a claim no rule computed.
+ *
+ * THE UNKNOWN BUCKET NEVER HIDES. It wears its own neutral paint in every strip
+ * and prints as a share with its rule id, because "the unknown bucket ships as
+ * a real number on the page, not as an embarrassment to hide" (spec).
+ */
+export function Playbook({ view }: { view: WorkflowView }) {
+	const reading = view.section as WorkflowReading;
+	const playbook = buildPlaybook(reading);
+	const gated = view.section.harnesses.filter(
+		(harness) => harness.phase === undefined,
+	);
+
+	return (
+		<div>
+			<BodyKicker>{BODY_KICKERS["phase-playbook"]}</BodyKicker>
+
+			{playbook ? (
+				<>
+					<div className="grid gap-6 md:grid-cols-2">
+						{playbook.tracks.map((track) => (
+							<Track key={track.id} track={track} />
+						))}
+					</div>
+					<Legend segments={phaseSegments(playbook.tracks[1])} />
+
+					{playbook.receipts.length > 0 && (
+						<div className="mt-6 grid gap-4 md:grid-cols-2">
+							{playbook.receipts.map((receipt) => (
+								<Receipt key={receipt.id} receipt={receipt} />
+							))}
+						</div>
+					)}
+
+					<BodyFootnote>
+						{playbook.sessions} sessions split at the median measured session,{" "}
+						{fmtMinutes(playbook.splitMinutes)} · {playbook.ruleVersion} ·{" "}
+						{view.phaseRuleVersions.join(" · ")}
+					</BodyFootnote>
+				</>
+			) : (
+				<p className="text-sm text-fg-secondary">
+					Not enough sessions in this window for a median. The phase mix above
+					still holds.
+				</p>
+			)}
+
+			{gated.length > 0 && (
+				<BodyFootnote>
+					held back by the playbook gate:{" "}
+					{gated.map((harness) => harnessLabelOf(harness.harness)).join(" · ")}{" "}
+					· a harness ships its playbook only when the rules leave 20% or less
+					of its measured time unclassified
+				</BodyFootnote>
+			)}
+		</div>
+	);
+}
+
+function phaseSegments(track: PlaybookTrack): Segment[] {
+	return PHASE_ORDER.filter((phase) => track.phaseShare[phase] > 0).map(
+		(phase) => ({
+			key: phase,
+			value: track.phaseShare[phase],
+			paint: PHASE_PAINT[phase],
+			label: phase,
+		}),
+	);
+}
+
+function Track({ track }: { track: PlaybookTrack }) {
+	return (
+		<div className="border border-stroke-subtle p-4">
+			<div className="flex flex-wrap items-baseline justify-between gap-x-4">
+				<h4 className="text-base font-bold text-fg-primary">{track.label}</h4>
+				<p className={cn(MONO_LABEL, "text-fg-muted")}>
+					{track.sessions} sessions
+				</p>
+			</div>
+			<p className="mt-1 font-mono text-[11px] text-fg-muted">{track.scope}</p>
+
+			<Strip className="mt-4" height="h-4" segments={phaseSegments(track)} />
+
+			<p className="mt-3 font-mono text-xs text-fg-secondary">
+				median{" "}
+				<b className="text-fg-primary">{fmtMinutes(track.medianMinutes)}</b> ·
+				review rounds{" "}
+				<b className="text-fg-primary">{fmtNumber(track.medianReviewRounds)}</b>{" "}
+				· merged{" "}
+				<b className="text-fg-primary">{fmtPercent(track.mergedShare)}</b>
+			</p>
+		</div>
+	);
+}
+
+/**
+ * One receipt card: a habit, both sides of it, and one median figure.
+ *
+ * The head names the two sides and claims no direction, and the footnote says
+ * the rest. Which side is larger is the reading's answer.
+ */
+function Receipt({ receipt }: { receipt: PlaybookReceipt }) {
+	const widest = Math.max(...receipt.sides.map((side) => side.value), 0);
+	return (
+		<div className="flex flex-col border border-stroke-subtle p-4">
+			<p className="text-sm font-bold leading-snug text-fg-primary">
+				{receipt.head}
+			</p>
+			<div className="mt-3 grid gap-2">
+				{receipt.sides.map((side) => (
+					<div key={side.label} className="flex items-center gap-3">
+						<span className="w-36 shrink-0 text-xs text-fg-secondary">
+							{side.label}
+						</span>
+						<span className="h-3 flex-1 bg-bg-panel">
+							<span
+								className="block h-full"
+								style={{
+									width: `${widest > 0 ? Math.max(2, (side.value / widest) * 100) : 2}%`,
+									background: PHASE_PAINT.verify,
+								}}
+							/>
+						</span>
+						<span className="w-12 shrink-0 text-right font-mono text-sm font-bold text-fg-primary">
+							{fmtNumber(side.value)}
+						</span>
+					</div>
+				))}
+			</div>
+			<p className={cn(MONO_LABEL, "mt-auto pt-3 text-fg-muted")}>
+				{receipt.unit} · {NO_CAUSE_CLAIMED}
+			</p>
+		</div>
+	);
+}

--- a/src/features/workflow/WorkflowSection.tsx
+++ b/src/features/workflow/WorkflowSection.tsx
@@ -1,0 +1,239 @@
+import { useQuery } from "convex/react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { type KeyboardEvent, useRef, useState } from "react";
+import { Section, SectionHeader } from "@/features/stack-view/ui";
+import { cn, timeAgo } from "@/lib/utils";
+import { api } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
+import {
+	KICKER,
+	MONO_LABEL,
+	TITLE,
+	WORKFLOW_ANCHOR,
+	type WorkflowView,
+} from "./copy";
+import { Lead } from "./Lead";
+import { RowSet } from "./rows";
+
+/**
+ * Journey section 04 - Workflow, the measured surface (spec
+ * `docs/specs/workflow-surface.md`).
+ *
+ * Wayfinder ticket #215 (map #200). Ticket #217 places it in the locked page
+ * order; this file is the section itself.
+ *
+ * THE SECTION COMPUTES ALMOST NOTHING. The CLI measured the values, the server
+ * ranked them and applied the owner's overrides, and `@aistack/workflow-rules`
+ * owns every sentence form. What is left here is markup and one machine
+ * selector.
+ *
+ * NOTHING RENDERS WITHOUT A READING. `getWorkflowByStackSlug` answers null when
+ * the stack has no stored reading AND when `publishWorkflow` is off, and the
+ * flag reads at both ends: an owner who turned the workflow off after a sync
+ * has turned it off for the reading already sent. A stack with no reading gets
+ * no section rather than an empty one, because section 01 already carries the
+ * page's one sync invitation and a second would double it.
+ */
+export function WorkflowSection({
+	index,
+	slug,
+	stackId,
+}: {
+	index: number;
+	slug: string;
+	stackId: Id<"stacks"> | null;
+}) {
+	const [selection, setSelection] = useState<{
+		slug: string;
+		ordinal: number;
+	} | null>(null);
+	const first = useQuery(api.workflow.getWorkflowByStackSlug, { slug });
+
+	// The selector addresses machines by their durable private ordinal (#250), so
+	// a machine whose name is withheld is still selectable.
+	const ordinal =
+		selection?.slug === slug &&
+		first?.machines.some(
+			(machine) => machine.machineOrdinal === selection.ordinal,
+		)
+			? selection.ordinal
+			: null;
+	const selected = useQuery(
+		api.workflow.getWorkflowByStackSlug,
+		ordinal === null ? "skip" : { slug, machineOrdinal: ordinal },
+	);
+	const view = ordinal === null ? first : selected;
+
+	if (view === undefined || view === null) return null;
+
+	return (
+		<Section index={index} id={WORKFLOW_ANCHOR}>
+			<SectionHeader
+				index={String(index).padStart(2, "0")}
+				kicker={KICKER}
+				title={TITLE}
+				meta={
+					view.machines.length > 1 ? (
+						<MachineSelect
+							machines={view.machines}
+							value={ordinal ?? currentOrdinal(view)}
+							onChange={(next) =>
+								setSelection(next === null ? null : { slug, ordinal: next })
+							}
+						/>
+					) : (
+						`read ${timeAgo(view.receivedAt)}`
+					)
+				}
+				metaAlwaysVisible={view.machines.length > 1}
+			/>
+
+			<Lead lead={view.lead} />
+			<RowSet view={view} stackId={stackId} />
+			<Provenance view={view} />
+		</Section>
+	);
+}
+
+function currentOrdinal(view: WorkflowView): number | null {
+	return (
+		view.machines.find((machine) => machine.isCurrent)?.machineOrdinal ?? null
+	);
+}
+
+type MachineOption = WorkflowView["machines"][number];
+
+/**
+ * Which machine's reading the section shows.
+ *
+ * A READING IS ONE MACHINE'S (ADR-0009). There is no "all machines" option here,
+ * unlike section 01's dropdown: the Git half cannot merge without a per-commit
+ * identity the wire does not carry, and a pool metric has no denominator to
+ * merge on. An option that silently summed two machines would be a fourth thing
+ * the data does not say.
+ */
+function MachineSelect({
+	machines,
+	value,
+	onChange,
+}: {
+	machines: readonly MachineOption[];
+	value: number | null;
+	onChange: (ordinal: number | null) => void;
+}) {
+	const [open, setOpen] = useState(false);
+	const triggerRef = useRef<HTMLButtonElement>(null);
+	const selected = machines.find((machine) => machine.machineOrdinal === value);
+	const closeOnEscape = (event: KeyboardEvent) => {
+		if (event.key !== "Escape" || !open) return;
+		event.preventDefault();
+		setOpen(false);
+		triggerRef.current?.focus();
+	};
+
+	return (
+		<div className="relative text-left">
+			<button
+				ref={triggerRef}
+				type="button"
+				aria-label="Machine"
+				aria-haspopup="listbox"
+				aria-expanded={open}
+				onClick={() => setOpen((held) => !held)}
+				onKeyDown={closeOnEscape}
+				className="flex max-w-[min(18rem,calc(100vw-2.5rem))] items-center gap-2 border border-stroke-subtle px-2.5 py-2 text-left font-mono text-[11px] normal-case tracking-normal text-fg-primary"
+			>
+				<span className={cn(MONO_LABEL, "text-[10px] text-fg-muted")}>
+					from
+				</span>
+				<span className="min-w-0 flex-1 truncate">
+					{machineLabel(selected)}
+				</span>
+				{open ? (
+					<ChevronUp aria-hidden="true" className="size-3 shrink-0" />
+				) : (
+					<ChevronDown aria-hidden="true" className="size-3 shrink-0" />
+				)}
+			</button>
+
+			{open && (
+				<div
+					role="listbox"
+					aria-label="Machine"
+					onKeyDown={closeOnEscape}
+					className="absolute top-full right-0 z-50 mt-1 min-w-full border border-stroke-strong bg-bg-panel-elevated shadow-[4px_4px_0_var(--stroke-strong)]"
+				>
+					{machines.map((machine) => (
+						<button
+							key={machine.machineOrdinal ?? machine.receivedAt}
+							type="button"
+							role="option"
+							aria-selected={machine.machineOrdinal === value}
+							onClick={() => {
+								onChange(machine.machineOrdinal);
+								setOpen(false);
+							}}
+							className="block w-full border-t border-stroke-subtle px-3 py-2 text-left first:border-t-0 hover:bg-bg-panel-muted"
+						>
+							<span className="block min-w-48 truncate">
+								{machineLabel(machine)}
+							</span>
+							<span className="mt-0.5 block text-[10px] text-fg-muted">
+								read {timeAgo(machine.receivedAt)}
+							</span>
+						</button>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
+
+/** The published name, or the durable ordinal when the name is withheld (#250). */
+function machineLabel(machine: MachineOption | undefined): string {
+	if (!machine) return "this machine";
+	return machine.machine ?? `machine ${machine.machineOrdinal ?? ""}`.trim();
+}
+
+/**
+ * What produced this reading, under the rows.
+ *
+ * RAW DATA NEVER LEAVES THE MACHINE, and the page says so rather than leaving a
+ * reader to assume the opposite. The rule ids ride along, because a number
+ * whose rule is not named is a number a reader has to take on trust.
+ */
+function Provenance({ view }: { view: WorkflowView }) {
+	const rules = [...view.phaseRuleVersions, ...view.metricRuleVersions];
+	return (
+		<div className="mt-8 border-t border-stroke-subtle pt-4">
+			{view.mixedRuleVersions && (
+				<p className="mb-2 font-mono text-[11px] text-fg-muted">
+					mixed rule versions: this reading carries aggregates from more than
+					one rule set, because a session whose local records are gone keeps the
+					aggregate it already had.
+				</p>
+			)}
+			{view.unknownMetricIds.length > 0 && (
+				<p className="mb-2 font-mono text-[11px] text-fg-muted">
+					{view.unknownMetricIds.length} measurement
+					{view.unknownMetricIds.length === 1 ? "" : "s"} this site has no rule
+					for yet, dropped rather than printed bare:{" "}
+					{view.unknownMetricIds.join(", ")}
+				</p>
+			)}
+			<p className="font-mono text-[11px] text-fg-muted">
+				measured on the owner's machine and published with their consent. Raw
+				transcripts and repository names never leave it. No language model reads
+				this section or writes a word of it
+				{rules.length > 0 ? ` · ${rules.join(" · ")}` : ""}
+				{view.cliVersion ? ` · cli ${view.cliVersion}` : ""}
+				{view.aggregateVersion ? ` · ${view.aggregateVersion}` : ""}
+			</p>
+			{!view.isFresh && (
+				<p className="mt-2 font-mono text-[11px] text-fg-muted">
+					last read {timeAgo(view.receivedAt)}
+				</p>
+			)}
+		</div>
+	);
+}

--- a/src/features/workflow/__tests__/components.test.tsx
+++ b/src/features/workflow/__tests__/components.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+/**
+ * The seven component bodies (#215, map #200).
+ *
+ * The decisions these tests guard:
+ *
+ *   1. THE UNKNOWN BUCKET NEVER HIDES. It has a paint in every strip and a
+ *      share in the footnote, because it ships as a real number rather than as
+ *      an embarrassment.
+ *   2. HOURS RENDER IN THE OWNER'S LOCAL TIME. A reader's own clock would put a
+ *      stranger's habit at the wrong hour and describe nobody.
+ *   3. A COMPONENT WITH NOTHING TO SHOW SAYS SO ABOUT THE READING, never about
+ *      the author: positive claims only (#40).
+ *   4. THE WITHHELD LINES STAY IN THE DENOMINATOR. A stack whose top language
+ *      is unapproved must not read as more concentrated than it is.
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ComponentBody } from "../components";
+import { view } from "./fixture";
+
+afterEach(cleanup);
+
+const show = (componentId: string, over = {}) =>
+	render(<ComponentBody componentId={componentId} view={view(over)} />);
+
+describe("the phase playbook", () => {
+	it("splits the sessions into two named tracks with median figures", () => {
+		show("phase-playbook");
+		expect(screen.getByText("Shorter sessions")).toBeTruthy();
+		expect(screen.getByText("Longer sessions")).toBeTruthy();
+		expect(screen.getAllByText(/median/).length).toBeGreaterThan(0);
+	});
+
+	it("keeps unknown in the legend and names both rule sets", () => {
+		show("phase-playbook");
+		expect(screen.getByText("unknown")).toBeTruthy();
+		expect(screen.getByText(/playbook-rules\/v1/)).toBeTruthy();
+		expect(screen.getByText(/phase-rules\/v1/)).toBeTruthy();
+	});
+
+	it("names the harness the gate held back, and why", () => {
+		show("phase-playbook");
+		expect(
+			screen.getByText(/held back by the playbook gate: opencode/),
+		).toBeTruthy();
+		expect(screen.getByText(/20% or less/)).toBeTruthy();
+	});
+
+	it("pairs a habit with a figure and claims no cause", () => {
+		show("phase-playbook");
+		expect(
+			screen.getByText("Review rounds, with and without a verify step."),
+		).toBeTruthy();
+		expect(
+			screen.getAllByText(/measured together, no cause claimed/).length,
+		).toBeGreaterThan(0);
+	});
+});
+
+describe("the git ledger", () => {
+	it("prints removals apart from additions, in the destructive paint", () => {
+		show("git-ledger");
+		const removals = screen.getByText("-19.3k");
+		expect(removals.getAttribute("style")).toContain("var(--destructive)");
+		expect(screen.getByText("+94.8k")).toBeTruthy();
+	});
+
+	it("draws one dot per commit on a log scale", () => {
+		const { container } = show("git-ledger");
+		const dots = container.querySelectorAll("[title$='changed lines']");
+		expect(dots).toHaveLength(4);
+		// 4 lines and 4,000 lines must not draw the same mark.
+		expect(dots[0]?.getAttribute("style")).not.toBe(
+			dots[3]?.getAttribute("style"),
+		);
+	});
+});
+
+describe("coding languages", () => {
+	it("counts the withheld lines in the denominator", () => {
+		show("coding-languages");
+		// 80,000 of 94,000, not of 92,000.
+		expect(screen.getByText("85%")).toBeTruthy();
+		expect(
+			screen.getByText(/2k in file types the machine withheld/),
+		).toBeTruthy();
+	});
+});
+
+describe("the week and time heatmap", () => {
+	it("shifts the cells into the owner's local time and says so", () => {
+		show("activity-heatmap");
+		expect(screen.getByText("hours in the owner's local time")).toBeTruthy();
+		// 21:00 UTC on Sunday, plus 120 minutes, is 23:00 on Sunday.
+		expect(
+			screen.getByRole("button", { name: "Sun 23:00, 120 events" }),
+		).toBeTruthy();
+	});
+
+	it("stays in UTC, labeled, when the reading carries no offset", () => {
+		render(
+			<ComponentBody
+				componentId="activity-heatmap"
+				view={view({ utcOffsetMinutes: null })}
+			/>,
+		);
+		expect(
+			screen.getByText(/this reading carries no machine offset/),
+		).toBeTruthy();
+	});
+
+	it("opens one cell's recorded events on a tap", () => {
+		show("activity-heatmap");
+		fireEvent.click(
+			screen.getByRole("button", { name: "Sun 23:00, 120 events" }),
+		);
+		expect(screen.getByText(/recorded events/)).toBeTruthy();
+	});
+});
+
+describe("model routing, the kit and delegation", () => {
+	it("gives one model the same paint in both rows", () => {
+		show("model-routing");
+		expect(screen.getByText("main loop")).toBeTruthy();
+		expect(screen.getByText("subagents")).toBeTruthy();
+		expect(screen.getAllByText("claude-opus-5").length).toBeGreaterThan(0);
+	});
+
+	it("lists the kit and explains the gap under the shares", () => {
+		show("kit");
+		expect(screen.getByText("grilling")).toBeTruthy();
+		expect(screen.getByText("curia")).toBeTruthy();
+		expect(screen.getByText(/1 names withheld on the machine/)).toBeTruthy();
+	});
+
+	it("prints the delegation ratio and both records", () => {
+		show("delegation");
+		expect(screen.getByText("2 : 1")).toBeTruthy();
+		expect(screen.getByText("11")).toBeTruthy();
+		expect(screen.getByText("43")).toBeTruthy();
+	});
+
+	it("says what the reading lacks, never what the author failed to do", () => {
+		const bare = view();
+		render(
+			<ComponentBody
+				componentId="model-routing"
+				view={{
+					...bare,
+					section: {
+						...bare.section,
+						harnesses: bare.section.harnesses.map((harness) => ({
+							harness: harness.harness,
+							activity: harness.activity,
+						})),
+					},
+				}}
+			/>,
+		);
+		expect(
+			screen.getByText(
+				"No harness on this machine records a model per response.",
+			),
+		).toBeTruthy();
+	});
+});

--- a/src/features/workflow/__tests__/fixture.ts
+++ b/src/features/workflow/__tests__/fixture.ts
@@ -1,0 +1,277 @@
+import type { WorkflowRow, WorkflowView } from "../copy";
+
+/**
+ * One machine's reading, shaped as `getWorkflowByStackSlug` answers it.
+ *
+ * The numbers are the #196 proof's, so the lead these tests assert against is
+ * the same one the locked wording was checked with.
+ */
+
+const MIN = 60;
+
+export function sessionRow(over: Partial<SessionRow> = {}): SessionRow {
+	return {
+		startHourUtc: 21,
+		eventCount: 40,
+		phaseSec: {
+			scout: 6 * MIN,
+			build: 3 * MIN,
+			verify: 0,
+			handoff: 0,
+			unknown: MIN,
+		},
+		phaseEvents: { scout: 20, build: 10, verify: 0, handoff: 0, unknown: 2 },
+		waitingSec: 0,
+		idleSec: 0,
+		merged: false,
+		verifyRuns: 0,
+		reviewRounds: 0,
+		openedWithScout: true,
+		...over,
+	};
+}
+
+type SessionRow = WorkflowView["section"]["harnesses"][number] extends {
+	phase?: { sessionRows: (infer R)[] };
+}
+	? R
+	: never;
+
+/** Twenty sessions in two sizes, so `playbook-rules/v1` finds two tracks. */
+export function sessionRows(): SessionRow[] {
+	return [
+		...Array.from({ length: 5 }, () =>
+			sessionRow({ verifyRuns: 1, reviewRounds: 1 }),
+		),
+		...Array.from({ length: 5 }, () =>
+			sessionRow({ reviewRounds: 3, openedWithScout: false }),
+		),
+		...Array.from({ length: 10 }, () =>
+			sessionRow({
+				phaseSec: {
+					scout: 20 * MIN,
+					build: 20 * MIN,
+					verify: 5 * MIN,
+					handoff: 2 * MIN,
+					unknown: 3 * MIN,
+				},
+				phaseEvents: {
+					scout: 40,
+					build: 40,
+					verify: 8,
+					handoff: 3,
+					unknown: 5,
+				},
+				verifyRuns: 2,
+				reviewRounds: 2,
+				merged: true,
+			}),
+		),
+	];
+}
+
+export function row(over: Partial<WorkflowRow> = {}): WorkflowRow {
+	return {
+		rowId: "metric:late-night-commits",
+		kind: "metric",
+		ruleId: "late-night-commits",
+		ruleVersion: "metric-rules/v1",
+		label: "of commits land between 23:00 and 03:00",
+		unit: "share",
+		value: 0.42,
+		band: { low: 0, high: 0.15 },
+		coverage: 1,
+		coverageTag: null,
+		surprise: 0.64,
+		fit: 0.86,
+		movement: null,
+		placement: "highlight",
+		pinned: false,
+		hidden: false,
+		...over,
+	};
+}
+
+/** Three highlights, two thin rows, one behind the expander. */
+export function rows(): WorkflowRow[] {
+	return [
+		row(),
+		row({
+			rowId: "metric:parallel-projects",
+			ruleId: "parallel-projects",
+			label: "projects run in parallel on a median active day",
+			unit: "count",
+			value: 2.8,
+			band: { low: 1, high: 1.5 },
+			fit: 0.81,
+		}),
+		row({
+			rowId: "component:phase-playbook",
+			kind: "component",
+			ruleId: "phase-playbook",
+			ruleVersion: "component-rules/v1",
+			label: "of measured time goes to a single phase",
+			value: 0.55,
+			band: { low: 0.25, high: 0.45 },
+			fit: 0.78,
+		}),
+		row({
+			rowId: "component:git-ledger",
+			kind: "component",
+			ruleId: "git-ledger",
+			ruleVersion: "component-rules/v1",
+			label: "of changed lines are removals",
+			value: 0.17,
+			band: { low: 0.15, high: 0.35 },
+			fit: 0.62,
+			placement: "normal",
+		}),
+		row({
+			rowId: "metric:thinking-share",
+			ruleId: "thinking-share",
+			label: "of response tokens are thinking",
+			value: 0.38,
+			band: { low: 0.1, high: 0.3 },
+			coverage: 0.5,
+			coverageTag: "Claude Code",
+			fit: 0.44,
+			movement: 0.03,
+			placement: "normal",
+		}),
+		row({
+			rowId: "metric:web-searches-per-active-day",
+			ruleId: "web-searches-per-active-day",
+			label: "web searches per active day, inside the harness",
+			unit: "count",
+			value: 6,
+			band: { low: 0, high: 4 },
+			fit: 0.24,
+			placement: "low",
+		}),
+	];
+}
+
+export function view(over: Partial<WorkflowView> = {}): WorkflowView {
+	return {
+		machine: "workstation",
+		machineOrdinal: 1,
+		machines: [
+			{
+				machine: "workstation",
+				machineOrdinal: 1,
+				receivedAt: 1_756_000_000_000,
+				isCurrent: true,
+			},
+		],
+		capturedAt: 1_756_000_000_000,
+		receivedAt: 1_756_000_000_000,
+		isFresh: true,
+		cliVersion: "0.9.0",
+		aggregateVersion: "workflow-aggregates/v1",
+		utcOffsetMinutes: 120,
+		trimmed: null,
+		phaseRuleVersions: ["phase-rules/v1"],
+		metricRuleVersions: ["metric-rules/v1"],
+		mixedRuleVersions: false,
+		lead: {
+			sessionCount: 464,
+			harnessCount: 3,
+			playbookHarnessCount: 2,
+			phaseShare: {
+				scout: 0.64,
+				build: 0.18,
+				verify: 0.06,
+				handoff: 0.05,
+				unknown: 0.07,
+			},
+			verifySessionShare: 0.4,
+			handoffSessionShare: 0.62,
+			modalStartHourOwnerLocal: 23,
+			ruleVersion: "phase-rules/v1",
+		},
+		rows: rows(),
+		unknownMetricIds: [],
+		lastSwapDayUtc: null,
+		isOwner: false,
+		kit: [
+			{
+				harness: "claude-code",
+				skills: [
+					{ name: "grilling", callShare: 0.24, calls: 48 },
+					{ name: "tdd", callShare: 0.17, calls: 34 },
+				],
+				mcpServers: [{ name: "curia", callShare: 0.13, calls: 26 }],
+				subagents: [{ name: "Explore", callShare: 0.41, calls: 82 }],
+				withheld: { skills: 1, mcpServers: 0, subagents: 0 },
+			},
+		],
+		section: {
+			aggregateVersion: "workflow-aggregates/v1",
+			utcOffsetMinutes: 120,
+			harnesses: [
+				{
+					harness: "claude-code",
+					phase: {
+						ruleVersion: "phase-rules/v1",
+						publishable: true,
+						sessions: 20,
+						phaseSec: {
+							scout: 0,
+							build: 0,
+							verify: 0,
+							handoff: 0,
+							unknown: 0,
+						},
+						phaseEvents: {
+							scout: 0,
+							build: 0,
+							verify: 0,
+							handoff: 0,
+							unknown: 0,
+						},
+						waitingSec: 0,
+						idleSec: 0,
+						unknownShare: 0.06,
+						sessionRows: sessionRows(),
+					},
+					routing: {
+						main: [{ model: "claude-opus-5", tokens: 890_000 }],
+						subagents: [{ model: "claude-haiku-4-5", tokens: 210_000 }],
+					},
+					delegation: {
+						mainToolCalls: 800,
+						subagentToolCalls: 400,
+						widestFanOut: 11,
+						mostSubagents: 43,
+					},
+					activity: [
+						{ weekdayUtc: 0, hourUtc: 21, events: 120 },
+						{ weekdayUtc: 3, hourUtc: 9, events: 40 },
+					],
+				},
+				{
+					harness: "opencode",
+					activity: [],
+				},
+			],
+			git: {
+				testFileRuleVersion: "test-file-rules/v1",
+				fileTypeRuleVersion: "file-type-rules/v1",
+				totalCommits: 120,
+				lateNightCommits: 50,
+				additions: 94_800,
+				removals: 19_300,
+				changedLinesPerCommit: [4, 40, 400, 4000],
+				testFileCommits: 44,
+				changedLinesByExtension: [
+					{ extension: "ts", changedLines: 80_000 },
+					{ extension: "css", changedLines: 12_000 },
+				],
+				withheldExtensionLines: 2_000,
+				weekdayHourCells: [],
+			},
+			metrics: [],
+		},
+		...over,
+	};
+}

--- a/src/features/workflow/__tests__/workflow-section.test.tsx
+++ b/src/features/workflow/__tests__/workflow-section.test.tsx
@@ -1,0 +1,268 @@
+// @vitest-environment jsdom
+/**
+ * Journey section 04 - Workflow (#215, map #200).
+ *
+ * The decisions these tests guard, rather than layout:
+ *
+ *   1. THE LEAD IS THE LOCKED WORDING (#220) OR NOTHING. Its two floors live in
+ *      the rule, and the section must honor an empty answer rather than
+ *      assembling a sentence of its own.
+ *   2. TWO `?` MARKERS, NO MORE. Six dashed underlines in a short paragraph
+ *      read as a minefield.
+ *   3. THE PODIUM IS THE SERVER'S PLACEMENT. The section ranks nothing: a
+ *      second ranking here could disagree with the first.
+ *   4. A HIDDEN ROW IS OFF THE PUBLIC PAGE. The owner sees it tagged; a visitor
+ *      never receives it.
+ *   5. EVERY FIGURE NAMES ITS RULE. A number whose band, coverage and rule id
+ *      are not shown is a number the reader has to take on trust.
+ *   6. NO LLM, AND RAW DATA STAYS LOCAL - the section says both.
+ */
+import {
+	act,
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+} from "@testing-library/react";
+import { getFunctionName } from "convex/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../../../convex/_generated/api";
+import type { Id } from "../../../../convex/_generated/dataModel";
+import type { WorkflowView } from "../copy";
+import { WorkflowSection } from "../WorkflowSection";
+import { row, view } from "./fixture";
+
+const queryMock = vi.fn();
+const overrideMock = vi.fn(() => Promise.resolve({ pinned: [], hidden: [] }));
+
+vi.mock("convex/react", () => ({
+	useQuery: (ref: unknown, args: unknown) => queryMock(ref, args),
+	useMutation: () => overrideMock,
+}));
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+const STACK_ID = "stack-1" as Id<"stacks">;
+
+function setup(answer: WorkflowView | null | undefined) {
+	queryMock.mockImplementation((ref: unknown, args: unknown) => {
+		if (
+			getFunctionName(ref as never) !==
+			getFunctionName(api.workflow.getWorkflowByStackSlug)
+		) {
+			return undefined;
+		}
+		return args === "skip" ? undefined : answer;
+	});
+	return render(<WorkflowSection index={4} slug="alp" stackId={STACK_ID} />);
+}
+
+describe("the section renders only a real reading", () => {
+	it("renders nothing before the query answers", () => {
+		const { container } = setup(undefined);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("renders nothing when the consent gate withholds the reading", () => {
+		// `publishWorkflow` off answers null even for a reading already stored.
+		const { container } = setup(null);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("titles the section Workflow under the measured kicker", () => {
+		setup(view());
+		expect(screen.getByRole("heading", { name: "Workflow" })).toBeTruthy();
+		expect(screen.getByText("// measured")).toBeTruthy();
+	});
+});
+
+describe("the template lead", () => {
+	it("prints the four locked lines over the measured numbers", () => {
+		setup(view());
+		expect(screen.getByText(/464/)).toBeTruthy();
+		expect(
+			screen.getByText(/Most measured time in these sessions goes to/),
+		).toBeTruthy();
+		expect(screen.getByText(/of sessions · most start around/)).toBeTruthy();
+		expect(screen.getByText(/of measured time unclassified/)).toBeTruthy();
+		expect(screen.getByText("phase-rules/v1")).toBeTruthy();
+	});
+
+	it("carries exactly two markers, and each opens its own card", () => {
+		setup(view());
+		const markers = screen.getAllByRole("button", { name: /^What / });
+		expect(markers).toHaveLength(2);
+
+		fireEvent.click(
+			screen.getByRole("button", { name: "What the phases mean" }),
+		);
+		expect(
+			screen.getByText("reading and searching before the change"),
+		).toBeTruthy();
+
+		fireEvent.click(
+			screen.getByRole("button", { name: "What measured time means" }),
+		);
+		expect(screen.getByText(/It is not wall-clock time/)).toBeTruthy();
+	});
+
+	it("withholds itself below the session floor, and the rows still render", () => {
+		const thin = view();
+		setup({ ...thin, lead: { ...thin.lead, sessionCount: 4 } });
+		expect(
+			screen.queryByText(/Most measured time in these sessions goes to/),
+		).toBeNull();
+		expect(screen.getByText("late night commits")).toBeTruthy();
+	});
+
+	it("withholds itself when no harness passed the playbook gate", () => {
+		const gated = view();
+		setup({ ...gated, lead: { ...gated.lead, playbookHarnessCount: 0 } });
+		expect(
+			screen.queryByText(/Most measured time in these sessions goes to/),
+		).toBeNull();
+	});
+});
+
+describe("the podium, the thin rows and the expander", () => {
+	it("puts the three highlight rows in the band, with their own figures", () => {
+		setup(view());
+		expect(screen.getByText("42%")).toBeTruthy();
+		expect(screen.getByText("2.8")).toBeTruthy();
+		expect(screen.getAllByText("+ tap to extend")).toHaveLength(3);
+	});
+
+	it("holds the low-fit rows behind one expander", () => {
+		setup(view());
+		expect(screen.queryByText("web searches per active day")).toBeNull();
+		fireEvent.click(screen.getByRole("button", { name: /below the fit line/ }));
+		expect(screen.getByText("web searches per active day")).toBeTruthy();
+	});
+
+	it("extends a podium box into its body on a tap", () => {
+		setup(view());
+		fireEvent.click(screen.getByText("late night commits"));
+		expect(
+			screen.getByText(/typical 0% to 15% · this window 42%/),
+		).toBeTruthy();
+	});
+
+	it("renders the component's own display when a component row opens", () => {
+		setup(view());
+		fireEvent.click(screen.getByText("phase playbook"));
+		expect(screen.getByText("Shorter sessions")).toBeTruthy();
+		expect(screen.getByText("Longer sessions")).toBeTruthy();
+	});
+});
+
+describe("every figure names its rule", () => {
+	it("shows the band, the coverage, the fit and the rule id", () => {
+		setup(view());
+		fireEvent.click(screen.getByText("thinking share"));
+		expect(
+			screen.getByText(/metric:thinking-share · metric-rules\/v1/),
+		).toBeTruthy();
+		expect(
+			screen.getByText(
+				/50% of the machine's synced harnesses · counts: Claude Code/,
+			),
+		).toBeTruthy();
+		expect(screen.getByText(/coverage times surprise/)).toBeTruthy();
+	});
+
+	it("says a first reading has no earlier window to compare against", () => {
+		setup(view());
+		fireEvent.click(screen.getByText("late night commits"));
+		expect(
+			screen.getByText(/no earlier window to compare against/),
+		).toBeTruthy();
+	});
+
+	it("names the rules, keeps the raw data local, and claims no LLM", () => {
+		setup(view());
+		expect(
+			screen.getByText(/Raw transcripts and repository names never leave it/),
+		).toBeTruthy();
+		expect(
+			screen.getByText(
+				/No language model reads this section or writes a word of it/,
+			),
+		).toBeTruthy();
+	});
+
+	it("counts the measurements it has no rule for rather than printing them bare", () => {
+		setup({ ...view(), unknownMetricIds: ["future-metric"] });
+		expect(
+			screen.getByText(/1 measurement this site has no rule for yet/),
+		).toBeTruthy();
+	});
+});
+
+describe("the owner's pins and hides", () => {
+	const owned = () =>
+		view({
+			isOwner: true,
+			rows: [
+				row({ placement: "highlight" }),
+				row({
+					rowId: "metric:parallel-projects",
+					ruleId: "parallel-projects",
+					label: "projects run in parallel on a median active day",
+					unit: "count",
+					value: 2.8,
+					placement: "normal",
+					hidden: true,
+				}),
+			],
+		});
+
+	it("shows a visitor no controls at all", () => {
+		setup(view());
+		fireEvent.click(screen.getByText("late night commits"));
+		expect(screen.queryByText("your controls")).toBeNull();
+	});
+
+	it("pins a row through the server, which owns the override", async () => {
+		setup(owned());
+		fireEvent.click(screen.getByText("late night commits"));
+		await act(async () => {
+			fireEvent.click(
+				screen.getByRole("button", { name: /pin to the podium/ }),
+			);
+		});
+		expect(overrideMock).toHaveBeenCalledWith({
+			stackId: STACK_ID,
+			rowId: "metric:late-night-commits",
+			state: "pinned",
+		});
+	});
+
+	it("tags a hidden row in the owner's own view and offers it back", async () => {
+		setup(owned());
+		expect(screen.getByText("hidden")).toBeTruthy();
+		fireEvent.click(screen.getByText("parallel projects"));
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: /show again/ }));
+		});
+		expect(overrideMock).toHaveBeenCalledWith({
+			stackId: STACK_ID,
+			rowId: "metric:parallel-projects",
+			state: null,
+		});
+	});
+
+	it("prints the server's refusal when the podium is full", async () => {
+		overrideMock.mockRejectedValueOnce(
+			new Error(
+				"[Request ID: x] Server Error Uncaught Error: The podium holds 3 rows. Unpin one before pinning another.",
+			) as never,
+		);
+		setup(owned());
+		fireEvent.click(screen.getByText("late night commits"));
+		fireEvent.click(screen.getByRole("button", { name: /pin to the podium/ }));
+		expect(await screen.findByText(/The podium holds 3 rows/)).toBeTruthy();
+	});
+});

--- a/src/features/workflow/components.tsx
+++ b/src/features/workflow/components.tsx
@@ -1,0 +1,637 @@
+import { useState } from "react";
+import { CHART_PAINTS } from "@/features/charts";
+import { cn } from "@/lib/utils";
+import {
+	BODY_KICKERS,
+	fmtLines,
+	fmtNumber,
+	fmtPercent,
+	harnessLabelOf,
+	hourLabel,
+	MONO_LABEL,
+	type WorkflowView,
+	weekdayLabel,
+} from "./copy";
+import { Playbook } from "./Playbook";
+import {
+	BarRow,
+	BodyFootnote,
+	BodyKicker,
+	Legend,
+	type Segment,
+	Strip,
+} from "./parts";
+
+/**
+ * The seven component bodies (spec, "The section").
+ *
+ * Wayfinder ticket #215 (map #200). Each one renders aggregates the machine
+ * already shipped: the phase playbook, model routing, the kit, delegation, the
+ * Git ledger, coding languages, and the week/time heatmap.
+ *
+ * POSITIVE CLAIMS ONLY (#40, carried on the map's Notes). Nothing here says a
+ * listed thing went unused, and a component with nothing to show renders a line
+ * about the reading rather than a demerit on the author.
+ */
+export function ComponentBody({
+	componentId,
+	view,
+}: {
+	componentId: string;
+	view: WorkflowView;
+}) {
+	switch (componentId) {
+		case "phase-playbook":
+			return <Playbook view={view} />;
+		case "model-routing":
+			return <ModelRouting view={view} />;
+		case "kit":
+			return <Kit view={view} />;
+		case "delegation":
+			return <Delegation view={view} />;
+		case "git-ledger":
+			return <GitLedger view={view} />;
+		case "coding-languages":
+			return <CodingLanguages view={view} />;
+		case "activity-heatmap":
+			return <ActivityHeatmap view={view} />;
+		default:
+			return null;
+	}
+}
+
+const paintFor = (index: number): string =>
+	CHART_PAINTS[index % CHART_PAINTS.length] as string;
+
+function sumBy<T>(rows: readonly T[], value: (row: T) => number): number {
+	return rows.reduce((sum, row) => sum + value(row), 0);
+}
+
+/** Fold `{name, value}` pairs into one ranked list, largest first. */
+function rank(
+	entries: readonly { name: string; value: number }[],
+): { name: string; value: number }[] {
+	const byName = new Map<string, number>();
+	for (const entry of entries) {
+		byName.set(entry.name, (byName.get(entry.name) ?? 0) + entry.value);
+	}
+	return [...byName.entries()]
+		.map(([name, value]) => ({ name, value }))
+		.filter((row) => row.value > 0)
+		.sort((a, b) => b.value - a.value || a.name.localeCompare(b.name));
+}
+
+function EmptyBody({ children }: { children: React.ReactNode }) {
+	return <p className="text-sm text-fg-secondary">{children}</p>;
+}
+
+// ---------------------------------------------------------------------------
+// Model routing: the main loop against the subagents.
+// ---------------------------------------------------------------------------
+
+function ModelRouting({ view }: { view: WorkflowView }) {
+	const harnesses = view.section.harnesses.filter((h) => h.routing);
+	const main = rank(
+		harnesses.flatMap((h) =>
+			(h.routing?.main ?? []).map((row) => ({
+				name: row.model,
+				value: row.tokens,
+			})),
+		),
+	);
+	const subagents = rank(
+		harnesses.flatMap((h) =>
+			(h.routing?.subagents ?? []).map((row) => ({
+				name: row.model,
+				value: row.tokens,
+			})),
+		),
+	);
+	if (main.length === 0 && subagents.length === 0) {
+		return (
+			<EmptyBody>
+				No harness on this machine records a model per response.
+			</EmptyBody>
+		);
+	}
+
+	// ONE PALETTE ACROSS BOTH ROWS. A model must wear the same paint in the main
+	// loop and in the subagents, or the two strips would answer different
+	// questions with the same colors.
+	const models = rank([...main, ...subagents]).map((row, index) => ({
+		name: row.name,
+		paint: paintFor(index),
+	}));
+	const paintOf = (name: string) =>
+		models.find((model) => model.name === name)?.paint ??
+		"var(--bg-panel-elevated)";
+	const segments = (rows: { name: string; value: number }[]): Segment[] =>
+		rows.map((row) => ({
+			key: row.name,
+			value: row.value,
+			paint: paintOf(row.name),
+			label: row.name,
+		}));
+
+	const mainTokens = sumBy(main, (row) => row.value);
+	const subagentTokens = sumBy(subagents, (row) => row.value);
+	const total = mainTokens + subagentTokens;
+
+	return (
+		<div>
+			<BodyKicker>{BODY_KICKERS["model-routing"]}</BodyKicker>
+			<RouteRow
+				who="main loop"
+				share={total > 0 ? mainTokens / total : 0}
+				segments={segments(main)}
+			/>
+			<RouteRow
+				who="subagents"
+				share={total > 0 ? subagentTokens / total : 0}
+				segments={segments(subagents)}
+			/>
+			<Legend
+				segments={models.map((model) => ({
+					key: model.name,
+					value: 1,
+					paint: model.paint,
+					label: model.name,
+				}))}
+			/>
+			<BodyFootnote>
+				share of response tokens ·{" "}
+				{harnesses.map((h) => harnessLabelOf(h.harness)).join(" · ")}
+			</BodyFootnote>
+		</div>
+	);
+}
+
+function RouteRow({
+	who,
+	share,
+	segments,
+}: {
+	who: string;
+	share: number;
+	segments: readonly Segment[];
+}) {
+	if (segments.length === 0) return null;
+	return (
+		<div className="mt-3">
+			<p className="mb-1 flex items-baseline justify-between gap-4">
+				<span className="text-sm text-fg-primary">{who}</span>
+				<span className="font-mono text-xs text-fg-muted">
+					{fmtPercent(share)} of tokens
+				</span>
+			</p>
+			<Strip segments={segments} height="h-4" />
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// The kit: skills and MCP servers, by share of the calls they were measured in.
+// ---------------------------------------------------------------------------
+
+function Kit({ view }: { view: WorkflowView }) {
+	const skills = rank(
+		view.kit.flatMap((harness) =>
+			harness.skills.map((atom) => ({
+				name: atom.name,
+				value: atom.callShare,
+			})),
+		),
+	);
+	const servers = rank(
+		view.kit.flatMap((harness) =>
+			harness.mcpServers.map((atom) => ({
+				name: atom.name,
+				value: atom.callShare,
+			})),
+		),
+	);
+	const withheld = sumBy(
+		view.kit,
+		(harness) => harness.withheld.skills + harness.withheld.mcpServers,
+	);
+	if (skills.length === 0 && servers.length === 0) {
+		return (
+			<EmptyBody>No skill or MCP call is published for this machine.</EmptyBody>
+		);
+	}
+
+	return (
+		<div>
+			<BodyKicker>{BODY_KICKERS.kit}</BodyKicker>
+			<KitList title="skills" rows={skills} />
+			<KitList title="mcp servers" rows={servers} />
+			<BodyFootnote>
+				share of calls in each category
+				{withheld > 0 ? ` · ${withheld} names withheld on the machine` : ""}
+			</BodyFootnote>
+		</div>
+	);
+}
+
+function KitList({
+	title,
+	rows,
+}: {
+	title: string;
+	rows: readonly { name: string; value: number }[];
+}) {
+	if (rows.length === 0) return null;
+	const widest = rows[0]?.value ?? 1;
+	return (
+		<div className="mt-4">
+			<p className={cn(MONO_LABEL, "mb-1 text-fg-muted")}>{title}</p>
+			{rows.slice(0, 6).map((row, index) => (
+				<BarRow
+					key={row.name}
+					rank={index + 1}
+					name={row.name}
+					share={widest > 0 ? row.value / widest : 0}
+					figure={fmtPercent(row.value)}
+				/>
+			))}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Delegation: the main loop against the subagents, and the two records.
+// ---------------------------------------------------------------------------
+
+function Delegation({ view }: { view: WorkflowView }) {
+	const rows = view.section.harnesses
+		.map((harness) => harness.delegation)
+		.filter((row): row is NonNullable<typeof row> => row !== undefined);
+	if (rows.length === 0) {
+		return (
+			<EmptyBody>
+				No harness on this machine records a subagent call separately.
+			</EmptyBody>
+		);
+	}
+	const mainCalls = sumBy(rows, (row) => row.mainToolCalls);
+	const subagentCalls = sumBy(rows, (row) => row.subagentToolCalls);
+	const widestFanOut = Math.max(...rows.map((row) => row.widestFanOut));
+	const mostSubagents = Math.max(...rows.map((row) => row.mostSubagents));
+	const types = rank(
+		view.kit.flatMap((harness) =>
+			harness.subagents.map((atom) => ({
+				name: atom.name,
+				value: atom.callShare,
+			})),
+		),
+	);
+	const widest = types[0]?.value ?? 1;
+
+	return (
+		<div>
+			<BodyKicker>{BODY_KICKERS.delegation}</BodyKicker>
+			<div className="grid gap-6 md:grid-cols-2">
+				<div>
+					<p className="font-mono text-3xl font-black text-fg-primary">
+						{ratio(mainCalls, subagentCalls)}
+					</p>
+					<p className={cn(MONO_LABEL, "mt-2 text-fg-muted")}>
+						main-loop to subagent tool calls
+					</p>
+					<div className="mt-4 grid grid-cols-2 gap-px border border-stroke-subtle bg-stroke-subtle">
+						<Record
+							value={widestFanOut}
+							label="widest parallel fan-out in one session"
+						/>
+						<Record
+							value={mostSubagents}
+							label="most subagents in one session"
+						/>
+					</div>
+				</div>
+				{types.length > 0 && (
+					<div>
+						<p className={cn(MONO_LABEL, "mb-1 text-fg-muted")}>
+							subagent runs by type
+						</p>
+						{types.slice(0, 5).map((row, index) => (
+							<BarRow
+								key={row.name}
+								rank={index + 1}
+								name={row.name}
+								share={widest > 0 ? row.value / widest : 0}
+								figure={fmtPercent(row.value)}
+							/>
+						))}
+					</div>
+				)}
+			</div>
+			<BodyFootnote>
+				{view.section.harnesses
+					.filter((harness) => harness.delegation)
+					.map((harness) => harnessLabelOf(harness.harness))
+					.join(" · ")}
+			</BodyFootnote>
+		</div>
+	);
+}
+
+/** "2 : 1", reduced against the smaller side. Both zero has no ratio to print. */
+function ratio(main: number, subagents: number): string {
+	if (subagents <= 0) return main > 0 ? `${fmtNumber(main)} : 0` : "0 : 0";
+	return `${fmtNumber(main / subagents)} : 1`;
+}
+
+function Record({ value, label }: { value: number; label: string }) {
+	return (
+		<div className="bg-bg-canvas p-3">
+			<p className="font-mono text-2xl font-black text-fg-primary">
+				{fmtNumber(value)}
+			</p>
+			<p className="mt-1 text-[11px] leading-snug text-fg-muted">{label}</p>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// The Git ledger: removals in red, per-commit sizes as a log-scale dot strip.
+// ---------------------------------------------------------------------------
+
+/** Dots the strip draws before it stops. A 30-day window rarely reaches it. */
+const MAX_DOTS = 240;
+
+function GitLedger({ view }: { view: WorkflowView }) {
+	const git = view.section.git;
+	const changed = git.additions + git.removals;
+	if (git.totalCommits === 0) {
+		return (
+			<EmptyBody>
+				No commit in this window sits in a repository a session touched.
+			</EmptyBody>
+		);
+	}
+	const dots = git.changedLinesPerCommit.slice(0, MAX_DOTS);
+	const dropped = git.changedLinesPerCommit.length - dots.length;
+
+	return (
+		<div>
+			<BodyKicker>{BODY_KICKERS["git-ledger"]}</BodyKicker>
+			<div className="flex flex-wrap items-baseline gap-x-6 gap-y-1">
+				<p className="font-mono text-2xl font-black text-accent-lime">
+					+{fmtLines(git.additions)}
+				</p>
+				<p
+					className="font-mono text-2xl font-black"
+					style={{ color: "var(--destructive)" }}
+				>
+					-{fmtLines(git.removals)}
+				</p>
+				<p className="font-mono text-xs text-fg-muted">
+					{git.totalCommits.toLocaleString("en-US")} commits ·{" "}
+					{fmtPercent(changed > 0 ? git.removals / changed : 0)} of changed
+					lines are removals
+				</p>
+			</div>
+
+			<Strip
+				className="mt-3"
+				height="h-4"
+				segments={[
+					{
+						key: "additions",
+						value: git.additions,
+						paint: "var(--accent-lime)",
+						label: "additions",
+					},
+					{
+						key: "removals",
+						value: git.removals,
+						paint: "var(--destructive-fill)",
+						label: "removals",
+					},
+				]}
+			/>
+
+			{dots.length > 0 && (
+				<div className="mt-5">
+					<p className={cn(MONO_LABEL, "mb-2 text-fg-muted")}>
+						one dot per commit · log scale
+					</p>
+					<CommitDots sizes={dots} />
+					{dropped > 0 && (
+						<p className="mt-2 font-mono text-[11px] text-fg-muted">
+							{dropped.toLocaleString("en-US")} further commits not drawn
+						</p>
+					)}
+				</div>
+			)}
+
+			<BodyFootnote>
+				{git.testFileCommits.toLocaleString("en-US")} commits touch a test file
+				· {git.testFileRuleVersion}
+				{view.trimmed?.commitStrip
+					? " · the per-commit strip was dropped to fit the stored reading"
+					: ""}
+			</BodyFootnote>
+		</div>
+	);
+}
+
+/**
+ * One dot per commit, sized on a log scale.
+ *
+ * A LOG SCALE, because a 4,000-line commit beside a 4-line one on a linear
+ * scale makes every ordinary commit an invisible speck. Order carries no
+ * meaning: the wire ships the sizes unordered on purpose, so nothing here may
+ * read as a timeline.
+ */
+function CommitDots({ sizes }: { sizes: readonly number[] }) {
+	const largest = Math.max(...sizes, 1);
+	const ceiling = Math.log10(largest + 1);
+	return (
+		<div className="flex flex-wrap items-end gap-1">
+			{sizes.map((lines, index) => {
+				const scaled = ceiling > 0 ? Math.log10(lines + 1) / ceiling : 0;
+				const px = 3 + Math.round(scaled * 9);
+				return (
+					<span
+						// The sizes are unordered and repeat, so the index is the identity.
+						key={`${index}-${lines}`}
+						title={`${lines.toLocaleString("en-US")} changed lines`}
+						className="block shrink-0 bg-accent-lime"
+						style={{ width: px, height: px }}
+					/>
+				);
+			})}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Coding languages: changed lines by file type.
+// ---------------------------------------------------------------------------
+
+function CodingLanguages({ view }: { view: WorkflowView }) {
+	const git = view.section.git;
+	const rows = rank(
+		git.changedLinesByExtension.map((row) => ({
+			name: row.extension,
+			value: row.changedLines,
+		})),
+	);
+	if (rows.length === 0) {
+		return (
+			<EmptyBody>No approved file type carries a changed line here.</EmptyBody>
+		);
+	}
+	// The withheld lines belong in the denominator: a stack whose top language is
+	// unapproved would otherwise read as more concentrated than it is.
+	const total = sumBy(rows, (row) => row.value) + git.withheldExtensionLines;
+	const widest = rows[0]?.value ?? 1;
+
+	return (
+		<div>
+			<BodyKicker>{BODY_KICKERS["coding-languages"]}</BodyKicker>
+			{rows.slice(0, 8).map((row, index) => (
+				<BarRow
+					key={row.name}
+					rank={index + 1}
+					name={row.name}
+					share={widest > 0 ? row.value / widest : 0}
+					figure={fmtPercent(total > 0 ? row.value / total : 0)}
+				/>
+			))}
+			<BodyFootnote>
+				{fmtLines(total)} changed lines ·{" "}
+				{git.withheldExtensionLines > 0
+					? `${fmtLines(git.withheldExtensionLines)} in file types the machine withheld · `
+					: ""}
+				{git.fileTypeRuleVersion}
+			</BodyFootnote>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// The week/time heatmap, with a per-cell popup.
+// ---------------------------------------------------------------------------
+
+const HOURS = Array.from({ length: 24 }, (_, hour) => hour);
+const WEEKDAY_ROWS = [1, 2, 3, 4, 5, 6, 0];
+
+function ActivityHeatmap({ view }: { view: WorkflowView }) {
+	const [selected, setSelected] = useState<string | null>(null);
+	const offset = view.utcOffsetMinutes;
+	const cells = new Map<string, number>();
+	for (const harness of view.section.harnesses) {
+		for (const cell of harness.activity) {
+			// SHIFTED INTO THE OWNER'S LOCAL TIME, for the reason the lead's rhythm
+			// clause is: the reader's own clock would put a stranger's habit at the
+			// wrong hour. Without an offset the grid stays in UTC and says so.
+			const shifted = shift(cell.weekdayUtc, cell.hourUtc, offset ?? 0);
+			const key = `${shifted.weekday}-${shifted.hour}`;
+			cells.set(key, (cells.get(key) ?? 0) + cell.events);
+		}
+	}
+	if (cells.size === 0) {
+		return (
+			<EmptyBody>No harness on this machine records an event clock.</EmptyBody>
+		);
+	}
+	const busiest = Math.max(...cells.values());
+	const chosen = selected === null ? null : (cells.get(selected) ?? 0);
+
+	return (
+		<div>
+			<BodyKicker>{BODY_KICKERS["activity-heatmap"]}</BodyKicker>
+			<div className="overflow-x-auto">
+				<div className="min-w-[34rem]">
+					{WEEKDAY_ROWS.map((weekday) => (
+						<div key={weekday} className="flex items-center gap-1">
+							<span className="w-9 shrink-0 font-mono text-[10px] text-fg-muted">
+								{weekdayLabel(weekday)}
+							</span>
+							{HOURS.map((hour) => {
+								const key = `${weekday}-${hour}`;
+								const events = cells.get(key) ?? 0;
+								return (
+									<button
+										key={key}
+										type="button"
+										onClick={() =>
+											setSelected((held) => (held === key ? null : key))
+										}
+										aria-label={`${weekdayLabel(weekday)} ${hourLabel(hour)}, ${events} events`}
+										aria-pressed={selected === key}
+										className={cn(
+											"h-4 flex-1",
+											selected === key &&
+												"outline outline-1 outline-accent-lime",
+										)}
+										style={{ background: heatPaint(events, busiest) }}
+									/>
+								);
+							})}
+						</div>
+					))}
+					<div className="mt-1 flex items-center gap-1">
+						<span className="w-9 shrink-0" />
+						{HOURS.map((hour) => (
+							<span
+								key={hour}
+								className="flex-1 text-center font-mono text-[9px] text-fg-muted"
+							>
+								{hour % 6 === 0 ? hour : ""}
+							</span>
+						))}
+					</div>
+				</div>
+			</div>
+
+			<p className="mt-3 font-mono text-xs text-fg-secondary">
+				{selected === null ? (
+					<span className="text-fg-muted">
+						Select a cell for its recorded events.
+					</span>
+				) : (
+					<>
+						{weekdayLabel(Number(selected.split("-")[0]))}{" "}
+						{hourLabel(Number(selected.split("-")[1]))} ·{" "}
+						<b className="text-fg-primary">
+							{(chosen ?? 0).toLocaleString("en-US")}
+						</b>{" "}
+						recorded events
+					</>
+				)}
+			</p>
+
+			<BodyFootnote>
+				{offset === null
+					? "hours in UTC · this reading carries no machine offset"
+					: "hours in the owner's local time"}
+			</BodyFootnote>
+		</div>
+	);
+}
+
+function shift(
+	weekdayUtc: number,
+	hourUtc: number,
+	offsetMinutes: number,
+): { weekday: number; hour: number } {
+	const minutes = weekdayUtc * 24 * 60 + hourUtc * 60 + offsetMinutes;
+	const week = 7 * 24 * 60;
+	const wrapped = ((minutes % week) + week) % week;
+	return {
+		weekday: Math.floor(wrapped / (24 * 60)),
+		hour: Math.floor((wrapped % (24 * 60)) / 60),
+	};
+}
+
+/** Five steps, so a busy cell and a quiet one never read as the same tint. */
+function heatPaint(events: number, busiest: number): string {
+	if (events <= 0) return "var(--bg-panel)";
+	const share = busiest > 0 ? events / busiest : 0;
+	const mix = share < 0.12 ? 18 : share < 0.3 ? 38 : share < 0.6 ? 62 : 90;
+	return `color-mix(in oklab, var(--accent-lime) ${mix}%, var(--bg-panel))`;
+}

--- a/src/features/workflow/copy.ts
+++ b/src/features/workflow/copy.ts
@@ -1,0 +1,170 @@
+/**
+ * The Workflow section's vocabulary, paints and number formats.
+ *
+ * Wayfinder ticket #215 (map #200), spec `docs/specs/workflow-surface.md`.
+ *
+ * NO SENTENCE HERE IS DRAFTED (ADR-0002). Every string is fixed, and every
+ * number it wraps comes from a versioned rule the CLI or the server ran. The
+ * section computes nothing of its own.
+ */
+
+import type { PhaseId } from "@aistack/workflow-rules";
+import type { FunctionReturnType } from "convex/server";
+import type { api } from "../../../convex/_generated/api";
+
+export type WorkflowView = NonNullable<
+	FunctionReturnType<typeof api.workflow.getWorkflowByStackSlug>
+>;
+export type WorkflowRow = WorkflowView["rows"][number];
+export type WorkflowKit = WorkflowView["kit"][number];
+export type HarnessReading = WorkflowView["section"]["harnesses"][number];
+
+export const WORKFLOW_ANCHOR = "section-workflow";
+
+/** Position 04 in the settled page order (#193). Placed by ticket #217. */
+export const KICKER = "// measured";
+export const TITLE = "Workflow";
+
+export const MONO_LABEL =
+	"font-mono text-[11px] font-semibold uppercase tracking-[0.25em]";
+
+/** Under every receipt card, and under any pair the page prints side by side. */
+export const NO_CAUSE_CLAIMED = "measured together, no cause claimed";
+
+/** The one sentence that answers "what is measured time?" (#220's second marker). */
+export const MEASURED_TIME_NOTE =
+	"Measured time is the time recorded tool calls account for, each event holding the gap to the next one, capped at 5 minutes. It is not wall-clock time, and it is not billed time.";
+
+// ---------------------------------------------------------------------------
+// Phases.
+//
+// FOUR NAMED PHASES PLUS A VISIBLE UNKNOWN (spec, "Phases"). The paints are
+// validated palette slots, never the page accent: five series is categorical
+// color, and categorical color has to stay fixed across stacks. Verify keeps
+// the violet slot it wore in the anatomy prototype - a green verify would read
+// as a pass mark the data does not claim.
+// ---------------------------------------------------------------------------
+
+export const PHASE_ORDER: readonly PhaseId[] = [
+	"scout",
+	"build",
+	"verify",
+	"handoff",
+	"unknown",
+];
+
+export const PHASE_PAINT: Record<PhaseId, string> = {
+	scout: "var(--chart-4, #4278d2)",
+	build: "var(--chart-1, #69a621)",
+	verify: "var(--chart-2, #9e71fd)",
+	handoff: "var(--chart-3, #c21977)",
+	unknown: "var(--bg-panel-elevated, #1b1f24)",
+};
+
+/** The card the first phase name opens. One card, all four phases (#220). */
+export const PHASE_GLOSSARY: readonly { phase: PhaseId; text: string }[] = [
+	{ phase: "scout", text: "reading and searching before the change" },
+	{ phase: "build", text: "editing files and running the change" },
+	{ phase: "verify", text: "tests, type checks, linters, review skills" },
+	{ phase: "handoff", text: "the exchange at a blocking human gate" },
+	{
+		phase: "unknown",
+		text: "recorded events no rule classifies, printed rather than hidden",
+	},
+];
+
+// ---------------------------------------------------------------------------
+// Numbers.
+// ---------------------------------------------------------------------------
+
+export function fmtPercent(share: number): string {
+	return `${Math.round(share * 100)}%`;
+}
+
+/** One decimal, and no trailing `.0`: "2.8", "1", "12.5". */
+export function fmtNumber(value: number): string {
+	return value
+		.toLocaleString("en-US", { maximumFractionDigits: 1 })
+		.replace(/\.0$/, "");
+}
+
+export function fmtMinutes(minutes: number): string {
+	return `${fmtNumber(minutes)} min`;
+}
+
+export function fmtLines(lines: number): string {
+	if (Math.abs(lines) >= 1000) return `${fmtNumber(lines / 1000)}k`;
+	return lines.toLocaleString("en-US");
+}
+
+/** A row's headline figure, in the unit its own rule declared. */
+export function fmtRowValue(row: Pick<WorkflowRow, "unit" | "value">): string {
+	switch (row.unit) {
+		case "share":
+			return fmtPercent(row.value);
+		case "minutes":
+			return fmtMinutes(row.value);
+		default:
+			return fmtNumber(row.value);
+	}
+}
+
+/** The typical band the rule declared, in the row's own unit. */
+export function fmtBand(row: WorkflowRow): string {
+	const low = fmtRowValue({ unit: row.unit, value: row.band.low });
+	const high = fmtRowValue({ unit: row.unit, value: row.band.high });
+	return `${low} to ${high}`;
+}
+
+export const HARNESS_LABELS: Record<string, string> = {
+	"claude-code": "Claude Code",
+	codex: "Codex",
+	opencode: "opencode",
+	"pi-mono": "Pi",
+};
+
+export function harnessLabelOf(name: string): string {
+	return HARNESS_LABELS[name] ?? name;
+}
+
+const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+
+/**
+ * A weekday index as the reading stores it (0 = Sunday, `Date.getUTCDay`),
+ * rendered on a Monday-first row.
+ */
+export function weekdayLabel(weekdayUtc: number): string {
+	return WEEKDAYS[(weekdayUtc + 6) % 7] ?? "";
+}
+
+export function hourLabel(hour: number): string {
+	return `${String(hour).padStart(2, "0")}:00`;
+}
+
+/**
+ * A row's short display name, from its rule id.
+ *
+ * The rules give a row one `label`, which is the fragment completing
+ * "<value> <label>" - a caption, not a name. The rule id is the only stable
+ * short name either pool carries, and it was already chosen to read as one.
+ */
+export function rowName(ruleId: string): string {
+	return ruleId.replace(/-/g, " ");
+}
+
+/**
+ * Each component body's own kicker, keyed by its rule id.
+ *
+ * The strings live here rather than inline in the JSX because a text node
+ * opening with `//` reads as a comment to the linter, and the measured section
+ * already keeps its kickers in its own `copy.ts`.
+ */
+export const BODY_KICKERS: Record<string, string> = {
+	"phase-playbook": "// the playbook · how the sessions run",
+	"model-routing": "// model routing · who runs on what",
+	kit: "// the kit · skills and mcp servers",
+	delegation: "// delegation · main loop to subagents",
+	"git-ledger": "// the git ledger · what the commits carried",
+	"coding-languages": "// coding languages · changed lines by file type",
+	"activity-heatmap": "// when the work happens",
+};

--- a/src/features/workflow/parts.tsx
+++ b/src/features/workflow/parts.tsx
@@ -1,0 +1,121 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { fmtPercent, MONO_LABEL } from "./copy";
+
+/**
+ * The small marks the seven component bodies share.
+ *
+ * Wayfinder ticket #215 (map #200). These are plain DOM, not `@tanstack/charts`
+ * marks: `src/features/charts` stays the one place that imports the library,
+ * and a segmented bar of `<i>` elements needs neither a scale nor an axis.
+ * `ModelShareRows` in the measured section set the same precedent.
+ *
+ * SQUARE ENDS EVERYWHERE, and no border-radius (AGENTS.md).
+ */
+
+export type Segment = {
+	key: string;
+	value: number;
+	paint: string;
+	label: string;
+};
+
+/** One horizontal bar split into segments, sized by share of the total. */
+export function Strip({
+	segments,
+	className,
+	height = "h-3",
+}: {
+	segments: readonly Segment[];
+	className?: string;
+	height?: string;
+}) {
+	const total = segments.reduce((sum, segment) => sum + segment.value, 0);
+	if (total <= 0) return null;
+	return (
+		<div className={cn("flex w-full bg-bg-panel", height, className)}>
+			{segments.map((segment) => (
+				<i
+					key={segment.key}
+					title={`${segment.label} ${fmtPercent(segment.value / total)}`}
+					className="block h-full"
+					style={{
+						flexGrow: segment.value,
+						flexBasis: 0,
+						background: segment.paint,
+					}}
+				/>
+			))}
+		</div>
+	);
+}
+
+/** The legend a strip of two or more segments always carries. */
+export function Legend({ segments }: { segments: readonly Segment[] }) {
+	return (
+		<ul className="mt-3 flex flex-wrap gap-x-4 gap-y-1">
+			{segments.map((segment) => (
+				<li
+					key={segment.key}
+					className="flex items-center gap-1.5 font-mono text-[11px] text-fg-secondary"
+				>
+					<span
+						aria-hidden="true"
+						className="size-2 shrink-0"
+						style={{ background: segment.paint }}
+					/>
+					{segment.label}
+				</li>
+			))}
+		</ul>
+	);
+}
+
+/** A ranked list row: name, proportional bar, figure. */
+export function BarRow({
+	rank,
+	name,
+	share,
+	figure,
+	paint = "var(--accent-lime)",
+}: {
+	rank: number;
+	name: string;
+	/** 0..1 of the widest row, for the bar's width. */
+	share: number;
+	figure: string;
+	paint?: string;
+}) {
+	return (
+		<div className="flex items-center gap-3 py-1.5">
+			<span className="w-6 shrink-0 font-mono text-[11px] text-fg-muted">
+				{String(rank).padStart(2, "0")}
+			</span>
+			<span className="w-40 shrink-0 truncate text-sm text-fg-primary">
+				{name}
+			</span>
+			<span className="h-3 flex-1 bg-bg-panel">
+				<span
+					className="block h-full"
+					style={{
+						width: `${Math.max(1, share * 100)}%`,
+						background: paint,
+					}}
+				/>
+			</span>
+			<span className="w-16 shrink-0 text-right font-mono text-sm text-fg-primary">
+				{figure}
+			</span>
+		</div>
+	);
+}
+
+/** A component body's own kicker, in the section's mono voice. */
+export function BodyKicker({ children }: { children: ReactNode }) {
+	return <p className={cn(MONO_LABEL, "mb-3 text-accent-lime")}>{children}</p>;
+}
+
+/** The line under a body that names what produced it. */
+export function BodyFootnote({ children }: { children: ReactNode }) {
+	return <p className="mt-4 font-mono text-[11px] text-fg-muted">{children}</p>;
+}

--- a/src/features/workflow/rows.tsx
+++ b/src/features/workflow/rows.tsx
@@ -1,0 +1,419 @@
+import {
+	componentRule,
+	LOW_FIT_LINE,
+	MAX_PINS,
+	metricRule,
+} from "@aistack/workflow-rules";
+import { useMutation } from "convex/react";
+import { ChevronDown, ChevronUp, EyeOff, Pin } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { api } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
+import { ComponentBody } from "./components";
+import {
+	fmtBand,
+	fmtNumber,
+	fmtPercent,
+	fmtRowValue,
+	MONO_LABEL,
+	rowName,
+	type WorkflowRow,
+	type WorkflowView,
+} from "./copy";
+
+/**
+ * The podium: the top three by fit as one horizontal band, thin rows in fit
+ * order below it, and one expander for the rows under fit 0.40.
+ *
+ * Wayfinder ticket #215 (map #200). The composition is #191's variant B, and
+ * the state rules are the spec's: three highlight slots, the low-fit line at
+ * 0.40, and an owner pin or hide that wins over both.
+ *
+ * THE SECTION RANKS NOTHING. Fit, the rotation limit and the owner's overrides
+ * are all server state (spec, "Fit and rotation"), so every row arrives already
+ * placed and this file reads `placement` rather than recomputing it. Sorting
+ * here would be a second ranking that could disagree with the first.
+ */
+export function RowSet({
+	view,
+	stackId,
+}: {
+	view: WorkflowView;
+	stackId: Id<"stacks"> | null;
+}) {
+	const highlights = view.rows.filter((row) => row.placement === "highlight");
+	const normal = view.rows.filter((row) => row.placement === "normal");
+	const low = view.rows.filter((row) => row.placement === "low");
+
+	const [openHighlight, setOpenHighlight] = useState<string | null>(null);
+	const [openRows, setOpenRows] = useState<readonly string[]>([]);
+	const [expanded, setExpanded] = useState(false);
+	const toggleRow = (rowId: string) =>
+		setOpenRows((held) =>
+			held.includes(rowId)
+				? held.filter((id) => id !== rowId)
+				: [...held, rowId],
+		);
+
+	const open = highlights.find((row) => row.rowId === openHighlight);
+
+	return (
+		<div>
+			{highlights.length > 0 && (
+				<>
+					<div className="grid gap-px border border-stroke-subtle bg-stroke-subtle md:grid-cols-3">
+						{highlights.map((row) => (
+							<PodiumBox
+								key={row.rowId}
+								row={row}
+								open={openHighlight === row.rowId}
+								onClick={() =>
+									setOpenHighlight((held) =>
+										held === row.rowId ? null : row.rowId,
+									)
+								}
+							/>
+						))}
+					</div>
+					{open && (
+						<div className="border border-t-0 border-stroke-subtle p-5">
+							<RowBody row={open} view={view} stackId={stackId} />
+						</div>
+					)}
+				</>
+			)}
+
+			<div className="mt-6 divide-y divide-stroke-subtle border-y border-stroke-subtle">
+				{normal.map((row) => (
+					<ThinRow
+						key={row.rowId}
+						row={row}
+						view={view}
+						stackId={stackId}
+						open={openRows.includes(row.rowId)}
+						onToggle={() => toggleRow(row.rowId)}
+					/>
+				))}
+
+				{low.length > 0 && (
+					<>
+						<button
+							type="button"
+							onClick={() => setExpanded((held) => !held)}
+							aria-expanded={expanded}
+							className="flex w-full items-center gap-3 py-3 text-left hover:bg-bg-panel/40"
+						>
+							<span className="flex-1 text-sm text-fg-muted">
+								below the fit line
+							</span>
+							<span className="font-mono text-xs text-fg-muted">
+								{low.length} more
+							</span>
+							<Chevron open={expanded} />
+						</button>
+						{expanded &&
+							low.map((row) => (
+								<ThinRow
+									key={row.rowId}
+									row={row}
+									view={view}
+									stackId={stackId}
+									dim
+									open={openRows.includes(row.rowId)}
+									onToggle={() => toggleRow(row.rowId)}
+								/>
+							))}
+					</>
+				)}
+			</div>
+
+			<p className="mt-4 font-mono text-[11px] text-fg-muted">
+				one row set · ranked by fit · rows under fit {fmtNumber(LOW_FIT_LINE)}{" "}
+				wait behind the expander · at most one highlight swap per sync day
+			</p>
+		</div>
+	);
+}
+
+function Chevron({ open }: { open: boolean }) {
+	const Icon = open ? ChevronUp : ChevronDown;
+	return <Icon aria-hidden="true" className="size-4 shrink-0 text-fg-muted" />;
+}
+
+/** One of the three band boxes. A tap extends its body below the band. */
+function PodiumBox({
+	row,
+	open,
+	onClick,
+}: {
+	row: WorkflowRow;
+	open: boolean;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			aria-expanded={open}
+			className={cn(
+				"bg-bg-canvas p-5 text-left hover:bg-bg-panel/50",
+				open && "bg-bg-panel/60",
+			)}
+		>
+			<span className={cn(MONO_LABEL, "block text-fg-muted")}>
+				{rowName(row.ruleId)}
+				{row.pinned && <PinTag />}
+				{row.hidden && <HiddenTag />}
+			</span>
+			<span className="mt-3 block font-mono text-4xl font-black text-fg-primary">
+				{fmtRowValue(row)}
+			</span>
+			<span className="mt-2 block text-sm leading-snug text-fg-secondary">
+				{row.label}
+			</span>
+			<span className={cn(MONO_LABEL, "mt-4 block text-accent-lime")}>
+				{open ? "close" : "+ tap to extend"}
+			</span>
+		</button>
+	);
+}
+
+function ThinRow({
+	row,
+	view,
+	stackId,
+	open,
+	onToggle,
+	dim,
+}: {
+	row: WorkflowRow;
+	view: WorkflowView;
+	stackId: Id<"stacks"> | null;
+	open: boolean;
+	onToggle: () => void;
+	dim?: boolean;
+}) {
+	return (
+		<div className={cn(dim && "opacity-70")}>
+			<button
+				type="button"
+				onClick={onToggle}
+				aria-expanded={open}
+				className="flex w-full items-center gap-3 py-3 text-left hover:bg-bg-panel/40"
+			>
+				<span className="w-44 shrink-0 truncate text-sm font-bold text-fg-primary">
+					{rowName(row.ruleId)}
+					{row.pinned && <PinTag />}
+					{row.hidden && <HiddenTag />}
+				</span>
+				<span className="hidden flex-1 truncate text-sm text-fg-secondary md:block">
+					{row.label}
+				</span>
+				<span className="ml-auto shrink-0 font-mono text-sm font-bold text-fg-primary">
+					{fmtRowValue(row)}
+				</span>
+				<Chevron open={open} />
+			</button>
+			{open && (
+				<div className="pb-5">
+					<RowBody row={row} view={view} stackId={stackId} />
+				</div>
+			)}
+		</div>
+	);
+}
+
+function PinTag() {
+	return (
+		<span className="ml-2 border border-accent-lime px-1 font-mono text-[9px] uppercase tracking-wider text-accent-lime">
+			pinned
+		</span>
+	);
+}
+
+/** Only ever rendered in the owner's own view: a public read drops hidden rows. */
+function HiddenTag() {
+	return (
+		<span className="ml-2 border border-stroke-strong px-1 font-mono text-[9px] uppercase tracking-wider text-fg-muted">
+			hidden
+		</span>
+	);
+}
+
+/**
+ * What a row shows when it opens: the component's own display for a component
+ * row, then the derivation both kinds carry, then the owner's controls.
+ *
+ * THE DERIVATION IS NOT OPTIONAL. Every figure on this page is a rule's output,
+ * and a reader who cannot see the band, the coverage and the rule id has to
+ * take the number on trust.
+ */
+function RowBody({
+	row,
+	view,
+	stackId,
+}: {
+	row: WorkflowRow;
+	view: WorkflowView;
+	stackId: Id<"stacks"> | null;
+}) {
+	return (
+		<div>
+			{row.kind === "component" && (
+				<div className="mb-5">
+					<ComponentBody componentId={row.ruleId} view={view} />
+				</div>
+			)}
+			<Derivation row={row} />
+			{view.isOwner && stackId && <OwnerControls row={row} stackId={stackId} />}
+		</div>
+	);
+}
+
+/** Source, coverage, band, surprise, fit and movement, for one row. */
+export function Derivation({ row }: { row: WorkflowRow }) {
+	const rule =
+		row.kind === "metric" ? metricRule(row.ruleId) : componentRule(row.ruleId);
+	const kind =
+		row.kind === "component"
+			? "derived from aggregates the machine shipped"
+			: rule && "kind" in rule && rule.kind === "proxy"
+				? "a proxy, named by its rule"
+				: "exact, as the machine measured it";
+
+	return (
+		<dl className="border border-stroke-subtle p-4 font-mono text-[11px] leading-relaxed text-fg-secondary">
+			<Line label="from">{kind}</Line>
+			<Line label="rule">
+				{row.rowId} · {row.ruleVersion}
+			</Line>
+			<Line label="band">
+				typical {fmtBand(row)} · this window {fmtRowValue(row)}
+			</Line>
+			<Line label="coverage">
+				{fmtPercent(row.coverage)} of the machine's synced harnesses
+				{row.coverageTag ? ` · counts: ${row.coverageTag}` : ""}
+			</Line>
+			<Line label="surprise">
+				{fmtNumber(row.surprise)} · distance outside the band
+			</Line>
+			<Line label="fit">
+				<b className="text-fg-primary">{fmtNumber(row.fit)}</b> · coverage times
+				surprise
+			</Line>
+			<Line label="movement">
+				{row.movement === null
+					? "no earlier window to compare against"
+					: `${fmtNumber(row.movement)} against the previous window`}
+			</Line>
+		</dl>
+	);
+}
+
+function Line({
+	label,
+	children,
+}: {
+	label: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="flex gap-2">
+			<dt className="w-20 shrink-0 text-fg-muted">{label}:</dt>
+			<dd className="min-w-0 flex-1">{children}</dd>
+		</div>
+	);
+}
+
+/**
+ * Pin and hide, for the stack's owner.
+ *
+ * A pin puts the row on the podium and a hide takes it off the public page
+ * entirely, rather than pushing it behind the expander: an expander is still
+ * published. Either wins over the fit thresholds.
+ *
+ * THE PODIUM HOLDS THREE. A fourth pin has no slot to promise, so the server
+ * refuses it and the refusal prints here rather than failing silently.
+ */
+export function OwnerControls({
+	row,
+	stackId,
+}: {
+	row: WorkflowRow;
+	stackId: Id<"stacks">;
+}) {
+	const setOverride = useMutation(api.workflow.setWorkflowRowOverride);
+	const [error, setError] = useState<string | null>(null);
+	const [busy, setBusy] = useState(false);
+
+	const apply = async (state: "pinned" | "hidden" | null) => {
+		setBusy(true);
+		setError(null);
+		try {
+			await setOverride({ stackId, rowId: row.rowId, state });
+		} catch (caught) {
+			setError(
+				caught instanceof Error
+					? caught.message.replace(/^.*Uncaught Error:\s*/, "")
+					: `The podium holds ${MAX_PINS} rows.`,
+			);
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	return (
+		<div className="mt-4 flex flex-wrap items-center gap-3">
+			<span className={cn(MONO_LABEL, "text-fg-muted")}>your controls</span>
+			<ControlButton
+				active={row.pinned}
+				busy={busy}
+				icon={<Pin aria-hidden="true" className="size-3" />}
+				label={row.pinned ? "unpin" : "pin to the podium"}
+				onClick={() => apply(row.pinned ? null : "pinned")}
+			/>
+			<ControlButton
+				active={row.hidden}
+				busy={busy}
+				icon={<EyeOff aria-hidden="true" className="size-3" />}
+				label={row.hidden ? "show again" : "hide from the page"}
+				onClick={() => apply(row.hidden ? null : "hidden")}
+			/>
+			{error && (
+				<span className="font-mono text-[11px] text-destructive">{error}</span>
+			)}
+		</div>
+	);
+}
+
+function ControlButton({
+	active,
+	busy,
+	icon,
+	label,
+	onClick,
+}: {
+	active: boolean;
+	busy: boolean;
+	icon: React.ReactNode;
+	label: string;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			disabled={busy}
+			onClick={onClick}
+			className={cn(
+				"inline-flex items-center gap-1.5 border px-2 py-1 font-mono text-[11px] disabled:opacity-50",
+				active
+					? "border-accent-lime text-accent-lime"
+					: "border-stroke-subtle text-fg-secondary hover:border-stroke-strong",
+			)}
+		>
+			{icon}
+			{label}
+		</button>
+	);
+}


### PR DESCRIPTION
Wayfinder ticket [#215](https://github.com/alp82/aistack/issues/215), map [#200](https://github.com/alp82/aistack/issues/200). Spec: `docs/specs/workflow-surface.md`.

## What lands

**The section**, `src/features/workflow`. Section 04 renders one machine's stored reading:

- the locked template lead (`lead-templates/v1`, wording from #220), with its two `?` markers and no more,
- the podium: the top three by fit as one horizontal band, a tap extending the box below it,
- thin rows in fit order, and one expander for the rows under fit 0.40,
- the seven component bodies: the phase playbook, model routing, the kit, delegation, the Git ledger, coding languages, and the week/time heatmap,
- the derivation every row carries: source, band, coverage, surprise, fit and movement,
- pin and hide per row, for the owner.

**The section ranks nothing.** `placement`, `pinned` and `hidden` arrive computed from #218's server half, so a second ranking on the page cannot disagree with the first.

**A new rule set, `playbook-rules/v1`**, in `packages/workflow-rules`. The playbook's two shipping tracks split on the median measured session, never on an intent nothing recorded: "quick fix" and "feature work" would be labels no rule computed, so the tracks are the shorter sessions and the longer ones. A receipt card's head names both sides and claims no direction, because on a stack where the numbers run the other way a directional head would print a sentence its own figures refute. Both carry a 20-session floor, and each receipt side a five-session floor.

**One server change.** `getWorkflowByStackSlug` now returns the per-harness inventory the kit and delegation bodies draw. Skills, MCP servers and subagents are inventory and travel in the measured payload, not in the workflow section, so the two rows that render them need the payload beside the reading. `component-rules/v1` already read it for the kit row's value.

## What does not land

Nothing renders the section yet. [#217](https://github.com/alp82/aistack/issues/217) places it at position 04 in the locked page order.

## Checks

- 2,463 tests pass, 33 of them new across the section, the component bodies and `playbook-rules/v1`.
- `tsc` clean on both projects, `biome check` clean on every changed path.
- Docs updated: `AGENTS.md`, `CONTEXT.md` (the shipping-track term), and the spec's playbook paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fu2UYXr1VCkMiJ4LrABeyz