### PR TITLE
Integrate Workflow into the stack page (alp82/aistack#217)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,18 +39,25 @@ mirroring makes the Workflow section appear locally: something has to publish on
 Point the CLI at the local app and sync. The whole ingest path runs for real, and
 nothing touches prod.
 
+**The owner runs this, not an agent.** `sync` refuses to run without a TTY
+(`packages/cli/src/commands/sync.ts`, #31: a gate that cannot ask must not
+send), and a model-launched Bash call has no TTY. In a Claude Code session, type
+the sync line with a leading `!` so it runs in the owner's own shell, or run it
+in a terminal. Do not try to route around the gate.
+
 ```sh
 cd packages/cli && pnpm build   # dist/index.js is what you run
 cd ../..
 
 # One login per server. Opens the LOCAL approval page; approve it there.
+# `sync` runs this inline on an unlinked machine, so it is optional.
 AISTACK_URL=http://localhost:3019 node packages/cli/dist/index.js login
 
-# Scan, preview, approve, publish - against the local backend.
+# Scan, preview, approve, publish - against the local backend. Needs a TTY.
 AISTACK_URL=http://localhost:3019 node packages/cli/dist/index.js sync
 ```
 
-Four things that make this safe and make it work:
+Five things that make this safe and make it work:
 
 * **`AISTACK_URL` is the only switch.** `packages/cli/src/api.ts` reads it and
   falls back to `https://aistack.to`. The device-auth URL comes from whichever
@@ -64,6 +71,9 @@ Four things that make this safe and make it work:
 * **The local app and `convex dev` both have to be up**, and your stack has to
   exist in the local database. Run `scripts/sync-prod-db.sh` first if it does
   not, then log in to the local app again - the mirror replaces the auth tables.
+* **Be signed in to the LOCAL app in a browser before you start.** The approval
+  page is served by localhost, and it can only approve a machine for an account
+  it already has a session for.
 
 ## CLI release
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,11 +23,47 @@ scripts/convex-prod.sh run migrations/<name>:run
 scripts/sync-prod-db.sh
 ```
 
-The local database lags behind prod. Before work that depends on real rows (catalog data entry, migration dry runs), run `scripts/sync-prod-db.sh` first.
+The local database lags behind prod. Before work that depends on real rows (catalog data entry, migration dry runs), run `scripts/sync-prod-db.sh` first. It copies what prod HAS: for a reading no machine has published yet, see "Publishing a measured reading to the local backend".
 
 **Prod deploys run through GitHub Actions exclusively.** A push to `main` triggers `.github/workflows/deploy-convex.yml`, which pulls the `~/aistack` checkout on the server and runs `pnpm convex deploy` there. Never run `npx convex deploy` against prod from a local machine. To run a new migration on prod: push to `main`, wait for the workflow, then `scripts/convex-prod.sh run migrations/<name>:run`.
 
 **Never pass `--push` to `scripts/convex-prod.sh`, and never give it `deploy`, `dev`, or `push`.** The CLI runs from a minimal project dir on the server that holds no `convex/` directory, so anything that writes code pushes an EMPTY function set and prod loses every function and every index at once. That is a full outage, and it happened on 2026-08-24. The script now refuses those four forms, and the recovery is the workflow's own command, run on the server: `ssh root@10.0.0.20 "bash -l -c 'cd ~/aistack && git fetch origin main && git reset --hard origin/main && /root/.local/share/pnpm/pnpm i && /root/.local/share/pnpm/pnpm convex deploy'"`. Table rows survive; the indexes come back with the deploy.
+
+## Publishing a measured reading to the local backend
+
+`scripts/sync-prod-db.sh` copies prod's rows, so it can only give you data prod
+already has. A measured reading it cannot give you is one no machine has ever
+published. As of 2026-08-25 `measuredWorkflows` is empty on prod, so no amount of
+mirroring makes the Workflow section appear locally: something has to publish one.
+
+Point the CLI at the local app and sync. The whole ingest path runs for real, and
+nothing touches prod.
+
+```sh
+cd packages/cli && pnpm build   # dist/index.js is what you run
+cd ../..
+
+# One login per server. Opens the LOCAL approval page; approve it there.
+AISTACK_URL=http://localhost:3019 node packages/cli/dist/index.js login
+
+# Scan, preview, approve, publish - against the local backend.
+AISTACK_URL=http://localhost:3019 node packages/cli/dist/index.js sync
+```
+
+Four things that make this safe and make it work:
+
+* **`AISTACK_URL` is the only switch.** `packages/cli/src/api.ts` reads it and
+  falls back to `https://aistack.to`. The device-auth URL comes from whichever
+  server answered, so a localhost run sends you to a localhost approval page.
+* **A localhost login cannot clobber the prod token.** `~/.config/aistack/credentials.json`
+  keys credentials by server URL, which is exactly what that keying is for. You
+  log in once per server and both tokens survive.
+* **`publishWorkflow` defaults ON.** `stack.publishWorkflow !== false` is the
+  gate, so a stack that never set the flag still publishes its workflow section.
+  There is nothing to toggle before the first run.
+* **The local app and `convex dev` both have to be up**, and your stack has to
+  exist in the local database. Run `scripts/sync-prod-db.sh` first if it does
+  not, then log in to the local app again - the mirror replaces the auth tables.
 
 ## CLI release
 

--- a/convex/measured.ts
+++ b/convex/measured.ts
@@ -470,6 +470,23 @@ const ResolvedModel = v.object({
     output: v.number(),
     cacheWrite: v.number(),
     cacheRead: v.number(),
+    /**
+     * The cache-write TTL breakdown (#213). Stored optional, so it is optional
+     * here too: a pre-#213 row carries the merged total alone.
+     *
+     * IT HAS TO BE DECLARED EVEN THOUGH NO SURFACE READS IT YET. The read path
+     * hands the stored token object straight out, and a Convex returns
+     * validator refuses an undeclared field. Leaving it out did not hide the
+     * field - it broke every page for any stack that had synced with a CLI new
+     * enough to send it (#217).
+     */
+    cacheWriteTtl: v.optional(
+      v.object({
+        fiveMinute: v.number(),
+        oneHour: v.number(),
+        unsplit: v.number(),
+      })
+    ),
   }),
   apiEquivalentUSD: v.optional(v.number()),
   /**
@@ -598,6 +615,19 @@ async function newestSnapshotsPerSource(
 }
 
 /** One SOURCE's current snapshot: a harness on a machine (#66, #243). */
+/**
+ * One published inventory name, as a surface reads it.
+ *
+ * `calls` is the absolute count behind the share (#213), optional because a
+ * pre-#213 row carries the share alone. The kit component in the Workflow
+ * section is what reads it.
+ */
+const PublicAtom = v.object({
+  name: v.string(),
+  callShare: v.number(),
+  calls: v.optional(v.number()),
+})
+
 const HarnessSnapshot = v.object({
   /**
    * The published machine name. Null means the name is withheld or the row
@@ -628,13 +658,11 @@ const HarnessSnapshot = v.object({
   }),
   models: v.array(ResolvedModel),
   inventory: v.object({
-    builtinTools: v.array(v.object({ name: v.string(), callShare: v.number() })),
-    mcpServers: v.array(v.object({ name: v.string(), callShare: v.number() })),
-    skills: v.array(v.object({ name: v.string(), callShare: v.number() })),
-    subagents: v.array(v.object({ name: v.string(), callShare: v.number() })),
-    slashCommands: v.array(
-      v.object({ name: v.string(), callShare: v.number() })
-    ),
+    builtinTools: v.array(PublicAtom),
+    mcpServers: v.array(PublicAtom),
+    skills: v.array(PublicAtom),
+    subagents: v.array(PublicAtom),
+    slashCommands: v.array(PublicAtom),
     withheld: v.object({
       builtinTools: v.number(),
       mcpServers: v.number(),
@@ -642,6 +670,21 @@ const HarnessSnapshot = v.object({
       subagents: v.number(),
       slashCommands: v.number(),
     }),
+    /**
+     * Every observed call per category, withheld names included (#213) - the
+     * denominator the per-atom `calls` need. Optional for the same reason they
+     * are, and declared here for the same reason `cacheWriteTtl` is: the read
+     * path passes the stored inventory straight out.
+     */
+    calls: v.optional(
+      v.object({
+        builtinTools: v.number(),
+        mcpServers: v.number(),
+        skills: v.number(),
+        subagents: v.number(),
+        slashCommands: v.number(),
+      })
+    ),
   }),
   coverage: v.object({
     filesScanned: v.number(),

--- a/convex/measuredRead.test.ts
+++ b/convex/measuredRead.test.ts
@@ -1,0 +1,184 @@
+/// <reference types="vite/client" />
+/**
+ * The stack page's own read query (#217 fallout).
+ *
+ * WHY THIS FILE EXISTS. `getCurrentByStackSlug` is what section 01 calls on
+ * every stack page, and until this file nothing called it in a test. #213 added
+ * three fields to the wire and to storage - per-atom `calls`, the
+ * `inventory.calls` denominators, and the `cacheWriteTtl` split - and widened
+ * `schema.ts` for all three. It did not widen the RETURNS validator here, and a
+ * Convex returns validator refuses an undeclared field exactly the way an args
+ * validator does.
+ *
+ * Nothing failed until a machine actually published a payload carrying them.
+ * Then every stack page for that stack answered `ReturnsValidationError` and
+ * rendered nothing. The fixtures in `measured.test.ts` predate #213, so they
+ * could not have caught it: these carry the new fields on purpose.
+ */
+import { convexTest } from 'convex-test'
+import { describe, expect, test } from 'vitest'
+import { api, internal } from './_generated/api'
+import type { Doc } from './_generated/dataModel'
+import schema from './schema'
+
+const modules = import.meta.glob('./**/*.{js,ts}')
+
+const USER = 'user_owner'
+
+type StoredPayload = Doc<'measuredSnapshots'>['payload']
+type PayloadV2 = Extract<StoredPayload, { schemaVersion: 2 }>
+
+/** A payload from a CLI that ships every #213 field. */
+function payloadWithCounts(): PayloadV2 {
+  return {
+    schemaVersion: 2,
+    capturedAt: Date.now(),
+    window: { days: 30, from: '2026-07-27', to: '2026-08-25' },
+    harness: { name: 'claude-code', version: '2.1.245' },
+    pricingTable: 'anthropic-list-2026-07-25',
+    activity: {
+      sessions: 459,
+      activeDayDates: ['2026-08-01', '2026-08-02'],
+      projectKeys: ['AAAAAAAAAAAAAAAAAAAAAA'],
+      totalTokens: 1_000_000,
+      cacheHitShare: 0.9,
+      subagentShare: 0.07,
+    },
+    models: [
+      {
+        id: 'claude-opus-5',
+        tokenShare: 1,
+        tokens: {
+          input: 10,
+          output: 20,
+          cacheWrite: 30,
+          cacheRead: 40,
+          // The split #213 put on the wire so the repricer can charge each
+          // tier its own rate.
+          cacheWriteTtl: { fiveMinute: 10, oneHour: 20, unsplit: 0 },
+        },
+        apiEquivalentUSD: 12.34,
+      },
+    ],
+    inventory: {
+      // The absolute count behind each share.
+      builtinTools: [{ name: 'Bash', callShare: 0.713, calls: 22_634 }],
+      mcpServers: [],
+      skills: [{ name: 'grilling', callShare: 0.3067, calls: 50 }],
+      subagents: [],
+      slashCommands: [],
+      withheld: {
+        builtinTools: 1,
+        mcpServers: 2,
+        skills: 7,
+        subagents: 1,
+        slashCommands: 5,
+      },
+      // The denominator those counts need to be interpretable.
+      calls: {
+        builtinTools: 31_745,
+        mcpServers: 9,
+        skills: 163,
+        subagents: 169,
+        slashCommands: 649,
+      },
+    },
+    coverage: {
+      filesScanned: 646,
+      filesUnreadable: 0,
+      linesParsed: 170_912,
+      linesFailed: 8,
+    },
+    excludedTokens: { unpriced: 0, synthetic: 0 },
+  } as unknown as PayloadV2
+}
+
+type Ctx = Awaited<ReturnType<typeof convexTest>>
+
+async function seedStack(t: Ctx) {
+  return await t.run(async (ctx) => {
+    const creatorId = await ctx.db.insert('creators', {
+      name: 'Owner',
+      slug: 'owner-read',
+      userId: USER,
+      verified: false,
+      personalPages: [],
+      projectPages: [],
+      createdAt: Date.now(),
+    })
+    // The query resolves a stack by the shortId suffix of the slug, so the
+    // page's URL form is what a test has to ask for.
+    const stackId = await ctx.db.insert('stacks', {
+      name: 'My Stack',
+      slug: 'my-stack-sidread',
+      shortId: 'sidread',
+      creatorId,
+      oneLiner: 'A stack',
+      toolSubscriptions: [],
+      hasUsageComponent: false,
+      published: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    })
+    return { stackId }
+  })
+}
+
+describe('getCurrentByStackSlug reads what the CLI publishes', () => {
+  test('answers a payload carrying every #213 field', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payloadWithCounts(),
+    })
+
+    const current = await t.query(api.measured.getCurrentByStackSlug, {
+      slug: 'my-stack-sidread',
+    })
+
+    expect(current).not.toBeNull()
+    expect(current?.harnesses).toHaveLength(1)
+  })
+
+  test('carries the per-atom counts and their denominator through to the page', async () => {
+    // Not just "does not throw": the counts are what the kit component reads,
+    // so a validator that dropped them silently would be a second bug.
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payloadWithCounts(),
+    })
+
+    const current = await t.query(api.measured.getCurrentByStackSlug, {
+      slug: 'my-stack-sidread',
+    })
+    const inventory = current?.harnesses[0]?.inventory
+
+    expect(inventory?.builtinTools[0]).toMatchObject({
+      name: 'Bash',
+      calls: 22_634,
+    })
+    expect(inventory?.calls?.builtinTools).toBe(31_745)
+  })
+
+  test('carries the cache-write TTL split through to the page', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payloadWithCounts(),
+    })
+
+    const current = await t.query(api.measured.getCurrentByStackSlug, {
+      slug: 'my-stack-sidread',
+    })
+
+    expect(current?.models[0]?.tokens.cacheWriteTtl).toEqual({
+      fiveMinute: 10,
+      oneHour: 20,
+      unsplit: 0,
+    })
+  })
+})

--- a/convex/workflow-wire-contract.test.ts
+++ b/convex/workflow-wire-contract.test.ts
@@ -1,0 +1,172 @@
+/**
+ * The CLI's workflow payload against the server's validator (#217 fallout).
+ *
+ * WHY THIS FILE EXISTS. The CLI builds the workflow section and the Convex
+ * schema validates it, and until this test nothing checked that the two agreed.
+ * They did not: every harness carried an `aggregateVersion` the server had no
+ * field for, and Convex object validators refuse an extra key. Both sides had
+ * green suites, and the first real sync died at the publish gate with
+ * `extra field \`aggregateVersion\` ... Path: .workflow.harnesses[0]`.
+ *
+ * The walker below is the general form of that bug, not the instance: it fails
+ * on any key the CLI sends that the validator does not declare, at any depth,
+ * and names the path the way Convex does.
+ */
+import { describe, expect, it } from "vitest";
+import { toPayloadWorkflow } from "../packages/cli/src/harness/shared/payload.js";
+import type { WorkflowExtraction } from "../packages/cli/src/workflow/extract.js";
+import { WorkflowSection } from "./schema";
+
+// The runtime shape of a Convex validator, as much of it as the walk needs.
+type Node = {
+	kind: string;
+	fields?: Record<string, Node>;
+	element?: Node;
+	members?: Node[];
+};
+
+/**
+ * Every path in `value` that the validator has no field for.
+ *
+ * A union takes the branch that explains the most keys, which is the reading
+ * Convex's own error gives on a union mismatch: the branch that fit best.
+ */
+function extraKeys(value: unknown, node: Node, path: string): string[] {
+	if (value === null || value === undefined) return [];
+	if (node.kind === "union" && node.members) {
+		const perBranch = node.members.map((member) =>
+			extraKeys(value, member, path),
+		);
+		const best = perBranch.reduce((a, b) => (a.length <= b.length ? a : b));
+		return best;
+	}
+	if (node.kind === "array" && node.element) {
+		if (!Array.isArray(value)) return [];
+		return value.flatMap((item, index) =>
+			extraKeys(item, node.element as Node, `${path}[${index}]`),
+		);
+	}
+	if (node.kind === "object" && node.fields) {
+		if (typeof value !== "object" || Array.isArray(value)) return [];
+		const found: string[] = [];
+		for (const [key, child] of Object.entries(value as object)) {
+			const field = node.fields[key];
+			if (!field) {
+				found.push(`${path}.${key}`);
+				continue;
+			}
+			found.push(...extraKeys(child, field, `${path}.${key}`));
+		}
+		return found;
+	}
+	return [];
+}
+
+const phaseTotals = () => ({
+	scout: 60,
+	build: 30,
+	verify: 5,
+	handoff: 3,
+	unknown: 2,
+});
+
+/** One machine's extraction, with every optional half present. */
+function extraction(): WorkflowExtraction {
+	return {
+		aggregateVersion: "workflow-aggregates/v1",
+		utcOffsetMinutes: 120,
+		harnesses: [
+			{
+				aggregateVersion: "workflow-aggregates/v1",
+				harness: "claude-code",
+				phase: {
+					ruleVersion: "phase-rules/v1",
+					publishable: true,
+					sessions: 42,
+					phaseSec: phaseTotals(),
+					phaseEvents: phaseTotals(),
+					waitingSec: 4,
+					idleSec: 9,
+					unknownShare: 0.02,
+					sessionRows: [
+						{
+							startHourUtc: 21,
+							eventCount: 40,
+							phaseSec: phaseTotals(),
+							phaseEvents: phaseTotals(),
+							waitingSec: 0,
+							idleSec: 0,
+							merged: false,
+							verifyRuns: 1,
+							reviewRounds: 0,
+							openedWithScout: true,
+						},
+					],
+				},
+				routing: {
+					main: [{ model: "claude-opus-5", tokens: 100 }],
+					subagents: [{ model: "claude-fable-5", tokens: 20 }],
+				},
+				delegation: {
+					mainToolCalls: 10,
+					subagentToolCalls: 4,
+					widestFanOut: 2,
+					mostSubagents: 3,
+				},
+				facts: {
+					sessions: [{ harness: "claude-code", thinkingTokens: 1234 }],
+					activeDays: [{ date: "2026-07-24", parallelProjectCount: 2 }],
+				},
+				activity: [{ weekdayUtc: 5, hourUtc: 23, events: 17 }],
+			},
+		],
+		git: {
+			testFileRuleVersion: "test-files/v1",
+			fileTypeRuleVersion: "file-types/v1",
+			totalCommits: 12,
+			lateNightCommits: 3,
+			additions: 400,
+			removals: 120,
+			changedLinesPerCommit: [40, 12],
+			testFileCommits: 5,
+			changedLinesByExtension: [{ extension: ".ts", changedLines: 500 }],
+			withheldExtensionLines: 20,
+			weekdayHourCells: [{ weekday: 5, hour: 23, commits: 3 }],
+		},
+		metricInputs: [
+			{
+				metricId: "late-night-commit-share",
+				ruleVersion: "metric-rules/v1",
+				value: 0.25,
+				band: { low: 0.05, high: 0.2 },
+				coverage: 1,
+				coverageTag: undefined,
+			},
+		],
+	};
+}
+
+describe("the CLI's workflow section against the server's validator", () => {
+	it("sends no key the validator has no field for", () => {
+		const payload = toPayloadWorkflow(extraction());
+		expect(
+			extraKeys(payload, WorkflowSection as unknown as Node, ".workflow"),
+		).toEqual([]);
+	});
+
+	it("would have caught the per-harness aggregateVersion", () => {
+		// The exact payload that died in a real sync, so the walker is checked
+		// against a failure and not only against a pass.
+		const payload = toPayloadWorkflow(extraction());
+		const broken = {
+			...payload,
+			harnesses: payload.harnesses.map((harness) => ({
+				...harness,
+				aggregateVersion: "workflow-aggregates/v1",
+			})),
+		};
+		expect(
+			extraKeys(broken, WorkflowSection as unknown as Node, ".workflow"),
+		).toEqual([".workflow.harnesses[0].aggregateVersion"]);
+	});
+});

--- a/docs/specs/workflow-surface.md
+++ b/docs/specs/workflow-surface.md
@@ -53,7 +53,19 @@ Ledger (removals in red, per-commit sizes as a log-scale dot strip), coding lang
 
 On the stack page the section is titled Workflow under `// measured`, position 04 in
 the settled order: Actual Usage 01, Projects 02, Tools 03, Workflow 04, Guide 05
-([#193](https://github.com/alp82/aistack/issues/193)).
+([#193](https://github.com/alp82/aistack/issues/193)). The writeup section that used
+to carry the title Workflow is renamed Guide, under `// writeup`.
+
+The order is locked, the numbers are not. Tools renders only when the stack lists
+tools, and Workflow only when a reading is stored and published, so the number a
+section prints is its position among the sections that render. A stack with no
+reading closes on Guide 04 rather than printing a gap where 04 would have been.
+
+A nav block of stat rows sits under the hero: one row per rendered section, showing
+the number, the title, and a headline figure the section itself already prints. A row
+is a link, and it opens nothing. Past the block, the same links dock as a fixed rail
+under the site header, carrying the stack name, the price, and the upvotes on its
+left, with a scroll spy marking the section in view.
 
 ## Fit and rotation
 

--- a/docs/specs/workflow-surface.md
+++ b/docs/specs/workflow-surface.md
@@ -236,6 +236,22 @@ Local Git history is a source and makes commit and line facts exact
 for working directories that windowed sessions touched. Repository names stay local
 under the name filter. Only aggregate counts and line totals ship.
 
+Two fixed rules decide which of those lines count, and both moved to v2 in
+[#278](https://github.com/alp82/aistack/issues/278).
+
+`test-files/v2` and `file-types/v2` first drop every changed line under a path a
+machine owns: a dependency tree, a build output directory, a directory of captured
+tool output, or a dependency lockfile. Those lines leave the reading in both halves,
+because withholding keeps a line in the denominator and a line nobody wrote belongs in
+neither. One accidental commit of a package store is otherwise enough to bury a whole
+month of authored work: on the first real reading it carried 6.85 million of 7.46
+million changed lines.
+
+`file-types/v2` then names only an approved extension. A path with no extension is not
+a coding language, so `Dockerfile`, `LICENSE` and `.gitignore` are withheld by type
+while their lines stay in the denominator. The v1 rule ranked them together as
+`(none)`, which read as the leading language of a TypeScript repository.
+
 ## The wire
 
 One new closed workflow section on the existing sync body. Every field is additive and

--- a/packages/cli/src/api.test.ts
+++ b/packages/cli/src/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { authPoll, authStart, setAutoSync, stackGet } from "./api";
+import { authPoll, authStart, setAutoSync, stackGet, syncPublish } from "./api";
 
 /**
  * The two statuses #52 introduced, as the user reads them.
@@ -146,6 +146,65 @@ describe("setAutoSync", () => {
 		);
 		await expect(setAutoSync("tok", { enabled: true })).rejects.toThrow(
 			/not linked/,
+		);
+	});
+});
+
+/**
+ * A server validation error carries the whole offending object (#217 fallout).
+ *
+ * Convex's `ArgumentValidationError` prints the reason, the path, and then the
+ * ENTIRE object it refused. A real failed sync filled the terminal with several
+ * screens of session rows, burying the one line that says what to fix. The
+ * reason and the path are the message; the dump is not.
+ */
+describe("a server error that carries a payload dump", () => {
+	const CONVEX_ERROR = [
+		"ArgumentValidationError: Object contains extra field `aggregateVersion` that is not in the validator.",
+		"Path: .workflow.harnesses[0]",
+		`Object: {activity: [${"{events: 55.0, hourUtc: 0.0, weekdayUtc: 0.0}, ".repeat(400)}]}`,
+		`Validator: v.object({${"harness: v.string(), ".repeat(200)}})`,
+	].join("\n");
+
+	function failWith(detail: string) {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() =>
+				Promise.resolve(
+					new Response(JSON.stringify({ error: detail }), { status: 400 }),
+				),
+			),
+		);
+	}
+
+	test("keeps the reason and the path, and drops the dump", async () => {
+		failWith(CONVEX_ERROR);
+		const error = await syncPublish("token", "{}").catch((e: Error) => e);
+		const message = String((error as Error).message);
+		expect(message).toContain("extra field `aggregateVersion`");
+		expect(message).toContain("Path: .workflow.harnesses[0]");
+		expect(message).not.toContain("weekdayUtc");
+	});
+
+	test("stays short enough to read in a terminal", async () => {
+		failWith(CONVEX_ERROR);
+		const error = await syncPublish("token", "{}").catch((e: Error) => e);
+		const message = String((error as Error).message);
+		expect(message.length).toBeLessThan(600);
+		expect(message.split("\n").length).toBeLessThanOrEqual(6);
+	});
+
+	test("says the detail was cut rather than pretending it was all there", async () => {
+		failWith(CONVEX_ERROR);
+		const error = await syncPublish("token", "{}").catch((e: Error) => e);
+		expect(String((error as Error).message)).toMatch(/truncated/i);
+	});
+
+	test("leaves a short error exactly as the server wrote it", async () => {
+		failWith("Stack not found.");
+		const error = await syncPublish("token", "{}").catch((e: Error) => e);
+		expect(String((error as Error).message)).toBe(
+			"Sync failed: 400 - Stack not found.",
 		);
 	});
 });

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -100,6 +100,43 @@ export async function stackCollect(
 	return res.json();
 }
 
+/** A terminal reader's budget for one error, not a log file's. */
+const MAX_DETAIL_LINES = 4;
+const MAX_DETAIL_LINE = 160;
+const MAX_DETAIL = 480;
+
+/**
+ * The readable part of a server error.
+ *
+ * A CONVEX VALIDATION ERROR CARRIES THE WHOLE OBJECT IT REFUSED. The reason and
+ * the path come first and are the entire message a user can act on; after them
+ * come `Object:` and `Validator:`, each holding a full dump. A real failed sync
+ * printed several screens of session rows and buried the one line that said
+ * what to fix. Keep the head, cut the rest, and SAY that it was cut - a message
+ * silently missing its end is worse than a short one.
+ */
+function readableDetail(detail: string): string {
+	const lines = detail.trim().split("\n");
+	const kept: string[] = [];
+	let cut = lines.length > MAX_DETAIL_LINES;
+	for (const line of lines.slice(0, MAX_DETAIL_LINES)) {
+		// A dump line is one enormous line, so the cap lands mid-object. Drop it
+		// entirely rather than print 160 characters of someone's session rows.
+		if (line.length > MAX_DETAIL_LINE) {
+			cut = true;
+			continue;
+		}
+		kept.push(line);
+	}
+	let text = kept.join("\n").trim();
+	if (text.length > MAX_DETAIL) {
+		text = text.slice(0, MAX_DETAIL).trimEnd();
+		cut = true;
+	}
+	if (!text) text = lines[0]?.slice(0, MAX_DETAIL_LINE).trimEnd() ?? "";
+	return cut ? `${text}\n(detail truncated)` : text;
+}
+
 async function formatHttpError(res: Response, label: string): Promise<string> {
 	const prefix = `${label}: ${res.status} ${res.statusText || ""}`.trim();
 	const text = await res.text().catch(() => "");
@@ -107,9 +144,9 @@ async function formatHttpError(res: Response, label: string): Promise<string> {
 	try {
 		const body = JSON.parse(text) as { error?: string; message?: string };
 		const detail = body.error || body.message;
-		if (detail) return `${prefix} - ${detail}`;
+		if (detail) return `${prefix} - ${readableDetail(detail)}`;
 	} catch {}
-	const snippet = text.trim().slice(0, 500);
+	const snippet = readableDetail(text);
 	return snippet ? `${prefix} - ${snippet}` : prefix;
 }
 

--- a/packages/cli/src/harness/shared/payload.test.ts
+++ b/packages/cli/src/harness/shared/payload.test.ts
@@ -489,6 +489,25 @@ describe("the workflow section on the wire (#213)", () => {
 		expect(JSON.stringify(body.payloads)).not.toContain("phase-rules");
 	});
 
+	it("carries the aggregate version ONCE, on the section", () => {
+		// The server's `HarnessWorkflow` validator is a closed object with no
+		// `aggregateVersion` field, and Convex refuses an object with an extra
+		// field. The reducer stamps every harness with the same module constant,
+		// so the per-harness copy is redundant as well as rejected: a real sync
+		// died on `extra field \`aggregateVersion\` ... Path: .workflow.harnesses[0]`.
+		const body = buildSyncBody(
+			[built()],
+			config(),
+			undefined,
+			"manual",
+			extraction(),
+		);
+		expect(body.workflow?.aggregateVersion).toBe("workflow-aggregates/v1");
+		for (const harness of body.workflow?.harnesses ?? []) {
+			expect(harness).not.toHaveProperty("aggregateVersion");
+		}
+	});
+
 	it("leaves the section out entirely when publishWorkflow is off", () => {
 		// The switch is applied here, on the machine. Off means the section is
 		// not in the bytes, so there is nothing server-side to reveal.

--- a/packages/cli/src/harness/shared/payload.test.ts
+++ b/packages/cli/src/harness/shared/payload.test.ts
@@ -450,8 +450,8 @@ describe("the workflow section on the wire (#213)", () => {
 			},
 		],
 		git: {
-			testFileRuleVersion: "test-files/v1",
-			fileTypeRuleVersion: "file-types/v1",
+			testFileRuleVersion: "test-files/v2",
+			fileTypeRuleVersion: "file-types/v2",
 			totalCommits: 12,
 			lateNightCommits: 3,
 			additions: 400,

--- a/packages/cli/src/harness/shared/payload.ts
+++ b/packages/cli/src/harness/shared/payload.ts
@@ -592,10 +592,17 @@ export type SyncBody = {
  * and the CLI has already reduced them into `metrics`. Shipping them too would
  * put finer-grained records on the wire than any surface reads, which is the
  * opposite of what a closed section is for.
+ *
+ * THE AGGREGATE VERSION RIDES ON THE SECTION, NOT ON EACH HARNESS. The reducer
+ * stamps every harness with the same module constant, and the server's
+ * `HarnessWorkflow` is a closed validator with no field for it, so the copy is
+ * both redundant and rejected.
  */
 export type PayloadWorkflow = {
 	aggregateVersion: string;
-	harnesses: Array<Omit<PublishableHarnessWorkflow, "facts">>;
+	harnesses: Array<
+		Omit<PublishableHarnessWorkflow, "facts" | "aggregateVersion">
+	>;
 	git: WorkflowExtraction["git"];
 	metrics: PayloadWorkflowMetric[];
 	utcOffsetMinutes: number;
@@ -624,14 +631,18 @@ export type PayloadWorkflowMetric = {
  *
  * `coverageTag` is dropped when it is `undefined` rather than sent as null: the
  * closed server validator takes an optional string, and "no tag" is an absent
- * field there.
+ * field there. Each harness drops `aggregateVersion` for the same reason, in
+ * the other direction: the server has no field for it, so sending it is an
+ * extra key and Convex refuses the whole object.
  */
 export function toPayloadWorkflow(
 	extraction: WorkflowExtraction,
 ): PayloadWorkflow {
 	return {
 		aggregateVersion: extraction.aggregateVersion,
-		harnesses: extraction.harnesses.map(({ facts: _local, ...rest }) => rest),
+		harnesses: extraction.harnesses.map(
+			({ facts: _local, aggregateVersion: _stamped, ...rest }) => rest,
+		),
 		git: extraction.git,
 		metrics: extraction.metricInputs.map((row) => ({
 			metricId: row.metricId,

--- a/packages/cli/src/sync/stage.test.ts
+++ b/packages/cli/src/sync/stage.test.ts
@@ -259,6 +259,6 @@ describe("stageSync", () => {
 	test("stamps the publishing CLI's version on the body (#213)", async () => {
 		const staged = await stageSync(deps({ gitRunnerImpl: () => null }));
 		expect(staged.body.cliVersion).toBe(CLI_VERSION);
-		expect(staged.summary).toContain(`client    aistack ${CLI_VERSION}`);
+		expect(staged.summary).toContain(`· aistack ${CLI_VERSION}`);
 	});
 });

--- a/packages/cli/src/sync/stage.ts
+++ b/packages/cli/src/sync/stage.ts
@@ -182,6 +182,9 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 		source,
 		baseUrl: deps.baseUrl,
 		scanStats,
+		// The real terminal, so the inventory rows break where this window ends
+		// (#217). A pipe reports nothing and the preview falls back to 80.
+		width: process.stdout.columns,
 	};
 
 	let blockedReason: string | null = null;

--- a/packages/cli/src/sync/summary.test.ts
+++ b/packages/cli/src/sync/summary.test.ts
@@ -135,8 +135,8 @@ function workflow(over: Partial<PayloadWorkflow> = {}): PayloadWorkflow {
 			},
 		],
 		git: {
-			testFileRuleVersion: "test-files/v1",
-			fileTypeRuleVersion: "file-types/v1",
+			testFileRuleVersion: "test-files/v2",
+			fileTypeRuleVersion: "file-types/v2",
 			totalCommits: 214,
 			lateNightCommits: 30,
 			additions: 9_000,

--- a/packages/cli/src/sync/summary.test.ts
+++ b/packages/cli/src/sync/summary.test.ts
@@ -105,7 +105,8 @@ function workflow(over: Partial<PayloadWorkflow> = {}): PayloadWorkflow {
 		utcOffsetMinutes: 120,
 		harnesses: [
 			{
-				aggregateVersion: "workflow-aggregates/v1",
+				// No `aggregateVersion` here: the section carries it once, and the
+				// server's harness validator has no field for it (#217).
 				harness: "claude-code",
 				phase: {
 					ruleVersion: "phase-rules/v1",
@@ -475,5 +476,155 @@ describe("keptPrivateRows", () => {
 			{ label: "internal-proxy", names: 1 },
 			{ label: "stripe", names: 1 },
 		]);
+	});
+});
+
+/**
+ * The preview a person actually reads (#217).
+ *
+ * The first real end-to-end sync produced ninety lines, with headings over
+ * empty sections and inventory rows several hundred characters wide that the
+ * terminal broke mid-name. These hold the shape that replaced it. The rule the
+ * fix had to keep: EVERY PUBLISHED NAME STAYS ON SCREEN. This is the consent
+ * surface, so nothing that goes up may be summarized away.
+ */
+describe("the preview stays readable", () => {
+	const MANY_TOOLS = [
+		"Bash",
+		"Edit",
+		"Read",
+		"Write",
+		"WebFetch",
+		"TaskUpdate",
+		"Agent",
+		"Skill",
+		"ToolSearch",
+		"TaskCreate",
+		"SendUserFile",
+		"WebSearch",
+		"Monitor",
+		"TaskStop",
+		"Artifact",
+		"TaskOutput",
+		"EnterWorktree",
+	];
+
+	function withTools() {
+		return ctx({
+			payload: {
+				inventory: {
+					builtinTools: MANY_TOOLS.map((name) => ({
+						name,
+						callShare: 0.01,
+						calls: 10,
+					})),
+					mcpServers: [],
+					skills: [{ name: "grilling", callShare: 0.1, calls: 12 }],
+					subagents: [],
+					slashCommands: [],
+					withheld: {
+						builtinTools: 0,
+						mcpServers: 0,
+						skills: 0,
+						subagents: 0,
+						slashCommands: 0,
+					},
+					calls: {
+						builtinTools: 1000,
+						mcpServers: 0,
+						skills: 120,
+						subagents: 0,
+						slashCommands: 0,
+					},
+				},
+			},
+		});
+	}
+
+	test("no line runs past the terminal", () => {
+		const summary = buildGateSummary({ ...withTools(), width: 80 });
+		for (const line of summary.split("\n")) {
+			expect(line.length).toBeLessThanOrEqual(80);
+		}
+	});
+
+	test("every published name is still printed, wrapped not truncated", () => {
+		const summary = buildGateSummary({ ...withTools(), width: 80 });
+		for (const name of MANY_TOOLS) {
+			expect(summary).toContain(name);
+		}
+		expect(summary).not.toMatch(/tools.*more\b/);
+	});
+
+	test("counts the inventory before listing it", () => {
+		const summary = buildGateSummary({ ...withTools(), width: 80 });
+		expect(summary).toContain("publishes 17 tools · 1 skills");
+	});
+
+	test("a harness that publishes no names says so, once", () => {
+		const summary = buildGateSummary(
+			ctx({
+				payload: {
+					inventory: {
+						builtinTools: [],
+						mcpServers: [],
+						skills: [],
+						subagents: [],
+						slashCommands: [],
+						withheld: {
+							builtinTools: 0,
+							mcpServers: 0,
+							skills: 0,
+							subagents: 0,
+							slashCommands: 0,
+						},
+						calls: {
+							builtinTools: 0,
+							mcpServers: 0,
+							skills: 0,
+							subagents: 0,
+							slashCommands: 0,
+						},
+					},
+				},
+			}),
+		);
+		expect(summary).toContain("publishes no names from this harness");
+		// The empty headings that used to stand over nothing.
+		expect(summary).not.toContain("what publishes");
+	});
+
+	test("a harness with no models prints no models rows at all", () => {
+		const summary = buildGateSummary(ctx({ payload: { models: [] } }));
+		expect(summary.split("\n").filter((l) => l.startsWith("models"))).toEqual(
+			[],
+		);
+	});
+
+	test("the model table hangs off the label column", () => {
+		const summary = buildGateSummary(ctx({}));
+		const lines = summary.split("\n");
+		const first = lines.findIndex((l) => l.startsWith("models"));
+		expect(first).toBeGreaterThan(-1);
+		// The second model sits under the first, not under a heading.
+		expect(lines[first + 1]).toMatch(/^ {10}claude-opus-5/);
+	});
+
+	test("a wrapped row lines up under its own first name", () => {
+		// `commands` is the longest label and used to run straight into the first
+		// name, and the continuation sat two columns off from the row above it.
+		const summary = buildGateSummary({ ...withTools(), width: 80 });
+		const lines = summary.split("\n");
+		const head = lines.findIndex((l) => l.startsWith("  tools "));
+		expect(head).toBeGreaterThan(-1);
+		const firstName = (lines[head] as string).indexOf("Bash");
+		const continued = lines[head + 1] as string;
+		expect(continued.search(/\S/)).toBe(firstName);
+	});
+
+	test("wraps to a wider terminal when it has one", () => {
+		const narrow = buildGateSummary({ ...withTools(), width: 60 });
+		const wide = buildGateSummary({ ...withTools(), width: 110 });
+		expect(wide.split("\n").length).toBeLessThan(narrow.split("\n").length);
 	});
 });

--- a/packages/cli/src/sync/summary.test.ts
+++ b/packages/cli/src/sync/summary.test.ts
@@ -296,8 +296,9 @@ describe("beat two - the dialog (binding copy, #48)", () => {
 
 describe("beat one - the summary", () => {
 	test("counts active days from the dates in the payload", () => {
+		// The totals ride on the harness header line since #217.
 		expect(buildGateSummary(ctx({}))).toContain(
-			"activity  382 sessions · 3 active days · 4.27B tokens",
+			"382 sessions · 3 active days · 4.27B tokens",
 		);
 	});
 
@@ -458,7 +459,7 @@ describe("the workflow section at the gate (#213)", () => {
 
 	test("names the publishing CLI, because it is in the bytes", () => {
 		const out = buildGateSummary(ctx({ cliVersion: "0.8.0" }));
-		expect(out).toContain("client    aistack 0.8.0");
+		expect(out).toContain("· aistack 0.8.0");
 	});
 
 	test("keeps beat two short - the workflow section adds no line", () => {
@@ -620,6 +621,78 @@ describe("the preview stays readable", () => {
 		const firstName = (lines[head] as string).indexOf("Bash");
 		const continued = lines[head + 1] as string;
 		expect(continued.search(/\S/)).toBe(firstName);
+	});
+
+	test("one harness costs a handful of lines, not a screen", () => {
+		// The first real sync printed ninety. The inventory names are the floor
+		// here, and they stay: everything else is what got cut.
+		const block = buildGateSummary({ ...withTools(), width: 100 })
+			.split("\n\n")
+			.find((b) => b.startsWith("- Claude Code"));
+		expect(block?.split("\n").length).toBeLessThanOrEqual(8);
+	});
+
+	test("a harness that measured nothing is one line", () => {
+		const summary = buildGateSummary(
+			ctx({
+				payload: {
+					activity: {
+						sessions: 1,
+						activeDayDates: ["2026-07-01"],
+						projectKeys: [],
+						totalTokens: 0,
+						cacheHitShare: 0,
+						subagentShare: 0,
+					},
+				},
+			}),
+		);
+		const block = summary
+			.split("\n\n")
+			.find((b) => b.startsWith("- Claude Code"));
+		expect(block?.split("\n")).toHaveLength(1);
+		// Nothing to price, so no cost line either.
+		expect(block).not.toContain("cost");
+	});
+
+	test("rolls up a model under one percent, keeping its dollars", () => {
+		// A four-model table where two carry 99.9% of the tokens hides its own
+		// headline. The rolled row keeps the dollars because every model in it
+		// published one.
+		const summary = buildGateSummary(
+			ctx({
+				payload: {
+					models: [
+						{
+							id: "claude-opus-5",
+							tokenShare: 0.99,
+							tokens: { input: 1, output: 2, cacheWrite: 3, cacheRead: 4 },
+							apiEquivalentUSD: 100,
+						},
+						{
+							id: "claude-haiku-4-5",
+							tokenShare: 0.008,
+							tokens: { input: 1, output: 2, cacheWrite: 3, cacheRead: 4 },
+							apiEquivalentUSD: 1,
+						},
+						{
+							id: "claude-sonnet-5",
+							tokenShare: 0.002,
+							tokens: { input: 1, output: 2, cacheWrite: 3, cacheRead: 4 },
+							apiEquivalentUSD: 1,
+						},
+					],
+				},
+			}),
+		);
+		expect(summary).toContain("+2 more");
+		expect(summary).toContain("claude-opus-5");
+		expect(summary).not.toContain("claude-haiku-4-5");
+	});
+
+	test("the window is the sync's, printed once", () => {
+		const summary = buildGateSummary(ctx({}));
+		expect(summary.split("window").length - 1).toBe(1);
 	});
 
 	test("wraps to a wider terminal when it has one", () => {

--- a/packages/cli/src/sync/summary.ts
+++ b/packages/cli/src/sync/summary.ts
@@ -35,6 +35,12 @@ export type GateContext = {
 	/** Web origin for the URLs the gate prints, e.g. https://aistack.to */
 	baseUrl: string;
 	/**
+	 * Terminal width the preview wraps to. Absent means 80, which is what a
+	 * pipe or a test gets: the gate must render the same way everywhere except
+	 * for where the lines break.
+	 */
+	width?: number;
+	/**
 	 * Per-harness scan stats, keyed by harness name - the LOCAL-ONLY detail
 	 * behind the payload's bare coverage counts (#75): unreadable file names,
 	 * error classes, foreign-file originators. Like `keptPrivate`, it rides
@@ -147,6 +153,59 @@ const CATEGORY_LABEL: Record<NameCategory, string> = {
 	slashCommands: "commands",
 };
 
+// ---------------------------------------------------------------------------
+// Wrapping.
+//
+// EVERY PUBLISHED NAME STAYS ON SCREEN. This is the consent surface, so a name
+// that goes up is a name the person reads first - the inventory rows are never
+// truncated to a count the way the kept-private list is, because that list is
+// the opposite case: those names do NOT leave the machine.
+//
+// What changed in #217 is only where the lines break. An unwrapped inventory
+// row ran to several hundred characters and the terminal broke it mid-name,
+// which reads as noise rather than as a list someone can check.
+// ---------------------------------------------------------------------------
+
+/** The label column every harness line shares: `window    30 days · ...`. */
+const LABEL_WIDTH = 10;
+const DEFAULT_WIDTH = 80;
+
+/** Wrap to the caller's terminal, clamped to a width a list stays readable at. */
+export function wrapWidth(width: number | undefined): number {
+	return Math.min(110, Math.max(60, width ?? DEFAULT_WIDTH));
+}
+
+/**
+ * One labelled row, wrapped with a hanging indent under its own label.
+ *
+ * Breaks on spaces only, and the callers join names with ", ", so a name is
+ * never split across two lines.
+ */
+export function wrapRow(
+	head: string,
+	continuation: string,
+	text: string,
+	width: number,
+): string[] {
+	const limit = Math.max(24, width - continuation.length);
+	const lines: string[] = [];
+	let line = "";
+	for (const word of text.split(" ")) {
+		if (line === "") {
+			line = word;
+			continue;
+		}
+		if (`${line} ${word}`.length > limit) {
+			lines.push(line);
+			line = word;
+		} else {
+			line = `${line} ${word}`;
+		}
+	}
+	if (line !== "") lines.push(line);
+	return lines.map((l, i) => (i === 0 ? head : continuation) + l);
+}
+
 /** Kept-private rows for the gate: one row per group, then singles (#48). */
 export function keptPrivateRows(
 	keptPrivate: Record<NameCategory, KeptPrivateAtom[]>,
@@ -208,8 +267,20 @@ export function scanNoteLines(stats: ScanStats, label: string): string[] {
 	return out;
 }
 
-/** One harness's payload block: window, activity, cost, models, inventory. */
-function payloadBlock(payload: MeasuredPayload, stats?: ScanStats): string[] {
+/**
+ * One harness's payload block: window, activity, cost, models, inventory.
+ *
+ * ONE ALIGNED BLOCK, NO EMPTY HEADINGS (#217). Every row hangs off the same
+ * label column, and a section with nothing in it is not announced: a bare
+ * `models` heading over nothing said only that the code has a models section.
+ * A harness that publishes no names says THAT, in one line, because silence
+ * there would read as a harness that was never scanned.
+ */
+function payloadBlock(
+	payload: MeasuredPayload,
+	width: number,
+	stats?: ScanStats,
+): string[] {
 	const out: string[] = [];
 	// The header is unconditional (#130): the `searched` line above names four
 	// harnesses, so an unlabeled block would be unreadable even when only one
@@ -243,23 +314,55 @@ function payloadBlock(payload: MeasuredPayload, stats?: ScanStats): string[] {
 		out.push(...scanNoteLines(stats, harnessLabel(payload.harness.name)));
 	}
 
-	out.push("");
-	out.push("models");
-	for (const m of payload.models) {
+	// A model table is columns, not prose, so it hangs off the label column
+	// rather than wrapping. A harness that reports no model prints nothing.
+	const indent = " ".repeat(LABEL_WIDTH);
+	const modelWidth = Math.max(0, ...payload.models.map((m) => m.id.length));
+	payload.models.forEach((m, i) => {
 		const dollars =
 			usd !== null && m.apiEquivalentUSD !== undefined
-				? `   ${fmtUSD(m.apiEquivalentUSD)}`
+				? `  ${fmtUSD(m.apiEquivalentUSD)}`
 				: "";
-		out.push(`  ${m.id.padEnd(28)} ${fmtPct(m.tokenShare)}${dollars}`);
-	}
+		const head = i === 0 ? "models".padEnd(LABEL_WIDTH) : indent;
+		out.push(
+			`${head}${m.id.padEnd(modelWidth)}  ${fmtPct(m.tokenShare).padStart(5)}${dollars}`,
+		);
+	});
 
-	out.push("");
-	out.push("what publishes");
-	for (const category of NAME_CATEGORIES) {
-		const atoms = payload.inventory[category];
-		if (atoms.length === 0) continue;
-		const names = atoms.map((a) => a.name).join(", ");
-		out.push(`  ${CATEGORY_LABEL[category].padEnd(9)} ${names}`);
+	// The inventory. The counts line is the glance, the rows underneath are the
+	// consent: every name that publishes is printed.
+	const filled = NAME_CATEGORIES.filter(
+		(category) => payload.inventory[category].length > 0,
+	);
+	if (filled.length === 0) {
+		out.push(`${"publishes".padEnd(LABEL_WIDTH)}no names from this harness`);
+		return out;
+	}
+	out.push(
+		`${"publishes".padEnd(LABEL_WIDTH)}${filled
+			.map(
+				(category) =>
+					`${payload.inventory[category].length} ${CATEGORY_LABEL[category]}`,
+			)
+			.join(" · ")}`,
+	);
+	// The names indent under their own category label, so a wrapped row and the
+	// row above it start in the same column. `commands` is the longest label and
+	// still needs a gap after it, which is why the width is its length plus one.
+	const subLabel = Math.max(
+		...filled.map((category) => CATEGORY_LABEL[category].length),
+	);
+	const subIndent = " ".repeat(2 + subLabel + 1);
+	for (const category of filled) {
+		const names = payload.inventory[category].map((a) => a.name).join(", ");
+		out.push(
+			...wrapRow(
+				`  ${CATEGORY_LABEL[category].padEnd(subLabel)} `,
+				subIndent,
+				names,
+				width,
+			),
+		);
 	}
 	return out;
 }
@@ -349,10 +452,11 @@ export function buildGateSummary(ctx: GateContext): string {
 	if (body.cliVersion) out.push(`client    aistack ${body.cliVersion}`);
 
 	// One block per detected harness, each under its own header.
+	const width = wrapWidth(ctx.width);
 	for (const payload of payloads) {
 		const stats = ctx.scanStats?.[payload.harness.name];
 		out.push("");
-		out.push(...payloadBlock(payload, stats));
+		out.push(...payloadBlock(payload, width, stats));
 	}
 	if (out[out.length - 1] === "") out.pop();
 

--- a/packages/cli/src/sync/summary.ts
+++ b/packages/cli/src/sync/summary.ts
@@ -224,7 +224,13 @@ export function keptPrivateRows(
 	return rows;
 }
 
-const KEPT_PRIVATE_ROWS_SHOWN = 6;
+/**
+ * How many kept-private rows the gate names before it counts the rest.
+ *
+ * Three, not six (#217). These names do NOT leave the machine, which is what
+ * makes truncating them safe here and unsafe for the published inventory.
+ */
+const KEPT_PRIVATE_ROWS_SHOWN = 3;
 
 // The harness display names live with the harness names themselves (#101), so
 // one harness has one label everywhere. Re-exported: this module is where the
@@ -279,27 +285,47 @@ export function scanNoteLines(stats: ScanStats, label: string): string[] {
 function payloadBlock(
 	payload: MeasuredPayload,
 	width: number,
+	ownWindow: boolean,
 	stats?: ScanStats,
 ): string[] {
 	const out: string[] = [];
 	// The header is unconditional (#130): the `searched` line above names four
 	// harnesses, so an unlabeled block would be unreadable even when only one
-	// harness was found.
-	out.push(
-		`- ${harnessLabel(payload.harness.name)}${payload.harness.version ? ` ${payload.harness.version}` : ""}`,
-	);
-	out.push(
-		`window    ${payload.window.days} days · ${payload.window.from} → ${payload.window.to}`,
-	);
-	out.push(
-		`activity  ${payload.activity.sessions} sessions · ${payload.activity.activeDayDates.length} active days · ${fmtTokens(payload.activity.totalTokens)} tokens`,
-	);
+	// harness was found. It also CARRIES the activity and the cost, which each
+	// held a line of their own until #217 - three lines saying one harness's
+	// totals, repeated per harness, was most of a preview nobody read.
+	const label = `${harnessLabel(payload.harness.name)}${payload.harness.version ? ` ${payload.harness.version}` : ""}`;
+	const days = payload.activity.activeDayDates.length;
 	const usd = totalUSD(payload);
+	const totals = [
+		`${payload.activity.sessions} session${payload.activity.sessions === 1 ? "" : "s"}`,
+		`${days} active day${days === 1 ? "" : "s"}`,
+		`${fmtTokens(payload.activity.totalTokens)} tokens`,
+	];
+	// Wrapped, because the merged header is the longest line in the block and a
+	// narrow terminal would otherwise break it mid-figure.
+	out.push(...wrapRow("", "  ", `- ${label} · ${totals.join(" · ")}`, width));
+
+	// A harness that measured nothing has nothing else to say - not even a cost
+	// line, because there is nothing to price. It still gets its header, because
+	// a scanned harness reading as an absent one is the mistake #130 fixed.
+	if (payload.activity.totalTokens === 0) return out;
+
+	// Cost keeps its own line. `at API prices` is the qualifier that makes the
+	// figure a lower bound rather than a bill (#93), and folding it into the
+	// header above pushed that line past a narrow terminal.
 	out.push(
 		usd === null
 			? "cost      not published"
 			: `cost      ${fmtUSD(usd)} at API prices`,
 	);
+
+	// Only when this harness read a different window from the rest.
+	if (ownWindow) {
+		out.push(
+			`window    ${payload.window.days} days · ${payload.window.from} → ${payload.window.to}`,
+		);
+	}
 
 	// Coverage is silent when clean; a degraded scan is named as a floor (#40).
 	const cov = payload.coverage;
@@ -316,18 +342,36 @@ function payloadBlock(
 
 	// A model table is columns, not prose, so it hangs off the label column
 	// rather than wrapping. A harness that reports no model prints nothing.
+	//
+	// A MODEL UNDER ONE PERCENT ROLLS UP. Four rows where two carry 99.9% of the
+	// tokens is a table that hides its own headline. The rolled figure keeps its
+	// dollars only when every model in it published one, the same rule a single
+	// row follows: a sum missing a term would understate without saying so.
 	const indent = " ".repeat(LABEL_WIDTH);
-	const modelWidth = Math.max(0, ...payload.models.map((m) => m.id.length));
-	payload.models.forEach((m, i) => {
+	const shown = payload.models.filter((m) => m.tokenShare >= MODEL_ROLLUP);
+	const rolled = payload.models.filter((m) => m.tokenShare < MODEL_ROLLUP);
+	const modelWidth = Math.max(0, ...shown.map((m) => m.id.length), 8);
+	const row = (i: number, name: string, share: number, dollars: string) =>
+		`${i === 0 ? "models".padEnd(LABEL_WIDTH) : indent}${name.padEnd(modelWidth)}  ${fmtPct(share).padStart(5)}${dollars}`;
+	shown.forEach((m, i) => {
 		const dollars =
 			usd !== null && m.apiEquivalentUSD !== undefined
 				? `  ${fmtUSD(m.apiEquivalentUSD)}`
 				: "";
-		const head = i === 0 ? "models".padEnd(LABEL_WIDTH) : indent;
-		out.push(
-			`${head}${m.id.padEnd(modelWidth)}  ${fmtPct(m.tokenShare).padStart(5)}${dollars}`,
-		);
+		out.push(row(i, m.id, m.tokenShare, dollars));
 	});
+	if (rolled.length > 0) {
+		const priced = rolled.every((m) => m.apiEquivalentUSD !== undefined);
+		const sum = rolled.reduce((a, m) => a + (m.apiEquivalentUSD ?? 0), 0);
+		out.push(
+			row(
+				shown.length,
+				`+${rolled.length} more`,
+				rolled.reduce((a, m) => a + m.tokenShare, 0),
+				usd !== null && priced ? `  ${fmtUSD(sum)}` : "",
+			),
+		);
+	}
 
 	// The inventory. The counts line is the glance, the rows underneath are the
 	// consent: every name that publishes is printed.
@@ -367,6 +411,9 @@ function payloadBlock(
 	return out;
 }
 
+/** Token share below which a model joins the rolled-up row (#217). */
+const MODEL_ROLLUP = 0.01;
+
 const PHASE_ORDER = ["scout", "build", "verify", "handoff", "unknown"] as const;
 
 /**
@@ -403,8 +450,7 @@ function workflowBlock(workflow: PayloadWorkflow, host: string): string[] {
 		const mix = PHASE_ORDER.map(
 			(phase, i) => `${phase} ${fmtPct((seconds[i] ?? 0) / total)}`,
 		).join(" · ");
-		out.push(`          ${mix}`);
-		out.push(`          ${ruleVersions.join(", ")}`);
+		out.push(`          ${mix} · ${ruleVersions.join(", ")}`);
 	}
 
 	const git = workflow.git;
@@ -443,20 +489,31 @@ export function buildGateSummary(ctx: GateContext): string {
 	// What the CLI LOOKED FOR, in search order - a claim about the CLI, never
 	// about the person's behavior, so it stays inside #40 (#130). Without it, a
 	// harness the scan misses reads identically to a harness never installed.
+	// The client version rides here because it travels (#213) and because one
+	// fact about the CLI does not earn a line of its own.
 	out.push(
-		`searched  ${HARNESS_ADAPTERS.map((a) => harnessLabel(a.name).toLowerCase()).join(", ")}`,
+		`searched  ${HARNESS_ADAPTERS.map((a) => harnessLabel(a.name).toLowerCase()).join(", ")}${
+			body.cliVersion ? ` · aistack ${body.cliVersion}` : ""
+		}`,
 	);
 
-	// Named because it travels (#213). It is one more field in the bytes, and
-	// the rule this file follows is that the preview describes what goes.
-	if (body.cliVersion) out.push(`client    aistack ${body.cliVersion}`);
+	// THE WINDOW IS THE SYNC'S, NOT EACH HARNESS'S (#217). Every payload carries
+	// the same one, so printing it per harness said the same sentence three
+	// times. A harness that somehow read a different window keeps its own line
+	// inside its block rather than being silently folded into this one.
+	const windows = new Set(
+		payloads.map(
+			(p) => `${p.window.days} days · ${p.window.from} → ${p.window.to}`,
+		),
+	);
+	if (windows.size === 1) out.push(`window    ${[...windows][0]}`);
 
 	// One block per detected harness, each under its own header.
 	const width = wrapWidth(ctx.width);
 	for (const payload of payloads) {
 		const stats = ctx.scanStats?.[payload.harness.name];
 		out.push("");
-		out.push(...payloadBlock(payload, width, stats));
+		out.push(...payloadBlock(payload, width, windows.size > 1, stats));
 	}
 	if (out[out.length - 1] === "") out.pop();
 

--- a/packages/cli/src/workflow/extract.test.ts
+++ b/packages/cli/src/workflow/extract.test.ts
@@ -31,8 +31,8 @@ describe("buildWorkflowExtraction", () => {
 		});
 
 		const git: GitWorkflowResult = {
-			testFileRuleVersion: "test-files/v1",
-			fileTypeRuleVersion: "file-types/v1",
+			testFileRuleVersion: "test-files/v2",
+			fileTypeRuleVersion: "file-types/v2",
 			totalCommits: 4,
 			lateNightCommits: 2,
 			additions: 30,
@@ -80,8 +80,8 @@ describe("buildWorkflowExtraction", () => {
 		const extraction = buildWorkflowExtraction(
 			[{ aggregate: reducer.finish(), local }],
 			{
-				testFileRuleVersion: "test-files/v1",
-				fileTypeRuleVersion: "file-types/v1",
+				testFileRuleVersion: "test-files/v2",
+				fileTypeRuleVersion: "file-types/v2",
 				totalCommits: 0,
 				lateNightCommits: 0,
 				additions: 0,
@@ -143,8 +143,8 @@ describe("buildWorkflowExtraction", () => {
 		const extraction = buildWorkflowExtraction(
 			[{ aggregate: reducer.finish(), local }],
 			{
-				testFileRuleVersion: "test-files/v1",
-				fileTypeRuleVersion: "file-types/v1",
+				testFileRuleVersion: "test-files/v2",
+				fileTypeRuleVersion: "file-types/v2",
 				totalCommits: 0,
 				lateNightCommits: 0,
 				additions: 0,

--- a/packages/cli/src/workflow/git.test.ts
+++ b/packages/cli/src/workflow/git.test.ts
@@ -49,8 +49,8 @@ describe("extractGitWorkflow", () => {
 		});
 
 		expect(result).toEqual({
-			testFileRuleVersion: "test-files/v1",
-			fileTypeRuleVersion: "file-types/v1",
+			testFileRuleVersion: "test-files/v2",
+			fileTypeRuleVersion: "file-types/v2",
 			totalCommits: 2,
 			lateNightCommits: 2,
 			additions: 20,
@@ -60,9 +60,10 @@ describe("extractGitWorkflow", () => {
 			changedLinesByExtension: [
 				{ extension: ".js", changedLines: 12 },
 				{ extension: ".ts", changedLines: 16 },
-				{ extension: "(none)", changedLines: 2 },
 			],
-			withheldExtensionLines: 0,
+			// `tests/helper` has no extension, so its 2 lines are withheld rather
+			// than ranked: a file with no extension is not a coding language.
+			withheldExtensionLines: 2,
 			weekdayHourCells: [
 				{ weekday: 1, hour: 23, commits: 1 },
 				{ weekday: 2, hour: 2, commits: 1 },

--- a/packages/cli/src/workflow/git.ts
+++ b/packages/cli/src/workflow/git.ts
@@ -1,8 +1,14 @@
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 
-export const TEST_FILE_RULE_VERSION = "test-files/v1";
-export const FILE_TYPE_RULE_VERSION = "file-types/v1";
+/**
+ * Both rules changed together in #278: a path a machine owns (a dependency
+ * tree, build output, a lockfile) no longer reaches either of them, so both the
+ * test-file count and the file-type mix can differ from what v1 published for
+ * the same repository.
+ */
+export const TEST_FILE_RULE_VERSION = "test-files/v2";
+export const FILE_TYPE_RULE_VERSION = "file-types/v2";
 
 export type GitWorkflowRunner = (
 	cwd: string,
@@ -69,13 +75,20 @@ const emptyResult = (): GitWorkflowResult => ({
 const AUTHOR_LOCAL_RE =
 	/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
 
+/**
+ * The names this rule is willing to print. A path with no extension is absent
+ * on purpose: `Dockerfile`, `LICENSE` and `.gitignore` are not coding
+ * languages, and ranking them as one made the leading language of a TypeScript
+ * repository read as `(none)`.
+ */
 const APPROVED_EXTENSIONS: ReadonlySet<string> = new Set([
-	"(none)",
 	".c",
 	".cc",
+	".cjs",
 	".cpp",
 	".cs",
 	".css",
+	".cts",
 	".dart",
 	".ex",
 	".exs",
@@ -91,6 +104,8 @@ const APPROVED_EXTENSIONS: ReadonlySet<string> = new Set([
 	".kts",
 	".lua",
 	".md",
+	".mjs",
+	".mts",
 	".php",
 	".py",
 	".r",
@@ -111,6 +126,74 @@ const APPROVED_EXTENSIONS: ReadonlySet<string> = new Set([
 	".yml",
 	".zig",
 ]);
+
+/**
+ * Directory names a machine owns rather than a person. A dependency tree, a
+ * build output directory, or a directory of captured tool output can carry
+ * millions of changed lines that nobody wrote, and one accidental commit of one
+ * of them is enough to bury every authored line in the reading.
+ */
+const UNAUTHORED_SEGMENTS: ReadonlySet<string> = new Set([
+	".bundle",
+	".cache",
+	".cargo",
+	".gradle",
+	".next",
+	".nuxt",
+	".pnpm",
+	".pnpm-store",
+	".svelte-kit",
+	".turbo",
+	".venv",
+	"_generated",
+	"bower_components",
+	"build",
+	"coverage",
+	"dist",
+	"generated",
+	"node_modules",
+	"out",
+	"pods",
+	"site-packages",
+	"target",
+	"third_party",
+	"vendor",
+	"venv",
+	"__pycache__",
+]);
+
+/** Dependency lockfiles. A resolver writes these, and their extension lies. */
+const UNAUTHORED_BASENAMES: ReadonlySet<string> = new Set([
+	"bun.lock",
+	"bun.lockb",
+	"cargo.lock",
+	"composer.lock",
+	"flake.lock",
+	"gemfile.lock",
+	"go.sum",
+	"mix.lock",
+	"npm-shrinkwrap.json",
+	"package-lock.json",
+	"packages.lock.json",
+	"pipfile.lock",
+	"pnpm-lock.yaml",
+	"podfile.lock",
+	"poetry.lock",
+	"pubspec.lock",
+	"uv.lock",
+	"yarn.lock",
+]);
+
+/**
+ * True when the path is machine-written rather than authored. Those lines leave
+ * the reading entirely: they are not withheld, because withholding keeps a line
+ * in the denominator, and a line nobody wrote does not belong in either half.
+ */
+function isUnauthoredPath(file: string): boolean {
+	const parts = file.replaceAll("\\", "/").toLowerCase().split("/");
+	if (parts.some((part) => UNAUTHORED_SEGMENTS.has(part))) return true;
+	return UNAUTHORED_BASENAMES.has(parts.at(-1) ?? "");
+}
 
 const COMMIT_MARKER = "aistack-commit";
 
@@ -229,13 +312,15 @@ export function extractGitWorkflow(
 				file = fields[fieldIndex] ?? fields[fieldIndex - 1] ?? "";
 			}
 			if (!current?.included) continue;
+			if (isUnauthoredPath(file)) continue;
 			const fileChangedLines = stat.additions + stat.removals;
 			result.additions += stat.additions;
 			result.removals += stat.removals;
 			current.changedLines += fileChangedLines;
 			if (isTestFile(file)) current.touchesTest = true;
 			if (fileChangedLines <= 0) continue;
-			const extension = path.extname(file).toLowerCase() || "(none)";
+			// An empty extension is not in the approved set, so it withholds.
+			const extension = path.extname(file).toLowerCase();
 			if (APPROVED_EXTENSIONS.has(extension)) {
 				extensionLines.set(
 					extension,

--- a/packages/cli/src/workflow/gitReal.test.ts
+++ b/packages/cli/src/workflow/gitReal.test.ts
@@ -1,0 +1,153 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { extractGitWorkflow } from "./git.js";
+
+/**
+ * These cases run the real `git` binary, so the extractor parses the real
+ * `--numstat -z` framing rather than a hand-written imitation of it. The
+ * framing is where the reading went wrong before, and a fixture written by hand
+ * cannot catch a mistake about what Git actually prints.
+ */
+
+const AUTHORED_AT = "2026-08-10T14:00:00+02:00";
+
+function git(cwd: string, args: readonly string[], date = AUTHORED_AT): void {
+	execFileSync("git", [...args], {
+		cwd,
+		stdio: ["ignore", "ignore", "ignore"],
+		env: {
+			...process.env,
+			GIT_AUTHOR_NAME: "Test",
+			GIT_AUTHOR_EMAIL: "test@example.com",
+			GIT_COMMITTER_NAME: "Test",
+			GIT_COMMITTER_EMAIL: "test@example.com",
+			GIT_AUTHOR_DATE: date,
+			GIT_COMMITTER_DATE: date,
+		},
+	});
+}
+
+function write(root: string, file: string, contents: string | Buffer): void {
+	const target = path.join(root, file);
+	fs.mkdirSync(path.dirname(target), { recursive: true });
+	fs.writeFileSync(target, contents);
+}
+
+const lines = (count: number, text = "line"): string =>
+	`${Array.from({ length: count }, (_, index) => `${text} ${index}`).join("\n")}\n`;
+
+let root: string;
+
+beforeAll(() => {
+	root = fs.mkdtempSync(path.join(os.tmpdir(), "aistack-git-"));
+	git(root, ["init", "--initial-branch=main", "--quiet"]);
+	git(root, ["config", "commit.gpgsign", "false"]);
+});
+
+afterAll(() => {
+	fs.rmSync(root, { recursive: true, force: true });
+});
+
+const read = () =>
+	extractGitWorkflow({
+		workingDirectories: [root],
+		fromMs: Date.parse("2026-08-01T00:00:00Z"),
+		toMs: Date.parse("2026-08-31T23:59:59Z"),
+	});
+
+describe("extractGitWorkflow over real Git output", () => {
+	it("counts authored lines and leaves a vendored dependency tree out", () => {
+		write(root, "src/app.ts", lines(10));
+		write(root, ".pnpm-store/v11/files/ab/deadbeefcafe", lines(1000));
+		write(root, "node_modules/left-pad/index.js", lines(500));
+		git(root, ["add", "-A"]);
+		git(root, ["commit", "-m", "first"]);
+
+		const result = read();
+
+		expect(result.totalCommits).toBe(1);
+		expect(result.additions).toBe(10);
+		expect(result.changedLinesPerCommit).toEqual([10]);
+		expect(result.changedLinesByExtension).toEqual([
+			{ extension: ".ts", changedLines: 10 },
+		]);
+		expect(result.withheldExtensionLines).toBe(0);
+	});
+
+	it("withholds a file with no extension instead of ranking it as a language", () => {
+		write(root, "Dockerfile", lines(6));
+		write(root, ".gitignore", lines(4));
+		write(root, "LICENSE", lines(2));
+		write(root, "src/second.ts", lines(12));
+		git(root, ["add", "-A"]);
+		git(root, ["commit", "-m", "second"]);
+
+		const result = read();
+
+		expect(
+			result.changedLinesByExtension.map((row) => row.extension),
+		).not.toContain("(none)");
+		// 10 from the first commit, 12 from this one.
+		expect(result.changedLinesByExtension).toEqual([
+			{ extension: ".ts", changedLines: 22 },
+		]);
+		// 6 + 4 + 2: the lines stay in the denominator, only their type is withheld.
+		expect(result.withheldExtensionLines).toBe(12);
+	});
+
+	it("reads a rename record against the new path and counts no line for a binary", () => {
+		fs.rmSync(path.join(root, "src/second.ts"));
+		write(root, "src/moved.py", lines(15));
+		write(
+			root,
+			"assets/logo.png",
+			Buffer.from([0x89, 0x50, 0x4e, 0x47, 0, 1, 2, 3]),
+		);
+		git(root, ["add", "-A"]);
+		git(root, ["commit", "-m", "third"]);
+
+		const result = read();
+		const byExtension = Object.fromEntries(
+			result.changedLinesByExtension.map((row) => [
+				row.extension,
+				row.changedLines,
+			]),
+		);
+
+		// Git reports the rename as one record whose path field is empty, followed
+		// by the old path and the new path. The new path is the one that counts, so
+		// the three added lines land on Python, not on TypeScript.
+		expect(byExtension[".py"]).toBe(3);
+		expect(byExtension[".ts"]).toBe(22);
+		// A binary record reads `-` for both counts. It is worth no changed line,
+		// and it must not spill into the record that follows it.
+		expect(byExtension[".png"]).toBeUndefined();
+		expect(result.withheldExtensionLines).toBe(12);
+	});
+
+	it("names the module spellings of JavaScript and TypeScript", () => {
+		write(root, "daemon/dispatch.mjs", lines(9));
+		write(root, "scripts/legacy.cjs", lines(5));
+		write(root, "src/config.mts", lines(4));
+		git(root, ["add", "-A"]);
+		git(root, ["commit", "-m", "fourth"]);
+
+		const result = read();
+		const byExtension = Object.fromEntries(
+			result.changedLinesByExtension.map((row) => [
+				row.extension,
+				row.changedLines,
+			]),
+		);
+
+		expect(byExtension[".mjs"]).toBe(9);
+		expect(byExtension[".cjs"]).toBe(5);
+		expect(byExtension[".mts"]).toBe(4);
+		// Unchanged from the previous commit: none of the three was withheld.
+		expect(result.withheldExtensionLines).toBe(12);
+	});
+});

--- a/src/__tests__/workflow-wire-contract.test.ts
+++ b/src/__tests__/workflow-wire-contract.test.ts
@@ -11,11 +11,16 @@
  * The walker below is the general form of that bug, not the instance: it fails
  * on any key the CLI sends that the validator does not declare, at any depth,
  * and names the path the way Convex does.
+ *
+ * IT LIVES IN `src`, NOT IN `convex`. A test inside `convex/` pulls whatever it
+ * imports into the Convex tsconfig's program, and the CLI's sources need a
+ * newer lib than that project targets. `convex dev` typechecks before it
+ * pushes, so the misplaced file silently stopped every backend push.
  */
 import { describe, expect, it } from "vitest";
-import { toPayloadWorkflow } from "../packages/cli/src/harness/shared/payload.js";
-import type { WorkflowExtraction } from "../packages/cli/src/workflow/extract.js";
-import { WorkflowSection } from "./schema";
+import { WorkflowSection } from "../../convex/schema";
+import { toPayloadWorkflow } from "../../packages/cli/src/harness/shared/payload.js";
+import type { WorkflowExtraction } from "../../packages/cli/src/workflow/extract.js";
 
 // The runtime shape of a Convex validator, as much of it as the walk needs.
 type Node = {

--- a/src/__tests__/workflow-wire-contract.test.ts
+++ b/src/__tests__/workflow-wire-contract.test.ts
@@ -126,8 +126,8 @@ function extraction(): WorkflowExtraction {
 			},
 		],
 		git: {
-			testFileRuleVersion: "test-files/v1",
-			fileTypeRuleVersion: "file-types/v1",
+			testFileRuleVersion: "test-files/v2",
+			fileTypeRuleVersion: "file-types/v2",
 			totalCommits: 12,
 			lateNightCommits: 3,
 			additions: 400,

--- a/src/features/stack-view/PageNav.tsx
+++ b/src/features/stack-view/PageNav.tsx
@@ -1,0 +1,177 @@
+import { ArrowDown, ChevronUp } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import type { PageSection } from "./pageOrder";
+
+/**
+ * The stack page's section navigation: a stat-row block under the hero, and a
+ * fixed rail that takes over once the block scrolls away.
+ *
+ * Wayfinder ticket #217 (map #200), the shell fit from prototype #193.
+ *
+ * THE ROWS NAVIGATE, THEY DO NOT EXPAND. Thirteen prototype rounds ended on one
+ * continuous page: a row is a link to a section further down, and the reader
+ * never has to open anything to reach the content. The saved accordion
+ * alternative is on record in the ticket and is not what shipped.
+ *
+ * THE NAV RESTATES, IT NEVER COMPUTES. Every number in a row is a figure its
+ * section already prints, handed in through `sections`. A stat the nav derived
+ * on its own could disagree with the section it points at.
+ */
+export function StackPageNav({
+	sections,
+	identity,
+}: {
+	sections: readonly PageSection[];
+	identity: { name: string; priceText: string; upvotes: number };
+}) {
+	const blockRef = useRef<HTMLElement>(null);
+	const [railShown, setRailShown] = useState(false);
+	const [currentAnchor, setCurrentAnchor] = useState<string | null>(null);
+	const anchorKey = sections.map((section) => section.anchor).join(",");
+
+	// The block leaves the screen upward, the rail arrives. `bottom < 0` is what
+	// keeps the rail down while the reader is still ABOVE the block, where the
+	// block is out of view but has not been passed yet.
+	//
+	// THIS READS THE POSITION, IT DOES NOT WATCH FOR A CROSSING. An
+	// IntersectionObserver on the block reports a CHANGE in whether the block
+	// overlaps the viewport, and on a short screen the block never overlaps it:
+	// it starts below the fold, and a tap on a nav row jumps the reader straight
+	// past it to a section further down. The observer would see "not
+	// intersecting" on both sides of that jump, report nothing, and leave the
+	// rail undocked for the rest of the page.
+	useEffect(() => {
+		const block = blockRef.current;
+		if (!block) return;
+		const update = () => setRailShown(block.getBoundingClientRect().bottom < 0);
+		update();
+		window.addEventListener("scroll", update, { passive: true });
+		window.addEventListener("resize", update);
+		return () => {
+			window.removeEventListener("scroll", update);
+			window.removeEventListener("resize", update);
+		};
+	}, []);
+
+	// The scroll spy. The margins pick the band a third of the way down the
+	// viewport, so the marked link is the section the reader is reading rather
+	// than whichever one happens to touch the top edge.
+	useEffect(() => {
+		if (typeof IntersectionObserver === "undefined") return;
+		const targets = anchorKey
+			.split(",")
+			.map((anchor) => document.getElementById(anchor))
+			.filter((element): element is HTMLElement => element !== null);
+		if (targets.length === 0) return;
+		const spy = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (entry.isIntersecting) setCurrentAnchor(entry.target.id);
+				}
+			},
+			{ rootMargin: "-30% 0px -60% 0px" },
+		);
+		for (const target of targets) spy.observe(target);
+		return () => spy.disconnect();
+	}, [anchorKey]);
+
+	if (sections.length === 0) return null;
+
+	return (
+		<>
+			<nav
+				ref={blockRef}
+				aria-label="Stack sections"
+				className="mx-auto max-w-7xl px-6 pt-7 pb-10"
+			>
+				<ul className="border border-stroke-subtle">
+					{sections.map((section) => (
+						<li
+							key={section.key}
+							className="border-t border-stroke-subtle first:border-t-0"
+						>
+							<a
+								href={`#${section.anchor}`}
+								className="flex items-center gap-4 px-4 py-4 transition-colors hover:bg-bg-panel/50 motion-reduce:transition-none"
+							>
+								<span className="shrink-0 font-mono text-[15px] font-extrabold text-stroke-strong">
+									{numberLabel(section.index)}
+								</span>
+								<span className="shrink-0 text-[15px] font-black uppercase tracking-tight text-fg-primary">
+									{section.title}
+								</span>
+								<span className="ml-auto flex min-w-0 items-center gap-3">
+									{section.stat && (
+										<span className="truncate font-mono text-[11px] uppercase tracking-[0.18em] text-fg-muted">
+											{section.stat}
+										</span>
+									)}
+									<ArrowDown className="size-3.5 shrink-0 text-accent-lime" />
+								</span>
+							</a>
+						</li>
+					))}
+				</ul>
+			</nav>
+
+			{/* Under the site header, which is 64px tall and holds z-50. Hidden, the
+			    rail sits behind it rather than off the top of the document. */}
+			<nav
+				aria-label="Stack sections, pinned"
+				aria-hidden={!railShown}
+				className={cn(
+					"fixed inset-x-0 top-16 z-40 flex overflow-x-auto border-b-2 border-stroke-strong bg-bg-panel/95 backdrop-blur transition-transform duration-200 motion-reduce:transition-none",
+					railShown ? "translate-y-0" : "-translate-y-full",
+				)}
+				data-testid="section-rail"
+				data-shown={railShown ? "true" : "false"}
+			>
+				<span className="flex shrink-0 items-center gap-3 border-r-2 border-stroke-strong px-3.5 py-2">
+					<span className="whitespace-nowrap text-xs font-black uppercase tracking-tight text-fg-primary">
+						{identity.name}
+					</span>
+					<span className="whitespace-nowrap font-mono text-[10px] font-bold text-accent-lime">
+						{identity.priceText}
+					</span>
+					<span className="flex items-center whitespace-nowrap font-mono text-[10px] text-fg-muted">
+						<ChevronUp className="size-3" aria-hidden="true" />
+						{identity.upvotes}
+						<span className="sr-only"> upvotes</span>
+					</span>
+				</span>
+				{sections.map((section) => {
+					const on = currentAnchor === section.anchor;
+					return (
+						<a
+							key={section.key}
+							href={`#${section.anchor}`}
+							tabIndex={railShown ? undefined : -1}
+							aria-current={on ? "true" : undefined}
+							className={cn(
+								"shrink-0 whitespace-nowrap border-r border-stroke-subtle px-3.5 py-3 font-mono text-[10px] font-bold uppercase tracking-[0.1em] transition-colors motion-reduce:transition-none",
+								on
+									? "text-accent-lime shadow-[inset_0_-3px_0_var(--accent-lime)]"
+									: "text-fg-muted hover:text-fg-primary",
+							)}
+						>
+							<span
+								className={cn(
+									"mr-1.5",
+									on ? "text-accent-lime" : "text-stroke-strong",
+								)}
+							>
+								{numberLabel(section.index)}
+							</span>
+							{section.title}
+						</a>
+					);
+				})}
+			</nav>
+		</>
+	);
+}
+
+function numberLabel(index: number): string {
+	return String(index).padStart(2, "0");
+}

--- a/src/features/stack-view/__tests__/page-nav.test.tsx
+++ b/src/features/stack-view/__tests__/page-nav.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+/**
+ * The stat-row nav and the fixed rail (#217, the shell fit from #193).
+ *
+ * What these guard:
+ *
+ *   1. A ROW IS A LINK, NOT AN EXPANDER. Thirteen prototype rounds ended on one
+ *      continuous page, and a row that opened something would be the accordion
+ *      the ticket saved as the alternative.
+ *   2. THE ROW PRINTS THE NUMBER, THE TITLE AND THE STAT, in that order.
+ *   3. THE RAIL STARTS HIDDEN AND STAYS OUT OF THE TAB ORDER while it is, so a
+ *      keyboard reader never lands on a link they cannot see.
+ *   4. THE RAIL CARRIES THE STACK'S IDENTITY: name, price, upvotes.
+ */
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	within,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StackPageNav } from "../PageNav";
+import type { PageSection } from "../pageOrder";
+
+const SECTIONS: PageSection[] = [
+	{
+		key: "usage",
+		index: 1,
+		title: "Actual Usage",
+		anchor: "section-measured",
+		stat: "148.0M tokens",
+	},
+	{
+		key: "workflow",
+		index: 4,
+		title: "Workflow",
+		anchor: "section-workflow",
+		stat: "42% · late night commits",
+	},
+	{
+		key: "guide",
+		index: 5,
+		title: "Guide",
+		anchor: "section-guide",
+		stat: null,
+	},
+];
+
+const IDENTITY = { name: "Night Shift", priceText: "$220/mo", upvotes: 12 };
+
+/** jsdom lays nothing out, so the block's position is the thing under test. */
+function scrolledPast(element: HTMLElement, past: boolean) {
+	vi.spyOn(element, "getBoundingClientRect").mockReturnValue({
+		bottom: past ? -500 : 400,
+	} as DOMRect);
+}
+
+beforeEach(() => {
+	vi.stubGlobal(
+		"IntersectionObserver",
+		class {
+			observe() {}
+			disconnect() {}
+			unobserve() {}
+		},
+	);
+});
+
+afterEach(() => {
+	cleanup();
+	vi.unstubAllGlobals();
+});
+
+function block() {
+	return screen.getByRole("navigation", { name: "Stack sections" });
+}
+
+// The rail is `aria-hidden` until it docks, which is the point: an element the
+// accessibility tree is right to skip cannot be reached by role, so the test
+// reaches it by test id and asserts the hidden state from there.
+function rail() {
+	return screen.getByTestId("section-rail");
+}
+
+describe("the nav block", () => {
+	it("gives every section one link to its anchor", () => {
+		render(<StackPageNav sections={SECTIONS} identity={IDENTITY} />);
+		const links = within(block()).getAllByRole("link");
+		expect(links.map((link) => link.getAttribute("href"))).toEqual([
+			"#section-measured",
+			"#section-workflow",
+			"#section-guide",
+		]);
+	});
+
+	it("prints the number, the title and the stat on a row", () => {
+		render(<StackPageNav sections={SECTIONS} identity={IDENTITY} />);
+		const row = within(block()).getAllByRole("link")[1];
+		expect(row?.textContent).toContain("04");
+		expect(row?.textContent).toContain("Workflow");
+		expect(row?.textContent).toContain("42% · late night commits");
+	});
+
+	it("opens nothing: no row is a button or a disclosure", () => {
+		render(<StackPageNav sections={SECTIONS} identity={IDENTITY} />);
+		expect(within(block()).queryAllByRole("button")).toHaveLength(0);
+		expect(block().querySelectorAll("[aria-expanded]").length).toBe(0);
+	});
+
+	it("leaves the stat out when a section has none", () => {
+		render(<StackPageNav sections={SECTIONS} identity={IDENTITY} />);
+		const guide = within(block()).getAllByRole("link")[2];
+		expect(guide?.textContent?.replace(/\s/g, "")).toBe("05Guide");
+	});
+
+	it("renders nothing at all when no section renders", () => {
+		const { container } = render(
+			<StackPageNav sections={[]} identity={IDENTITY} />,
+		);
+		expect(container).toBeEmptyDOMElement();
+	});
+});
+
+describe("the fixed rail", () => {
+	it("starts hidden and keeps its links out of the tab order", () => {
+		render(<StackPageNav sections={SECTIONS} identity={IDENTITY} />);
+		const pinned = rail();
+		expect(pinned).toHaveAttribute("data-shown", "false");
+		expect(pinned).toHaveAttribute("aria-hidden", "true");
+		for (const link of within(pinned).getAllByRole("link", {
+			hidden: true,
+		})) {
+			expect(link).toHaveAttribute("tabindex", "-1");
+		}
+	});
+
+	it("carries the stack name, the price and the upvotes", () => {
+		render(<StackPageNav sections={SECTIONS} identity={IDENTITY} />);
+		expect(rail().textContent).toContain("Night Shift");
+		expect(rail().textContent).toContain("$220/mo");
+		expect(rail().textContent).toContain("12");
+	});
+
+	// The regression this replaced an IntersectionObserver to fix: on a short
+	// screen the block starts BELOW the fold, so a tap on a nav row jumps the
+	// reader past it without the block ever overlapping the viewport. An
+	// observer sees no crossing and reports nothing; a position read does.
+	it("docks on a jump that never crosses the block", () => {
+		render(<StackPageNav sections={SECTIONS} identity={IDENTITY} />);
+		expect(screen.getByTestId("section-rail")).toHaveAttribute(
+			"data-shown",
+			"false",
+		);
+
+		scrolledPast(block(), true);
+		fireEvent.scroll(window);
+		expect(screen.getByTestId("section-rail")).toHaveAttribute(
+			"data-shown",
+			"true",
+		);
+
+		scrolledPast(block(), false);
+		fireEvent.scroll(window);
+		expect(screen.getByTestId("section-rail")).toHaveAttribute(
+			"data-shown",
+			"false",
+		);
+	});
+
+	it("repeats the same anchors as the block", () => {
+		render(<StackPageNav sections={SECTIONS} identity={IDENTITY} />);
+		const railHrefs = within(rail())
+			.getAllByRole("link", { hidden: true })
+			.map((link) => link.getAttribute("href"));
+		expect(railHrefs).toEqual([
+			"#section-measured",
+			"#section-workflow",
+			"#section-guide",
+		]);
+	});
+});

--- a/src/features/stack-view/__tests__/page-order.test.ts
+++ b/src/features/stack-view/__tests__/page-order.test.ts
@@ -1,0 +1,116 @@
+/**
+ * The locked stack-page order (#217, map #200).
+ *
+ * What these guard, rather than layout:
+ *
+ *   1. THE ORDER NEVER MOVES. Actual Usage, Projects, Tools, Workflow, Guide.
+ *   2. THE NUMBERS DO. Two sections render only when they have content, and the
+ *      number is the position among the ones that do, so a page without a
+ *      workflow reading closes on Guide 04 and prints no gap at 04.
+ *   3. A NAV STAT IS A FIGURE THE SECTION ALREADY SHOWS. A section with no
+ *      figure yet shows no stat rather than a zero.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	buildPageSections,
+	guideStat,
+	projectsStat,
+	SECTION_ORDER,
+	sectionIndex,
+	toolsStat,
+	usageStat,
+} from "../pageOrder";
+
+const ALL_PRESENT = {
+	usage: { present: true, stat: null },
+	projects: { present: true, stat: null },
+	tools: { present: true, stat: null },
+	workflow: { present: true, stat: null },
+	guide: { present: true, stat: null },
+};
+
+describe("the locked section order", () => {
+	it("is Actual Usage 01, Projects 02, Tools 03, Workflow 04, Guide 05", () => {
+		const sections = buildPageSections(ALL_PRESENT);
+		expect(sections.map((section) => [section.index, section.title])).toEqual([
+			[1, "Actual Usage"],
+			[2, "Projects"],
+			[3, "Tools"],
+			[4, "Workflow"],
+			[5, "Guide"],
+		]);
+	});
+
+	it("keeps the key order fixed in SECTION_ORDER", () => {
+		expect(SECTION_ORDER).toEqual([
+			"usage",
+			"projects",
+			"tools",
+			"workflow",
+			"guide",
+		]);
+	});
+
+	it("gives every rendered section its own anchor", () => {
+		const anchors = buildPageSections(ALL_PRESENT).map(
+			(section) => section.anchor,
+		);
+		expect(new Set(anchors).size).toBe(anchors.length);
+		expect(anchors).toContain("section-measured");
+		expect(anchors).toContain("section-workflow");
+	});
+});
+
+describe("a section that does not render", () => {
+	it("takes no number, and Guide closes on 04 without a workflow reading", () => {
+		const sections = buildPageSections({
+			...ALL_PRESENT,
+			workflow: { present: false, stat: null },
+		});
+		expect(sections.map((section) => section.key)).toEqual([
+			"usage",
+			"projects",
+			"tools",
+			"guide",
+		]);
+		expect(sectionIndex(sections, "guide")).toBe(4);
+		expect(sectionIndex(sections, "workflow")).toBeNull();
+	});
+
+	it("moves everything after it up, tools included", () => {
+		const sections = buildPageSections({
+			...ALL_PRESENT,
+			tools: { present: false, stat: null },
+		});
+		expect(sectionIndex(sections, "workflow")).toBe(3);
+		expect(sectionIndex(sections, "guide")).toBe(4);
+	});
+});
+
+describe("the nav row stats", () => {
+	it("shows tokens for a stack that synced, and nothing for one that did not", () => {
+		expect(usageStat(148_000_000)).toBe("148.0M tokens");
+		expect(usageStat(null)).toBeNull();
+		expect(usageStat(0)).toBeNull();
+	});
+
+	it("counts projects, singular and plural, and hides an empty set", () => {
+		expect(projectsStat(5)).toBe("5 projects");
+		expect(projectsStat(1)).toBe("1 project");
+		expect(projectsStat(0)).toBeNull();
+	});
+
+	it("prints the tool count with the monthly price when there is one", () => {
+		expect(toolsStat(11, 220)).toBe("11 tools · $220/mo");
+		expect(toolsStat(1, 0)).toBe("1 tool");
+		expect(toolsStat(0, 220)).toBeNull();
+	});
+
+	it("reads the guide's minutes off the stored rich text", () => {
+		const words = Array.from({ length: 400 }, () => "word").join(" ");
+		expect(guideStat(`<p>${words}</p>`)).toBe("2 min read");
+		expect(guideStat("<p>short</p>")).toBe("1 min read");
+		expect(guideStat("<p></p>")).toBeNull();
+		expect(guideStat(undefined)).toBeNull();
+	});
+});

--- a/src/features/stack-view/__tests__/stack-view-sections.test.tsx
+++ b/src/features/stack-view/__tests__/stack-view-sections.test.tsx
@@ -343,7 +343,7 @@ describe("BundleCard highlight", () => {
 });
 
 // ===========================================================================
-// GROUP A - Titles (ToolsSection → "Tools" / "// AI Components"; GuideSection → "Workflow" / "// GUIDE")
+// GROUP A - Titles (ToolsSection → "Tools" / "// AI Components"; GuideSection → "Guide" / "// writeup")
 // ===========================================================================
 
 describe("GROUP A - Section titles", () => {
@@ -360,32 +360,39 @@ describe("GROUP A - Section titles", () => {
 		expect(screen.getByText(/\/\/ AI Components/i)).toBeInTheDocument();
 	});
 
-	// A-2: GuideSection uses "Workflow" heading and "// GUIDE" kicker
-	it("GuideSection: heading is /^Workflow$/i", () => {
+	// A-2: GuideSection uses "Guide" heading and "// writeup" kicker.
+	//
+	// It was titled Workflow until #217. The measured section now placed at 04
+	// owns that name (#193), and two sections called Workflow would have read as
+	// the same thing twice.
+	it("GuideSection: heading is /^Guide$/i", () => {
 		render(
 			<GuideSection
-				index={3}
+				index={5}
 				description="Some content"
 				isOwner={false}
 				slug="my-stack"
 			/>,
 		);
 		expect(
-			screen.getByRole("heading", { name: /^Workflow$/i }),
+			screen.getByRole("heading", { name: /^Guide$/i }),
 		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("heading", { name: /^Workflow$/i }),
+		).not.toBeInTheDocument();
 	});
 
-	it("GuideSection: kicker contains '// GUIDE' (not '// WRITEUP')", () => {
+	it("GuideSection: kicker contains '// writeup' (not '// GUIDE')", () => {
 		render(
 			<GuideSection
-				index={3}
+				index={5}
 				description="Some content"
 				isOwner={false}
 				slug="my-stack"
 			/>,
 		);
-		expect(screen.getByText(/\/\/ GUIDE/i)).toBeInTheDocument();
-		expect(screen.queryByText(/\/\/ WRITEUP/i)).not.toBeInTheDocument();
+		expect(screen.getByText(/\/\/ writeup/i)).toBeInTheDocument();
+		expect(screen.queryByText(/\/\/ GUIDE/i)).not.toBeInTheDocument();
 	});
 });
 

--- a/src/features/stack-view/pageOrder.ts
+++ b/src/features/stack-view/pageOrder.ts
@@ -1,0 +1,150 @@
+/**
+ * The locked stack-page section order, and the stats its nav rows carry.
+ *
+ * Wayfinder ticket #217 (map #200). The order was settled by prototype #193
+ * and written into `docs/specs/workflow-surface.md`: Actual Usage 01,
+ * Projects 02, Tools 03, Workflow 04, Guide 05.
+ *
+ * THE ORDER IS LOCKED, THE NUMBERS ARE NOT. Two sections render only when they
+ * have something to show: Tools drops out of a stack with no tools, and
+ * Workflow drops out of every stack without a stored reading, which is most of
+ * them. The number is the position among the sections that DO render, so a page
+ * without a workflow reading closes on Guide 04 and never prints a gap where 04
+ * would have been. `SECTION_ORDER` is the part that never moves.
+ *
+ * This module is pure so the order and the numbering are testable without a
+ * page: the route hands it presence and figures, and renders what it returns.
+ */
+
+import { fmtTokens, MEASURED_ANCHOR } from "@/features/measured/copy";
+import { WORKFLOW_ANCHOR } from "@/features/workflow/copy";
+import { formatPriceDisplay } from "@/lib/pricing";
+
+export const SECTION_ORDER = [
+	"usage",
+	"projects",
+	"tools",
+	"workflow",
+	"guide",
+] as const;
+
+export type SectionKey = (typeof SECTION_ORDER)[number];
+
+/**
+ * Where each section mounts. Two of the five already owned an anchor, and the
+ * nav needs all five to be addressable.
+ */
+export const SECTION_ANCHORS: Record<SectionKey, string> = {
+	usage: MEASURED_ANCHOR,
+	projects: "section-projects",
+	tools: "section-tools",
+	workflow: WORKFLOW_ANCHOR,
+	guide: "section-guide",
+};
+
+/**
+ * The titles the page prints, and the two #193 renamed.
+ *
+ * The measured section takes `Workflow`, and the writeup section that used to
+ * carry that title becomes `Guide`. The collision is why both names are here
+ * rather than inline in each section.
+ */
+export const SECTION_TITLES: Record<SectionKey, string> = {
+	usage: "Actual Usage",
+	projects: "Projects",
+	tools: "Tools",
+	workflow: "Workflow",
+	guide: "Guide",
+};
+
+export type PageSection = {
+	key: SectionKey;
+	/** Position among the sections that render, 1-based. */
+	index: number;
+	title: string;
+	anchor: string;
+	/** The headline figure the nav row shows. Absent when there is none. */
+	stat: string | null;
+};
+
+export type SectionState = {
+	present: boolean;
+	stat: string | null;
+};
+
+/**
+ * The rendered sections, in the locked order, numbered from 1.
+ *
+ * An absent section takes no number, so the sections after it move up.
+ */
+export function buildPageSections(
+	states: Record<SectionKey, SectionState>,
+): PageSection[] {
+	const sections: PageSection[] = [];
+	for (const key of SECTION_ORDER) {
+		const state = states[key];
+		if (!state.present) continue;
+		sections.push({
+			key,
+			index: sections.length + 1,
+			title: SECTION_TITLES[key],
+			anchor: SECTION_ANCHORS[key],
+			stat: state.stat,
+		});
+	}
+	return sections;
+}
+
+/** The number a section renders under, or null when it does not render. */
+export function sectionIndex(
+	sections: readonly PageSection[],
+	key: SectionKey,
+): number | null {
+	return sections.find((section) => section.key === key)?.index ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// The nav row stats.
+//
+// Each one restates a figure the section itself already prints. Nothing here
+// computes a new fact, and a section with no figure yet shows no stat rather
+// than a zero.
+// ---------------------------------------------------------------------------
+
+export function usageStat(totalTokens: number | null): string | null {
+	if (totalTokens === null || totalTokens <= 0) return null;
+	return `${fmtTokens(totalTokens)} tokens`;
+}
+
+export function projectsStat(count: number): string | null {
+	if (count <= 0) return null;
+	return `${count} ${count === 1 ? "project" : "projects"}`;
+}
+
+export function toolsStat(count: number, monthlyAmount: number): string | null {
+	if (count <= 0) return null;
+	const label = `${count} ${count === 1 ? "tool" : "tools"}`;
+	if (monthlyAmount <= 0) return label;
+	const price = formatPriceDisplay(monthlyAmount, "month", "floor");
+	return `${label} · $${price.amountText}${price.suffix}`;
+}
+
+const WORDS_PER_MINUTE = 200;
+
+/**
+ * The guide's reading time, from the stored rich text.
+ *
+ * The description is Tiptap HTML, so the tags come out before the words are
+ * counted. A guide too short to round up to a minute still reads as one.
+ */
+export function guideStat(description: string | undefined): string | null {
+	if (!description) return null;
+	const words = description
+		.replace(/<[^>]*>/g, " ")
+		.replace(/&[a-z]+;|&#\d+;/gi, " ")
+		.trim()
+		.split(/\s+/)
+		.filter(Boolean).length;
+	if (words === 0) return null;
+	return `${Math.max(1, Math.ceil(words / WORDS_PER_MINUTE))} min read`;
+}

--- a/src/features/stack-view/sections.tsx
+++ b/src/features/stack-view/sections.tsx
@@ -14,6 +14,7 @@ import {
 	ToolCardBig,
 	ToolCardMini,
 } from "./cards";
+import { SECTION_TITLES } from "./pageOrder";
 import { GAP, Section, SectionHeader } from "./ui";
 
 // ---------------------------------------------------------------------------
@@ -78,7 +79,7 @@ function Disclosure({
 }
 
 // ===========================================================================
-// 02 - TOOLS (hosts Models / Bundles disclosures)
+// 03 - TOOLS (hosts Models / Bundles disclosures)
 // ===========================================================================
 
 export function ToolsSection({
@@ -134,7 +135,7 @@ export function ToolsSection({
 			<SectionHeader
 				index={String(index).padStart(2, "0")}
 				kicker="// AI Components"
-				title="Tools"
+				title={SECTION_TITLES.tools}
 				meta={`${tools.length} ${tools.length === 1 ? "item" : "items"}${
 					(fixedTotal?.amount ?? 0) > 0
 						? ` · $${price.amountText}${price.suffix}`
@@ -211,26 +212,33 @@ export function ToolsSection({
 }
 
 // ===========================================================================
-// 03 - GUIDE (writeup)
+// 05 - GUIDE (writeup)
+//
+// TITLED "GUIDE" UNDER "// writeup" SINCE #217. It used to be titled Workflow,
+// and the measured section that now sits at 04 owns that name (#193). Two
+// sections called Workflow, one written and one measured, would have read as
+// the same thing twice.
 // ===========================================================================
 
 export function GuideSection({
 	index,
+	id,
 	description,
 	isOwner,
 	slug,
 }: {
 	index: number;
+	id?: string;
 	description: string | undefined;
 	isOwner: boolean;
 	slug: string;
 }) {
 	return (
-		<Section index={index}>
+		<Section index={index} id={id}>
 			<SectionHeader
 				index={String(index).padStart(2, "0")}
-				kicker="// GUIDE"
-				title="Workflow"
+				kicker="// writeup"
+				title={SECTION_TITLES.guide}
 			/>
 			{description ? (
 				<>

--- a/src/features/stack-view/ui.tsx
+++ b/src/features/stack-view/ui.tsx
@@ -234,7 +234,9 @@ export function Section({
 		<section
 			ref={ref}
 			className={cn(
-				"scroll-mt-24 px-6 py-16 md:py-24",
+				// Clears the 64px site header AND the 48px section rail (#217), so a
+				// nav jump never lands the section title behind them.
+				"scroll-mt-28 px-6 py-16 md:py-24",
 				sectionBg(index),
 				highlighted && !reduce && "ring-2 ring-accent-lime/50 ring-inset",
 			)}

--- a/src/features/workflow/__tests__/nav-stat.test.ts
+++ b/src/features/workflow/__tests__/nav-stat.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The Workflow section's line in the page nav (#217).
+ *
+ * The nav restates, it never ranks: the stat is the server's own top podium row
+ * (#218), and a reading whose podium is empty gets no stat rather than a figure
+ * the section does not lead with.
+ */
+import { describe, expect, it } from "vitest";
+import { workflowNavStat } from "../navStat";
+import { row, view } from "./fixture";
+
+describe("the workflow nav stat", () => {
+	it("is the first podium row, in its own unit", () => {
+		const reading = view({
+			rows: [
+				row({
+					rowId: "late-night-commits",
+					ruleId: "late-night-commits",
+					unit: "share",
+					value: 0.42,
+					placement: "highlight",
+				}),
+				row({ rowId: "second", placement: "normal" }),
+			],
+		});
+		expect(workflowNavStat(reading)).toBe("42% · late night commits");
+	});
+
+	it("skips a row the owner hid", () => {
+		const reading = view({
+			rows: [
+				row({
+					rowId: "hidden-one",
+					ruleId: "hidden-one",
+					placement: "highlight",
+					hidden: true,
+				}),
+				row({
+					rowId: "shown-one",
+					ruleId: "shown-one",
+					unit: "share",
+					value: 0.5,
+					placement: "highlight",
+				}),
+			],
+		});
+		expect(workflowNavStat(reading)).toBe("50% · shown one");
+	});
+
+	it("is absent without a reading, and without a podium", () => {
+		expect(workflowNavStat(null)).toBeNull();
+		expect(workflowNavStat(undefined)).toBeNull();
+		expect(
+			workflowNavStat(view({ rows: [row({ placement: "normal" })] })),
+		).toBeNull();
+	});
+});

--- a/src/features/workflow/navStat.ts
+++ b/src/features/workflow/navStat.ts
@@ -1,0 +1,21 @@
+/**
+ * The Workflow section's one line in the page nav (#217).
+ *
+ * THE NAV STAT IS THE SECTION'S OWN TOP ROW, never a fact the nav picked. The
+ * server ranked the rows and marked the podium (#218), so the stat is the first
+ * highlighted row read back in its own unit. A reading whose podium is empty
+ * gets no stat rather than a fallback figure the section does not lead with.
+ */
+
+import { fmtRowValue, rowName, type WorkflowView } from "./copy";
+
+export function workflowNavStat(
+	view: WorkflowView | null | undefined,
+): string | null {
+	if (!view) return null;
+	const top = view.rows.find(
+		(row) => row.placement === "highlight" && !row.hidden,
+	);
+	if (!top) return null;
+	return `${fmtRowValue(top)} · ${rowName(top.ruleId)}`;
+}

--- a/src/routes/stacks.$slug.tsx
+++ b/src/routes/stacks.$slug.tsx
@@ -15,9 +15,21 @@ import {
 	useEditorContext,
 } from "@/features/stack-editor/context/EditorContext";
 import { accentClassFor } from "@/features/stack-view/accentPresets";
+import { StackPageNav } from "@/features/stack-view/PageNav";
+import {
+	buildPageSections,
+	guideStat,
+	projectsStat,
+	SECTION_ANCHORS,
+	sectionIndex,
+	toolsStat,
+	usageStat,
+} from "@/features/stack-view/pageOrder";
 import { StackHeader } from "@/features/stack-view/StackHeader";
 import { GuideSection, ToolsSection } from "@/features/stack-view/sections";
 import { StackViewsLine } from "@/features/view-analytics/StackViewsLine";
+import { workflowNavStat } from "@/features/workflow/navStat";
+import { WorkflowSection } from "@/features/workflow/WorkflowSection";
 import { formatPricingSummary } from "@/lib/pricing";
 import { SITE_URL, seoMeta } from "@/lib/seo";
 import { useRecordView } from "@/lib/useRecordView";
@@ -114,10 +126,18 @@ function ViewLookupDataSync({
 export const Route = createFileRoute("/stacks/$slug")({
 	component: StackDetailsPage,
 	loader: async ({ context, params }) => {
-		const stack = await context.queryClient.ensureQueryData(
-			convexQuery(api.stacks.getBySlug, { slug: params.slug }),
-		);
-		return { stack };
+		// The workflow reading rides along because it decides the NUMBERING (#217):
+		// section 04 exists only when a reading does, and resolving that after
+		// hydration would renumber Guide from 04 to 05 under the reader.
+		const [stack, workflow] = await Promise.all([
+			context.queryClient.ensureQueryData(
+				convexQuery(api.stacks.getBySlug, { slug: params.slug }),
+			),
+			context.queryClient.ensureQueryData(
+				convexQuery(api.workflow.getWorkflowByStackSlug, { slug: params.slug }),
+			),
+		]);
+		return { stack, workflow };
 	},
 	head: ({ loaderData }) => {
 		if (!loaderData?.stack) {
@@ -160,7 +180,8 @@ function StackDetailsPage() {
 	// Falls back to the loader snapshot (same pattern as the landing page):
 	// the live query returns undefined until the Convex WebSocket delivers,
 	// and a wedged connection must show the SSR'd stack, not a loading state.
-	const { stack: loadedStack } = Route.useLoaderData();
+	const { stack: loadedStack, workflow: loadedWorkflow } =
+		Route.useLoaderData();
 	const stack = useQuery(api.stacks.getBySlug, { slug }) ?? loadedStack;
 	// Deduped daily visitors (#78). Counted on MOUNT and keyed by document id, so
 	// a slug rename keeps the page's history.
@@ -191,6 +212,22 @@ function StackDetailsPage() {
 	const upvotersData = useQuery(
 		api.stacks.getUpvoters,
 		hasHovered && stack ? { stackId: stack._id } : "skip",
+	);
+
+	// THE NAV RESTATES WHAT THE SECTIONS SHOW (#217), so the page reads the same
+	// three queries its sections read, with the same arguments. The Convex client
+	// serves both callers from one subscription, and the shared answer is also
+	// what keeps the nav's numbering and the sections' numbering identical: the
+	// workflow reading decides whether 04 exists at all, and both sides read it
+	// here rather than each deciding for itself.
+	const measuredSnapshot = useQuery(api.measured.getCurrentByStackSlug, {
+		slug,
+	});
+	const workflowReading =
+		useQuery(api.workflow.getWorkflowByStackSlug, { slug }) ?? loadedWorkflow;
+	const projects = useQuery(
+		api.projects.listByStack,
+		stack ? { stackId: stack._id } : "skip",
 	);
 
 	const scrollToBundle = (bundleSlug: string) => {
@@ -288,6 +325,30 @@ function StackDetailsPage() {
 		stack.hasUsageComponent,
 	);
 
+	// The locked order (#193, spec `docs/specs/workflow-surface.md`): Actual
+	// Usage 01, Projects 02, Tools 03, Workflow 04, Guide 05. Two of the five
+	// render only when they have content, so the NUMBER is the position among
+	// the ones that do. `buildPageSections` assigns it once, and both the nav
+	// and the sections take it from there.
+	const sections = buildPageSections({
+		usage: {
+			present: true,
+			stat: usageStat(measuredSnapshot?.activity.totalTokens ?? null),
+		},
+		projects: { present: true, stat: projectsStat(projects?.length ?? 0) },
+		tools: {
+			present: stack.tools.length > 0,
+			stat: toolsStat(stack.tools.length, stack.fixedTotal?.amount ?? 0),
+		},
+		workflow: {
+			present: workflowReading != null,
+			stat: workflowNavStat(workflowReading),
+		},
+		guide: { present: true, stat: guideStat(stack.description) },
+	});
+	const numberOf = (key: Parameters<typeof sectionIndex>[1]) =>
+		sectionIndex(sections, key);
+
 	return (
 		<EditorProvider>
 			<JsonLd
@@ -333,25 +394,37 @@ function StackDetailsPage() {
 						isOwner={upvoteStatus?.isOwner ?? false}
 					/>
 
-					{/* The journey (#40, reordered by #58): Actual Usage 01 → Projects 02
-					    → Tools 03 → Workflow 04. What ran now literally comes first. */}
+					{/* The nav block. It sits under the hero and above 01, and past it
+					    the same links dock as a fixed rail under the site header. */}
+					<StackPageNav
+						sections={sections}
+						identity={{
+							name: stack.name,
+							priceText: costText,
+							upvotes: upvoteStatus?.count ?? 0,
+						}}
+					/>
+
+					{/* The journey (#40, reordered by #58, workflow placed by #217):
+					    Actual Usage 01 → Projects 02 → Tools 03 → Workflow 04 →
+					    Guide 05. What ran now literally comes first. */}
 					<MeasuredSection
-						index={1}
+						index={numberOf("usage") ?? 1}
 						slug={stack.slug}
 						stackId={stack._id}
 						isOwner={upvoteStatus?.isOwner ?? false}
 					/>
 
 					<ProjectsSection
-						index={2}
+						index={numberOf("projects") ?? 2}
+						id={SECTION_ANCHORS.projects}
 						stackId={stack._id}
 						isOwner={upvoteStatus?.isOwner ?? false}
 					/>
 
-					{/* biome-ignore lint/correctness/useUniqueElementIds: stable single-instance scroll anchor for the hero tile jump target */}
 					<ToolsSection
-						index={3}
-						id="section-tools"
+						index={numberOf("tools") ?? 3}
+						id={SECTION_ANCHORS.tools}
 						highlighted={highlightedSection === "tools"}
 						tools={stack.tools}
 						models={stack.models}
@@ -364,8 +437,21 @@ function StackDetailsPage() {
 						fixedTotal={stack.fixedTotal}
 						onBundleClick={scrollToBundle}
 					/>
+
+					{/* Section 04 renders itself away when the stack has no reading, or
+					    when the owner never gave `publishWorkflow`. `numberOf` returns
+					    null in exactly that case, and the page renders no 04 either. */}
+					{numberOf("workflow") !== null && (
+						<WorkflowSection
+							index={numberOf("workflow") ?? 4}
+							slug={stack.slug}
+							stackId={stack._id}
+						/>
+					)}
+
 					<GuideSection
-						index={4}
+						index={numberOf("guide") ?? 4}
+						id={SECTION_ANCHORS.guide}
 						description={stack.description}
 						isOwner={upvoteStatus?.isOwner ?? false}
 						slug={stack.slug}


### PR DESCRIPTION
Wayfinder ticket [#217](https://github.com/alp82/aistack/issues/217), map [#200](https://github.com/alp82/aistack/issues/200). Spec: `docs/specs/workflow-surface.md`.

## What ships

- **Workflow at 04.** The measured section from #215 is now on the stack page, between Tools and Guide.
- **The order is locked, the numbers are not.** Tools renders only with tools, Workflow only with a stored, published reading. A section's number is its position among the sections that render, so a stack with no reading closes on Guide 04 rather than printing a gap at 04. `buildPageSections` assigns it once, and both the nav and the sections read it from there.
- **The writeup section is renamed.** It was titled Workflow under `// GUIDE`; it is now Guide under `// writeup`, resolving the collision #193 called out.
- **The stat-row nav block** under the hero: one row per rendered section, showing the number, the title, and a headline figure the section already prints. A row is a link and opens nothing.
- **The fixed rail** docks under the site header once the block scrolls away, carrying the stack name, price and upvotes on its left, with a scroll spy marking the section in view.

## Two things worth a second look

**The rail reads a position, it does not watch for a crossing.** The first build used an `IntersectionObserver` on the nav block, like the prototype. That reports a *change* in overlap, and on a short viewport the block never overlaps: it starts below the fold, and a tap on a nav row jumps the reader straight past it to a section further down. The observer saw "not intersecting" on both sides of that jump, reported nothing, and left the rail undocked for the rest of the page. Verified in a real browser, and locked by a test.

**The workflow reading is prefetched in the loader** because it decides the numbering. Resolving it after hydration renumbered Guide from 04 to 05 under the reader.

## Verification

- Full suite: 159 files, 2451 passed.
- Rendered against the dev server in headless Chrome: anchors resolve, the rail docks and undocks, the scroll spy tracks, and a nav jump lands the section heading clear of both the header and the rail.
- A live five-section render waits for a stack that has a workflow reading. Neither the local database nor prod has one yet, and the CLI release that produces one is [#221](https://github.com/alp82/aistack/issues/221). The five-section numbering is covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fu2UYXr1VCkMiJ4LrABeyz