### PR TITLE
Scope the Git reading's commit set and put its cells on one clock (alp82/aistack#281)

### DIFF
--- a/convex/measured.test.ts
+++ b/convex/measured.test.ts
@@ -680,7 +680,7 @@ describe('publishForToken - the destination comes from the token', () => {
       testFileCommits: 5,
       changedLinesByExtension: [{ extension: '.ts', changedLines: 500 }],
       withheldExtensionLines: 20,
-      weekdayHourCells: [{ weekday: 5, hour: 23, commits: 3 }],
+      weekdayHourCells: [{ weekdayUtc: 5, hourUtc: 23, commits: 3 }],
     },
     metrics: [
       {

--- a/convex/measured.ts
+++ b/convex/measured.ts
@@ -321,6 +321,9 @@ export function checkWorkflowSection(
 
   requireName(section.git.testFileRuleVersion, 'workflow.git.testFileRuleVersion')
   requireName(section.git.fileTypeRuleVersion, 'workflow.git.fileTypeRuleVersion')
+  if (section.git.commitSetRuleVersion !== undefined) {
+    requireName(section.git.commitSetRuleVersion, 'workflow.git.commitSetRuleVersion')
+  }
   requireSize(
     section.git.changedLinesPerCommit.length,
     WORKFLOW_LIMITS.commits,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -320,6 +320,8 @@ const HarnessWorkflow = v.object({
 const GitWorkflow = v.object({
   testFileRuleVersion: v.string(),
   fileTypeRuleVersion: v.string(),
+  /** Optional only for a reading a pre-commit-set/v1 CLI publishes. */
+  commitSetRuleVersion: v.optional(v.string()),
   totalCommits: v.number(),
   lateNightCommits: v.number(),
   additions: v.number(),
@@ -332,8 +334,9 @@ const GitWorkflow = v.object({
     v.object({ extension: v.string(), changedLines: v.number() })
   ),
   withheldExtensionLines: v.number(),
+  /** UTC cells, like the harness activity cells; the page shifts them. */
   weekdayHourCells: v.array(
-    v.object({ weekday: v.number(), hour: v.number(), commits: v.number() })
+    v.object({ weekdayUtc: v.number(), hourUtc: v.number(), commits: v.number() })
   ),
 })
 

--- a/convex/workflow.test.ts
+++ b/convex/workflow.test.ts
@@ -128,7 +128,7 @@ function section(over: Partial<Section> = {}): Section {
       testFileCommits: 4,
       changedLinesByExtension: [{ extension: '.ts', changedLines: 900 }],
       withheldExtensionLines: 100,
-      weekdayHourCells: [{ weekday: 1, hour: 23, commits: 9 }],
+      weekdayHourCells: [{ weekdayUtc: 1, hourUtc: 23, commits: 9 }],
     },
     metrics: [
       {

--- a/packages/cli/src/harness/shared/payload.test.ts
+++ b/packages/cli/src/harness/shared/payload.test.ts
@@ -451,6 +451,7 @@ describe("the workflow section on the wire (#213)", () => {
 		],
 		git: {
 			testFileRuleVersion: "test-files/v2",
+			commitSetRuleVersion: "commit-set/v1",
 			fileTypeRuleVersion: "file-types/v2",
 			totalCommits: 12,
 			lateNightCommits: 3,
@@ -460,7 +461,7 @@ describe("the workflow section on the wire (#213)", () => {
 			testFileCommits: 5,
 			changedLinesByExtension: [{ extension: ".ts", changedLines: 500 }],
 			withheldExtensionLines: 20,
-			weekdayHourCells: [{ weekday: 5, hour: 23, commits: 3 }],
+			weekdayHourCells: [{ weekdayUtc: 5, hourUtc: 23, commits: 3 }],
 		},
 		metricInputs: [
 			{

--- a/packages/cli/src/sync/summary.test.ts
+++ b/packages/cli/src/sync/summary.test.ts
@@ -136,6 +136,7 @@ function workflow(over: Partial<PayloadWorkflow> = {}): PayloadWorkflow {
 		],
 		git: {
 			testFileRuleVersion: "test-files/v2",
+			commitSetRuleVersion: "commit-set/v1",
 			fileTypeRuleVersion: "file-types/v2",
 			totalCommits: 214,
 			lateNightCommits: 30,
@@ -145,7 +146,7 @@ function workflow(over: Partial<PayloadWorkflow> = {}): PayloadWorkflow {
 			testFileCommits: 5,
 			changedLinesByExtension: [{ extension: ".ts", changedLines: 500 }],
 			withheldExtensionLines: 20,
-			weekdayHourCells: [{ weekday: 5, hour: 23, commits: 3 }],
+			weekdayHourCells: [{ weekdayUtc: 5, hourUtc: 23, commits: 3 }],
 		},
 		metrics: [
 			{

--- a/packages/cli/src/workflow/extract.test.ts
+++ b/packages/cli/src/workflow/extract.test.ts
@@ -32,6 +32,7 @@ describe("buildWorkflowExtraction", () => {
 
 		const git: GitWorkflowResult = {
 			testFileRuleVersion: "test-files/v2",
+			commitSetRuleVersion: "commit-set/v1",
 			fileTypeRuleVersion: "file-types/v2",
 			totalCommits: 4,
 			lateNightCommits: 2,
@@ -41,7 +42,7 @@ describe("buildWorkflowExtraction", () => {
 			testFileCommits: 2,
 			changedLinesByExtension: [{ extension: ".ts", changedLines: 40 }],
 			withheldExtensionLines: 0,
-			weekdayHourCells: [{ weekday: 1, hour: 23, commits: 4 }],
+			weekdayHourCells: [{ weekdayUtc: 1, hourUtc: 23, commits: 4 }],
 		};
 
 		const extraction = buildWorkflowExtraction(
@@ -81,6 +82,7 @@ describe("buildWorkflowExtraction", () => {
 			[{ aggregate: reducer.finish(), local }],
 			{
 				testFileRuleVersion: "test-files/v2",
+				commitSetRuleVersion: "commit-set/v1",
 				fileTypeRuleVersion: "file-types/v2",
 				totalCommits: 0,
 				lateNightCommits: 0,
@@ -144,6 +146,7 @@ describe("buildWorkflowExtraction", () => {
 			[{ aggregate: reducer.finish(), local }],
 			{
 				testFileRuleVersion: "test-files/v2",
+				commitSetRuleVersion: "commit-set/v1",
 				fileTypeRuleVersion: "file-types/v2",
 				totalCommits: 0,
 				lateNightCommits: 0,

--- a/packages/cli/src/workflow/extract.ts
+++ b/packages/cli/src/workflow/extract.ts
@@ -53,19 +53,18 @@ export type ExtractLocalWorkflowOptions = {
 export function extractLocalWorkflow(
 	options: ExtractLocalWorkflowOptions,
 ): WorkflowExtraction {
+	const utcOffsetMinutes =
+		options.utcOffsetMinutes ?? machineUtcOffsetMinutes();
 	const git = extractGitWorkflow({
 		workingDirectories: options.harnesses.flatMap(({ local }) => [
 			...local.projectWorkspaces,
 		]),
 		fromMs: options.fromMs,
 		toMs: options.toMs,
+		utcOffsetMinutes,
 		...(options.run ? { run: options.run } : {}),
 	});
-	return buildWorkflowExtraction(
-		options.harnesses,
-		git,
-		options.utcOffsetMinutes ?? machineUtcOffsetMinutes(),
-	);
+	return buildWorkflowExtraction(options.harnesses, git, utcOffsetMinutes);
 }
 
 /**

--- a/packages/cli/src/workflow/git.test.ts
+++ b/packages/cli/src/workflow/git.test.ts
@@ -22,6 +22,13 @@ describe("extractGitWorkflow", () => {
 				"5\t7\tsrc/index.js\n2\t0\ttests/helper\n",
 			),
 			record("cccc", "2026-09-01T01:00:00+00:00", "99\t0\toutside.ts\n"),
+			// Every path a machine owns: the commit leaves the reading entirely,
+			// rather than counting as a commit that changed nothing (commit-set/v1).
+			record(
+				"dddd",
+				"2026-08-05T10:00:00+00:00",
+				"800\t0\tnode_modules/left-pad/index.js\n1\t1\tpnpm-lock.yaml\n",
+			),
 		].join("");
 		const run: GitWorkflowRunner = (cwd, args) => {
 			if (args[0] === "rev-parse") {
@@ -31,6 +38,7 @@ describe("extractGitWorkflow", () => {
 			}
 			expect(args).not.toContain("--no-renames");
 			expect(args).toContain("-z");
+			expect(args).toContain("--no-merges");
 			expect(args.some((arg) => arg.startsWith("--since="))).toBe(false);
 			expect(args.some((arg) => arg.startsWith("--until="))).toBe(false);
 			return cwd === "/work/repo" || cwd === "/copy/repo" ? history : null;
@@ -45,12 +53,15 @@ describe("extractGitWorkflow", () => {
 			],
 			fromMs: Date.parse("2026-08-01T00:00:00Z"),
 			toMs: Date.parse("2026-08-31T23:59:59Z"),
+			// The machine sits five hours west of UTC, like both commit stamps.
+			utcOffsetMinutes: -300,
 			run,
 		});
 
 		expect(result).toEqual({
 			testFileRuleVersion: "test-files/v2",
 			fileTypeRuleVersion: "file-types/v2",
+			commitSetRuleVersion: "commit-set/v1",
 			totalCommits: 2,
 			lateNightCommits: 2,
 			additions: 20,
@@ -64,9 +75,12 @@ describe("extractGitWorkflow", () => {
 			// `tests/helper` has no extension, so its 2 lines are withheld rather
 			// than ranked: a file with no extension is not a coding language.
 			withheldExtensionLines: 2,
+			// Cells travel in UTC: 23:30-05:00 is Tuesday 04:30Z, and 02:15-05:00 is
+			// Tuesday 07:15Z. The late-night count reads the same cells through the
+			// machine's own offset, so the grid and the count cannot disagree.
 			weekdayHourCells: [
-				{ weekday: 1, hour: 23, commits: 1 },
-				{ weekday: 2, hour: 2, commits: 1 },
+				{ weekdayUtc: 2, hourUtc: 4, commits: 1 },
+				{ weekdayUtc: 2, hourUtc: 7, commits: 1 },
 			],
 		});
 		expect(JSON.stringify(result)).not.toContain("/work/");
@@ -86,6 +100,7 @@ describe("extractGitWorkflow", () => {
 			workingDirectories: ["/work/repo"],
 			fromMs: Date.parse("2026-08-01T00:00:00Z"),
 			toMs: Date.parse("2026-08-31T23:59:59Z"),
+			utcOffsetMinutes: 0,
 			run,
 		});
 
@@ -109,6 +124,7 @@ describe("extractGitWorkflow", () => {
 			workingDirectories: ["/work/repo"],
 			fromMs: Date.parse("2026-08-01T00:00:00Z"),
 			toMs: Date.parse("2026-08-31T23:59:59Z"),
+			utcOffsetMinutes: 0,
 			run,
 		});
 
@@ -117,5 +133,28 @@ describe("extractGitWorkflow", () => {
 		]);
 		expect(result.withheldExtensionLines).toBe(5);
 		expect(JSON.stringify(result)).not.toContain("customer-name");
+	});
+
+	it("counts late-night commits on the machine's clock, not each author's", () => {
+		// 15:00Z. A machine at +10:00 reads it as 01:00, inside the late-night
+		// window; a machine at +00:00 reads it as 15:00, outside it.
+		const run: GitWorkflowRunner = (_cwd, args) =>
+			args[0] === "rev-parse"
+				? "/work/repo\n"
+				: record("aaaa", "2026-08-03T17:00:00+02:00", "1\t0\tsrc/a.ts\n");
+		const at = (utcOffsetMinutes: number) =>
+			extractGitWorkflow({
+				workingDirectories: ["/work/repo"],
+				fromMs: Date.parse("2026-08-01T00:00:00Z"),
+				toMs: Date.parse("2026-08-31T23:59:59Z"),
+				utcOffsetMinutes,
+				run,
+			});
+
+		expect(at(600).lateNightCommits).toBe(1);
+		expect(at(0).lateNightCommits).toBe(0);
+		expect(at(0).weekdayHourCells).toEqual([
+			{ weekdayUtc: 1, hourUtc: 15, commits: 1 },
+		]);
 	});
 });

--- a/packages/cli/src/workflow/git.ts
+++ b/packages/cli/src/workflow/git.ts
@@ -9,6 +9,13 @@ import path from "node:path";
  */
 export const TEST_FILE_RULE_VERSION = "test-files/v2";
 export const FILE_TYPE_RULE_VERSION = "file-types/v2";
+/**
+ * Which commits count at all (#279). A merge commit and a commit whose every
+ * path is machine-owned leave the reading. Without this id a reading synced
+ * before the rule and one synced after are indistinguishable on the wire while
+ * disagreeing about which commits exist.
+ */
+export const COMMIT_SET_RULE_VERSION = "commit-set/v1";
 
 export type GitWorkflowRunner = (
 	cwd: string,
@@ -18,6 +25,7 @@ export type GitWorkflowRunner = (
 export type GitWorkflowResult = {
 	testFileRuleVersion: typeof TEST_FILE_RULE_VERSION;
 	fileTypeRuleVersion: typeof FILE_TYPE_RULE_VERSION;
+	commitSetRuleVersion: typeof COMMIT_SET_RULE_VERSION;
 	totalCommits: number;
 	lateNightCommits: number;
 	additions: number;
@@ -30,9 +38,9 @@ export type GitWorkflowResult = {
 	}>;
 	withheldExtensionLines: number;
 	weekdayHourCells: Array<{
-		/** Sunday is 0 and Saturday is 6, in the commit author's local date. */
-		weekday: number;
-		hour: number;
+		/** Sunday is 0 and Saturday is 6, on the UTC clock like the harness cells. */
+		weekdayUtc: number;
+		hourUtc: number;
 		commits: number;
 	}>;
 };
@@ -42,6 +50,12 @@ export type ExtractGitWorkflowOptions = {
 	workingDirectories: Iterable<string>;
 	fromMs: number;
 	toMs: number;
+	/**
+	 * This machine's offset from UTC, in minutes east. Cells ship in UTC, and the
+	 * late-night count reads those same cells through this offset, so the count
+	 * and the grid always agree. Every commit uses the one offset, not its own.
+	 */
+	utcOffsetMinutes: number;
 	run?: GitWorkflowRunner;
 };
 
@@ -61,6 +75,7 @@ const defaultRunner: GitWorkflowRunner = (cwd, args) => {
 const emptyResult = (): GitWorkflowResult => ({
 	testFileRuleVersion: TEST_FILE_RULE_VERSION,
 	fileTypeRuleVersion: FILE_TYPE_RULE_VERSION,
+	commitSetRuleVersion: COMMIT_SET_RULE_VERSION,
 	totalCommits: 0,
 	lateNightCommits: 0,
 	additions: 0,
@@ -71,9 +86,6 @@ const emptyResult = (): GitWorkflowResult => ({
 	withheldExtensionLines: 0,
 	weekdayHourCells: [],
 });
-
-const AUTHOR_LOCAL_RE =
-	/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
 
 /**
  * The names this rule is willing to print. A path with no extension is absent
@@ -225,19 +237,21 @@ function isTestFile(file: string): boolean {
 	return /(?:^|[._-])(test|spec)(?:[._-]|$)/.test(basename);
 }
 
-function localCell(
-	authoredAt: string,
-): { weekday: number; hour: number } | null {
-	const match = AUTHOR_LOCAL_RE.exec(authoredAt);
-	if (!match) return null;
-	const year = Number(match[1]);
-	const month = Number(match[2]);
-	const day = Number(match[3]);
-	const hour = Number(match[4]);
-	return {
-		weekday: new Date(Date.UTC(year, month - 1, day)).getUTCDay(),
-		hour,
-	};
+function utcCell(authoredMs: number): { weekdayUtc: number; hourUtc: number } {
+	const at = new Date(authoredMs);
+	return { weekdayUtc: at.getUTCDay(), hourUtc: at.getUTCHours() };
+}
+
+/** The hour on the machine's clock for a UTC cell. */
+function localHour(hourUtc: number, utcOffsetMinutes: number): number {
+	return (
+		((((hourUtc * 60 + utcOffsetMinutes) % (24 * 60)) + 24 * 60) % (24 * 60)) /
+		60
+	);
+}
+
+function isLateNight(hour: number): boolean {
+	return hour >= 23 || hour < 3;
 }
 
 /**
@@ -262,6 +276,7 @@ export function extractGitWorkflow(
 		const history = run(root, [
 			"log",
 			"--all",
+			"--no-merges",
 			`--format=%x00${COMMIT_MARKER}%x00%H%x00%aI%x00`,
 			"--numstat",
 			"-z",
@@ -270,14 +285,31 @@ export function extractGitWorkflow(
 
 		type CurrentCommit = {
 			included: boolean;
+			cell: { weekdayUtc: number; hourUtc: number };
+			/** True once one path a person could have written appears. */
+			authored: boolean;
+			additions: number;
+			removals: number;
 			changedLines: number;
 			touchesTest: boolean;
 		};
 		let current: CurrentCommit | undefined;
+		// A commit counts only once its records are read: one with no authored
+		// path leaves the reading entirely, rather than surviving as a commit
+		// that changed nothing (commit-set/v1).
 		const finishCommit = (): void => {
-			if (!current?.included) return;
+			if (!current?.included || !current.authored) return;
+			result.totalCommits++;
+			result.additions += current.additions;
+			result.removals += current.removals;
 			result.changedLinesPerCommit.push(current.changedLines);
 			if (current.touchesTest) result.testFileCommits++;
+			const { weekdayUtc, hourUtc } = current.cell;
+			if (isLateNight(localHour(hourUtc, options.utcOffsetMinutes))) {
+				result.lateNightCommits++;
+			}
+			const cellKey = `${weekdayUtc}:${hourUtc}`;
+			cells.set(cellKey, (cells.get(cellKey) ?? 0) + 1);
 		};
 		const fields = history.split("\u0000");
 		for (let fieldIndex = 0; fieldIndex < fields.length; fieldIndex++) {
@@ -287,20 +319,21 @@ export function extractGitWorkflow(
 				const hash = fields[++fieldIndex] ?? "";
 				const authoredAt = fields[++fieldIndex] ?? "";
 				const authoredMs = Date.parse(authoredAt);
-				const cell = localCell(authoredAt);
 				const included =
-					cell !== null &&
 					Number.isFinite(authoredMs) &&
 					authoredMs >= options.fromMs &&
 					authoredMs <= options.toMs &&
 					!seenCommits.has(hash);
-				current = { included, changedLines: 0, touchesTest: false };
-				if (!included || !cell) continue;
-				seenCommits.add(hash);
-				result.totalCommits++;
-				if (cell.hour >= 23 || cell.hour < 3) result.lateNightCommits++;
-				const cellKey = `${cell.weekday}:${cell.hour}`;
-				cells.set(cellKey, (cells.get(cellKey) ?? 0) + 1);
+				current = {
+					included,
+					cell: utcCell(included ? authoredMs : 0),
+					authored: false,
+					additions: 0,
+					removals: 0,
+					changedLines: 0,
+					touchesTest: false,
+				};
+				if (included) seenCommits.add(hash);
 				continue;
 			}
 
@@ -313,9 +346,10 @@ export function extractGitWorkflow(
 			}
 			if (!current?.included) continue;
 			if (isUnauthoredPath(file)) continue;
+			current.authored = true;
 			const fileChangedLines = stat.additions + stat.removals;
-			result.additions += stat.additions;
-			result.removals += stat.removals;
+			current.additions += stat.additions;
+			current.removals += stat.removals;
 			current.changedLines += fileChangedLines;
 			if (isTestFile(file)) current.touchesTest = true;
 			if (fileChangedLines <= 0) continue;
@@ -336,10 +370,10 @@ export function extractGitWorkflow(
 		.sort((a, b) => a.extension.localeCompare(b.extension));
 	result.weekdayHourCells = [...cells]
 		.map(([key, commits]) => {
-			const [weekday, hour] = key.split(":").map(Number);
-			return { weekday: weekday ?? 0, hour: hour ?? 0, commits };
+			const [weekdayUtc, hourUtc] = key.split(":").map(Number);
+			return { weekdayUtc: weekdayUtc ?? 0, hourUtc: hourUtc ?? 0, commits };
 		})
-		.sort((a, b) => a.weekday - b.weekday || a.hour - b.hour);
+		.sort((a, b) => a.weekdayUtc - b.weekdayUtc || a.hourUtc - b.hourUtc);
 
 	return result;
 }

--- a/packages/cli/src/workflow/gitReal.test.ts
+++ b/packages/cli/src/workflow/gitReal.test.ts
@@ -57,6 +57,7 @@ const read = () =>
 		workingDirectories: [root],
 		fromMs: Date.parse("2026-08-01T00:00:00Z"),
 		toMs: Date.parse("2026-08-31T23:59:59Z"),
+		utcOffsetMinutes: 120,
 	});
 
 describe("extractGitWorkflow over real Git output", () => {
@@ -149,5 +150,33 @@ describe("extractGitWorkflow over real Git output", () => {
 		expect(byExtension[".mts"]).toBe(4);
 		// Unchanged from the previous commit: none of the three was withheld.
 		expect(result.withheldExtensionLines).toBe(12);
+	});
+
+	it("leaves a merge commit out and keeps a pure rename in", () => {
+		const before = read();
+
+		git(root, ["checkout", "-b", "feature", "--quiet"]);
+		write(root, "src/feature.ts", lines(7));
+		git(root, ["add", "-A"]);
+		git(root, ["commit", "-m", "feature"]);
+		git(root, ["checkout", "main", "--quiet"]);
+		git(root, ["merge", "--no-ff", "--no-edit", "feature"]);
+		git(root, ["mv", "src/app.ts", "src/renamed.ts"]);
+		git(root, ["commit", "-m", "rename only"]);
+
+		const result = read();
+
+		// The feature commit and the rename count. The merge does not: it carries
+		// no authored work, so it is neither a commit nor a zero-line dot.
+		expect(result.totalCommits).toBe(before.totalCommits + 2);
+		expect([...result.changedLinesPerCommit].sort()).toEqual(
+			[...before.changedLinesPerCommit, 7, 0].sort(),
+		);
+		expect(result.additions).toBe(before.additions + 7);
+		expect(result.commitSetRuleVersion).toBe("commit-set/v1");
+		// 14:00+02:00 is 12:00Z. The cell ships in UTC.
+		expect(result.weekdayHourCells.every((cell) => cell.hourUtc === 12)).toBe(
+			true,
+		);
 	});
 });

--- a/packages/workflow-rules/src/reading.ts
+++ b/packages/workflow-rules/src/reading.ts
@@ -56,6 +56,8 @@ export type WorkflowHarnessReading = {
 export type WorkflowGitReading = {
 	testFileRuleVersion: string;
 	fileTypeRuleVersion: string;
+	/** Absent on a reading synced before commit-set/v1 shipped. */
+	commitSetRuleVersion?: string;
 	totalCommits: number;
 	lateNightCommits: number;
 	additions: number;
@@ -67,9 +69,10 @@ export type WorkflowGitReading = {
 		changedLines: number;
 	}[];
 	withheldExtensionLines: number;
+	/** UTC, like the harness activity cells beside them. */
 	weekdayHourCells: readonly {
-		weekday: number;
-		hour: number;
+		weekdayUtc: number;
+		hourUtc: number;
 		commits: number;
 	}[];
 };

--- a/packages/workflow-rules/src/workflowRows.test.ts
+++ b/packages/workflow-rules/src/workflowRows.test.ts
@@ -85,7 +85,7 @@ function reading(over: Partial<WorkflowReading> = {}): WorkflowReading {
 				{ extension: ".css", changedLines: 200 },
 			],
 			withheldExtensionLines: 100,
-			weekdayHourCells: [{ weekday: 1, hour: 23, commits: 9 }],
+			weekdayHourCells: [{ weekdayUtc: 1, hourUtc: 23, commits: 9 }],
 		},
 		metrics: [
 			{

--- a/src/__tests__/workflow-wire-contract.test.ts
+++ b/src/__tests__/workflow-wire-contract.test.ts
@@ -127,6 +127,7 @@ function extraction(): WorkflowExtraction {
 		],
 		git: {
 			testFileRuleVersion: "test-files/v2",
+			commitSetRuleVersion: "commit-set/v1",
 			fileTypeRuleVersion: "file-types/v2",
 			totalCommits: 12,
 			lateNightCommits: 3,
@@ -136,7 +137,7 @@ function extraction(): WorkflowExtraction {
 			testFileCommits: 5,
 			changedLinesByExtension: [{ extension: ".ts", changedLines: 500 }],
 			withheldExtensionLines: 20,
-			weekdayHourCells: [{ weekday: 5, hour: 23, commits: 3 }],
+			weekdayHourCells: [{ weekdayUtc: 5, hourUtc: 23, commits: 3 }],
 		},
 		metricInputs: [
 			{

--- a/src/features/workflow/__tests__/components.test.tsx
+++ b/src/features/workflow/__tests__/components.test.tsx
@@ -66,6 +66,13 @@ describe("the git ledger", () => {
 		expect(screen.getByText("+94.8k")).toBeTruthy();
 	});
 
+	it("names the commit-set rule beside the test-file rule", () => {
+		show("git-ledger");
+		expect(
+			screen.getByText(/test-file-rules\/v1 · commit-set\/v1/),
+		).toBeTruthy();
+	});
+
 	it("draws one dot per commit on a log scale", () => {
 		const { container } = show("git-ledger");
 		const dots = container.querySelectorAll("[title$='changed lines']");
@@ -108,6 +115,30 @@ describe("the week and time heatmap", () => {
 		expect(
 			screen.getByText(/this reading carries no machine offset/),
 		).toBeTruthy();
+	});
+
+	it("switches the grid to commits without moving the row's ranked figure", () => {
+		show("activity-heatmap");
+		// Sessions first: all 160 events sit in two hours, so the body figure reads
+		// 100% in the three busiest hours.
+		const figure = (text: RegExp) =>
+			screen.queryByText(
+				(_content, node) =>
+					node?.tagName === "P" && text.test(node.textContent ?? ""),
+			);
+		expect(
+			figure(/^100% of events fall in the three busiest hours$/),
+		).toBeTruthy();
+		fireEvent.click(screen.getByRole("button", { name: "commits" }));
+		// The commit series shifts by the same offset: 21:00 UTC is Sun 23:00.
+		expect(
+			screen.getByRole("button", { name: "Sun 23:00, 9 commits" }),
+		).toBeTruthy();
+		// 9 + 1 + 1 of 12 commits sit in the three busiest hours.
+		expect(
+			figure(/^92% of commits fall in the three busiest hours$/),
+		).toBeTruthy();
+		expect(figure(/of events fall/)).toBeNull();
 	});
 
 	it("opens one cell's recorded events on a tap", () => {

--- a/src/features/workflow/__tests__/fixture.ts
+++ b/src/features/workflow/__tests__/fixture.ts
@@ -257,6 +257,7 @@ export function view(over: Partial<WorkflowView> = {}): WorkflowView {
 			git: {
 				testFileRuleVersion: "test-file-rules/v1",
 				fileTypeRuleVersion: "file-type-rules/v1",
+				commitSetRuleVersion: "commit-set/v1",
 				totalCommits: 120,
 				lateNightCommits: 50,
 				additions: 94_800,
@@ -268,7 +269,12 @@ export function view(over: Partial<WorkflowView> = {}): WorkflowView {
 					{ extension: "css", changedLines: 12_000 },
 				],
 				withheldExtensionLines: 2_000,
-				weekdayHourCells: [],
+				weekdayHourCells: [
+					{ weekdayUtc: 0, hourUtc: 21, commits: 9 },
+					{ weekdayUtc: 3, hourUtc: 9, commits: 1 },
+					{ weekdayUtc: 4, hourUtc: 10, commits: 1 },
+					{ weekdayUtc: 5, hourUtc: 11, commits: 1 },
+				],
 			},
 			metrics: [],
 		},

--- a/src/features/workflow/components.tsx
+++ b/src/features/workflow/components.tsx
@@ -429,6 +429,7 @@ function GitLedger({ view }: { view: WorkflowView }) {
 			<BodyFootnote>
 				{git.testFileCommits.toLocaleString("en-US")} commits touch a test file
 				· {git.testFileRuleVersion}
+				{git.commitSetRuleVersion ? ` · ${git.commitSetRuleVersion}` : ""}
 				{view.trimmed?.commitStrip
 					? " · the per-commit strip was dropped to fit the stored reading"
 					: ""}
@@ -519,31 +520,91 @@ function CodingLanguages({ view }: { view: WorkflowView }) {
 const HOURS = Array.from({ length: 24 }, (_, hour) => hour);
 const WEEKDAY_ROWS = [1, 2, 3, 4, 5, 6, 0];
 
+type HeatSeries = "sessions" | "commits";
+
+/**
+ * ONE component with ONE band (#279). The commit grid is a second series on
+ * the same heatmap, not a second row: a near-identical row would compete for
+ * placement against this one. The row's RANKED figure is the session share and
+ * never follows the toggle, because the page ranks nothing and a reader's
+ * switch must not move a row. The body figure under the grid recomputes for
+ * whichever series is shown, so the reader always has a number for what they
+ * are looking at.
+ */
 function ActivityHeatmap({ view }: { view: WorkflowView }) {
 	const [selected, setSelected] = useState<string | null>(null);
+	const [series, setSeries] = useState<HeatSeries>("sessions");
 	const offset = view.utcOffsetMinutes;
 	const cells = new Map<string, number>();
-	for (const harness of view.section.harnesses) {
-		for (const cell of harness.activity) {
-			// SHIFTED INTO THE OWNER'S LOCAL TIME, for the reason the lead's rhythm
-			// clause is: the reader's own clock would put a stranger's habit at the
-			// wrong hour. Without an offset the grid stays in UTC and says so.
-			const shifted = shift(cell.weekdayUtc, cell.hourUtc, offset ?? 0);
-			const key = `${shifted.weekday}-${shifted.hour}`;
-			cells.set(key, (cells.get(key) ?? 0) + cell.events);
+	const add = (weekdayUtc: number, hourUtc: number, count: number): void => {
+		// SHIFTED INTO THE OWNER'S LOCAL TIME, for the reason the lead's rhythm
+		// clause is: the reader's own clock would put a stranger's habit at the
+		// wrong hour. Without an offset the grid stays in UTC and says so. Both
+		// series shift by the same offset, so a commit and a session at the same
+		// real moment land in the same cell.
+		const shifted = shift(weekdayUtc, hourUtc, offset ?? 0);
+		const key = `${shifted.weekday}-${shifted.hour}`;
+		cells.set(key, (cells.get(key) ?? 0) + count);
+	};
+	if (series === "sessions") {
+		for (const harness of view.section.harnesses) {
+			for (const cell of harness.activity) {
+				add(cell.weekdayUtc, cell.hourUtc, cell.events);
+			}
+		}
+	} else {
+		for (const cell of view.section.git.weekdayHourCells) {
+			add(cell.weekdayUtc, cell.hourUtc, cell.commits);
 		}
 	}
+	const hasCommits = view.section.git.weekdayHourCells.length > 0;
+	const unit = series === "sessions" ? "events" : "commits";
+	const busiest = cells.size > 0 ? Math.max(...cells.values()) : 0;
+	const chosen = selected === null ? null : (cells.get(selected) ?? 0);
+
+	const toggle = hasCommits ? (
+		<div className="mb-2 flex gap-1">
+			{(["sessions", "commits"] as const).map((option) => (
+				<button
+					key={option}
+					type="button"
+					onClick={() => {
+						setSeries(option);
+						setSelected(null);
+					}}
+					aria-pressed={series === option}
+					className={cn(
+						MONO_LABEL,
+						"border px-2 py-0.5",
+						series === option
+							? "border-accent-lime text-fg-primary"
+							: "border-border text-fg-muted",
+					)}
+				>
+					{option}
+				</button>
+			))}
+		</div>
+	) : null;
+
 	if (cells.size === 0) {
 		return (
-			<EmptyBody>No harness on this machine records an event clock.</EmptyBody>
+			<div>
+				<BodyKicker>{BODY_KICKERS["activity-heatmap"]}</BodyKicker>
+				{toggle}
+				<EmptyBody>
+					{series === "sessions"
+						? "No harness on this machine records an event clock."
+						: "No commit in this window sits in a repository a session touched."}
+				</EmptyBody>
+			</div>
 		);
 	}
-	const busiest = Math.max(...cells.values());
-	const chosen = selected === null ? null : (cells.get(selected) ?? 0);
 
 	return (
 		<div>
 			<BodyKicker>{BODY_KICKERS["activity-heatmap"]}</BodyKicker>
+			{toggle}
 			<div className="overflow-x-auto">
 				<div className="min-w-[34rem]">
 					{WEEKDAY_ROWS.map((weekday) => (
@@ -553,7 +614,7 @@ function ActivityHeatmap({ view }: { view: WorkflowView }) {
 							</span>
 							{HOURS.map((hour) => {
 								const key = `${weekday}-${hour}`;
-								const events = cells.get(key) ?? 0;
+								const count = cells.get(key) ?? 0;
 								return (
 									<button
 										key={key}
@@ -561,14 +622,14 @@ function ActivityHeatmap({ view }: { view: WorkflowView }) {
 										onClick={() =>
 											setSelected((held) => (held === key ? null : key))
 										}
-										aria-label={`${weekdayLabel(weekday)} ${hourLabel(hour)}, ${events} events`}
+										aria-label={`${weekdayLabel(weekday)} ${hourLabel(hour)}, ${count} ${unit}`}
 										aria-pressed={selected === key}
 										className={cn(
 											"h-4 flex-1",
 											selected === key &&
 												"outline outline-1 outline-accent-lime",
 										)}
-										style={{ background: heatPaint(events, busiest) }}
+										style={{ background: heatPaint(count, busiest) }}
 									/>
 								);
 							})}
@@ -589,9 +650,17 @@ function ActivityHeatmap({ view }: { view: WorkflowView }) {
 			</div>
 
 			<p className="mt-3 font-mono text-xs text-fg-secondary">
+				<b className="text-fg-primary">
+					{fmtPercent(busiestHoursShare(cells))}
+				</b>{" "}
+				of {unit} fall in the three busiest hours
+			</p>
+
+			<p className="mt-1 font-mono text-xs text-fg-secondary">
 				{selected === null ? (
 					<span className="text-fg-muted">
-						Select a cell for its recorded events.
+						Select a cell for its{" "}
+						{series === "sessions" ? "recorded events" : "commits"}.
 					</span>
 				) : (
 					<>
@@ -600,7 +669,7 @@ function ActivityHeatmap({ view }: { view: WorkflowView }) {
 						<b className="text-fg-primary">
 							{(chosen ?? 0).toLocaleString("en-US")}
 						</b>{" "}
-						recorded events
+						{series === "sessions" ? "recorded events" : "commits"}
 					</>
 				)}
 			</p>
@@ -612,6 +681,23 @@ function ActivityHeatmap({ view }: { view: WorkflowView }) {
 			</BodyFootnote>
 		</div>
 	);
+}
+
+/**
+ * The same arithmetic as the `activity-heatmap` component rule, over the
+ * series on screen. The shift is a whole number of hours, so summing the
+ * shifted cells by hour gives the rule's figure exactly for the session series.
+ */
+function busiestHoursShare(cells: Map<string, number>): number {
+	const byHour = new Map<number, number>();
+	for (const [key, count] of cells) {
+		const hour = Number(key.split("-")[1]);
+		byHour.set(hour, (byHour.get(hour) ?? 0) + count);
+	}
+	const total = sumBy([...byHour.values()], (n) => n);
+	if (total <= 0) return 0;
+	const top = [...byHour.values()].sort((a, b) => b - a).slice(0, 3);
+	return sumBy(top, (n) => n) / total;
 }
 
 function shift(


### PR DESCRIPTION
Closes #281. Implements the thirteen decisions of #279. Stacked on #275 because it builds on the #278 path rule that lives there; retarget to `main` once #275 merges.

## What changes

- `packages/cli/src/workflow/git.ts`: `--no-merges`; a commit whose every path is machine-owned leaves the reading (a pure rename stays); cells ship in UTC as `weekdayUtc`/`hourUtc`; `lateNightCommits` reads those cells through the machine's `utcOffsetMinutes`; new `commitSetRuleVersion: "commit-set/v1"`.
- Wire, validator, schema, and `@aistack/workflow-rules` carry the renamed cells and the optional rule id. One revision: prod `measuredWorkflows` is empty.
- `src/features/workflow/components.tsx`: the Git ledger footnote prints `commit-set/v1`; `ActivityHeatmap` gets a sessions-or-commits toggle. One component, one band. The ranked figure never follows the toggle; the body figure under the grid recomputes per series.

## What deliberately does not change

Every author and every ref still count. No scope label, no author count, no band moves (#277 owns calibration).

## Measured, `aistack-web`, 30 days to 2026-08-26

| | before | after |
|---|---|---|
| commits | 227 | 207 |
| late-night share | 28.6% | 27.1% |
| removals share | 8.9% | 8.9% |
| zero-line dots | 22 | 2 |

## Tests

Full suite: 162 files, 2481 passed. New cases at the `extractGitWorkflow` seam (mock and real Git: merge left out, pure rename kept, offset-driven late-night count, UTC cells, all-machine commit dropped) and at the page (footnote, toggle, unmoved ranked figure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Xu3ep3ZAr8kXvcJCiKqrg