### PR TITLE
Release the CLI at 0.8.0 with the measured workflow section (alp82/aistack#221)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@use-aistack/cli",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Measure and share your AI stack from your terminal",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Bumps @use-aistack/cli to 0.8.0. npm's latest (0.7.2, 2026-08-17) predates the workflow section on the sync wire (#213, #219, #278, #281). The backend at main is already deployed. Part of #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Xu3ep3ZAr8kXvcJCiKqrg