### PR TITLE
Draw Git changes per active day as mirrored bars (alp82/aistack#288)

### DIFF
--- a/convex/lib/workflow.ts
+++ b/convex/lib/workflow.ts
@@ -211,6 +211,7 @@ export function emptyWorkflowWindow(
 			weekdayHourCells: [],
 		},
 		parallelProjectDays: [],
+		gitDays: [],
 		webSearchDays: 0,
 	}
 }

--- a/convex/workflow.ts
+++ b/convex/workflow.ts
@@ -159,6 +159,14 @@ const WorkflowWindow = v.object({
 	git: GitDay,
 	parallelProjects: v.optional(v.number()),
 	parallelProjectDays: v.array(v.number()),
+	gitDays: v.array(
+		v.object({
+			date: v.string(),
+			additions: v.number(),
+			removals: v.number(),
+			commits: v.number(),
+		})
+	),
 	webSearchDays: v.number(),
 })
 

--- a/packages/workflow-rules/src/daily.test.ts
+++ b/packages/workflow-rules/src/daily.test.ts
@@ -236,6 +236,26 @@ describe("foldWorkflowDays", () => {
 		expect(folded?.git.commits).toBe(15);
 	});
 
+	test("carries one Git entry per stored day, dated and sorted, for the per-day picture (#288)", () => {
+		const folded = foldWorkflowDays(
+			[
+				workflowDay({
+					date: "2026-08-25",
+					git: gitDay({ additions: 50, removals: 5, commits: 1 }),
+				}),
+				workflowDay({
+					date: "2026-08-23",
+					git: gitDay({ additions: 0, removals: 0, commits: 0 }),
+				}),
+			],
+			{ aggregateVersion: WORKFLOW_AGGREGATES_V2 },
+		);
+		expect(folded?.gitDays).toEqual([
+			{ date: "2026-08-23", additions: 0, removals: 0, commits: 0 },
+			{ date: "2026-08-25", additions: 50, removals: 5, commits: 1 },
+		]);
+	});
+
 	test("groups harnesses by name across days", () => {
 		const folded = foldWorkflowDays(
 			[

--- a/packages/workflow-rules/src/daily.ts
+++ b/packages/workflow-rules/src/daily.ts
@@ -165,6 +165,14 @@ export type GitDay = {
 	}[];
 };
 
+/** The three Git sums of one day, dated. What the mirrored bars draw. */
+export type GitDayTotals = {
+	date: string;
+	additions: number;
+	removals: number;
+	commits: number;
+};
+
 export type WorkflowDay = {
 	/** The UTC date, `YYYY-MM-DD`. Sessions belong to the day they started. */
 	date: string;
@@ -191,6 +199,12 @@ export type WorkflowWindow = Omit<WorkflowDay, "date"> & {
 	utcOffsetMinutes?: number;
 	/** The per-day parallel-project counts, for the median over days. */
 	parallelProjectDays: readonly number[];
+	/**
+	 * One Git entry per stored day, sorted by date, for the per-day picture
+	 * (#288). A derived list rather than the raw days: the page reads nothing
+	 * else per day, and the raw days would carry every harness atom with them.
+	 */
+	gitDays: readonly GitDayTotals[];
 	/** Days on which at least one harness recorded a web search count. */
 	webSearchDays: number;
 };
@@ -546,6 +560,14 @@ export function foldWorkflowDays(
 			? {}
 			: { parallelProjects: Math.max(...parallelProjectDays) }),
 		parallelProjectDays,
+		gitDays: [...days]
+			.sort((a, b) => a.date.localeCompare(b.date))
+			.map((day) => ({
+				date: day.date,
+				additions: day.git.additions,
+				removals: day.git.removals,
+				commits: day.git.commits,
+			})),
 		webSearchDays,
 	};
 }

--- a/src/features/workflow/__tests__/components.test.tsx
+++ b/src/features/workflow/__tests__/components.test.tsx
@@ -55,6 +55,23 @@ describe("lines changed", () => {
 		expect(screen.getByText("+95k")).toBeTruthy();
 	});
 
+	it("draws additions up and removals down, one slot per calendar day of the window (#288)", () => {
+		const { container } = show("component:git-ledger");
+		// The fixture window runs 2026-07-28 to 2026-08-26: 30 slots.
+		const slots = container.querySelectorAll("[data-day]");
+		expect(slots).toHaveLength(30);
+		const active = container.querySelector("[data-day='2026-08-25']");
+		expect(active?.getAttribute("title")).toBe(
+			"2026-08-25: +300 added, -100 removed, 2 commits",
+		);
+		// A day with no stored reading or no commit keeps its slot as a tick.
+		const empty = container.querySelector("[data-day='2026-08-01']");
+		expect(empty?.getAttribute("data-empty")).toBe("true");
+		expect(
+			screen.getByText("additions up, removals down, per day"),
+		).toBeTruthy();
+	});
+
 	it("draws one dot per commit on a log axis with the median labeled", () => {
 		const { container } = show("component:git-ledger");
 		expect(container.querySelectorAll("[title$='changed lines']")).toHaveLength(

--- a/src/features/workflow/__tests__/fixture.ts
+++ b/src/features/workflow/__tests__/fixture.ts
@@ -280,6 +280,15 @@ export function view(over: Partial<WorkflowView> = {}): WorkflowView {
 					{ weekdayUtc: 5, hourUtc: 11, commits: 1 },
 				],
 			},
+			gitDays: [
+				{
+					date: "2026-08-24",
+					additions: 94_500,
+					removals: 19_200,
+					commits: 118,
+				},
+				{ date: "2026-08-25", additions: 300, removals: 100, commits: 2 },
+			],
 			parallelProjects: 3,
 			parallelProjectDays: [2, 3],
 			webSearchDays: 2,

--- a/src/features/workflow/components.tsx
+++ b/src/features/workflow/components.tsx
@@ -401,31 +401,122 @@ function GitLedger({ view }: { view: WorkflowView }) {
 					touch a test file
 				</span>
 			</div>
-			<Strip
-				className="mt-2.5"
-				wide
-				label="additions against removals"
-				segments={[
-					{
-						key: "additions",
-						value: git.additions,
-						paint: ACCENT,
-						label: "additions",
-					},
-					{
-						key: "removals",
-						value: git.removals,
-						paint: "var(--destructive-fill)",
-						label: "removals",
-					},
-				]}
-			/>
+			<div className="mt-3.5">
+				<ColLabel>additions up, removals down, per day</ColLabel>
+				<DayBars
+					days={view.section.gitDays}
+					from={view.window.from}
+					to={view.window.to}
+				/>
+			</div>
 			{sizes.length > 0 && (
 				<div className="mt-3.5">
 					<ColLabel>lines changed per commit</ColLabel>
 					<CommitAxis sizes={sizes} />
 				</div>
 			)}
+		</div>
+	);
+}
+
+/** The slots the picture draws before it stops. A 30-day window fills 30. */
+const MAX_DAY_SLOTS = 62;
+
+/** The next UTC date after `date`, `YYYY-MM-DD`. */
+function nextDate(date: string): string {
+	const next = new Date(`${date}T00:00:00Z`);
+	next.setUTCDate(next.getUTCDate() + 1);
+	return next.toISOString().slice(0, 10);
+}
+
+/**
+ * Additions up and removals down as mirrored bars, one pair per calendar day
+ * of the window (#288).
+ *
+ * A CALENDAR AXIS, not an active-day axis: the wire ships only the days a
+ * sync stored, and drawing those side by side would collapse a two-week gap
+ * into one pixel. So the picture walks every date from the window's first to
+ * its last, and a day with no stored reading or no commit keeps its slot as a
+ * hairline tick on the baseline. The gap is part of the reading.
+ *
+ * ONE SCALE FOR BOTH HALVES: the tallest single side sets it, so a day that
+ * adds 4,000 and removes 40 reads that way.
+ */
+function DayBars({
+	days,
+	from,
+	to,
+}: {
+	days: readonly {
+		date: string;
+		additions: number;
+		removals: number;
+		commits: number;
+	}[];
+	from: string;
+	to: string;
+}) {
+	const byDate = new Map(days.map((day) => [day.date, day]));
+	const slots: string[] = [];
+	for (
+		let date = from;
+		date <= to && slots.length < MAX_DAY_SLOTS;
+		date = nextDate(date)
+	) {
+		slots.push(date);
+	}
+	const tallest =
+		Math.max(...days.map((day) => Math.max(day.additions, day.removals)), 0) ||
+		1;
+	const height = (value: number) => `${Math.round((value / tallest) * 100)}%`;
+	return (
+		<div
+			role="img"
+			aria-label={`additions and removals per day, ${from} to ${to}`}
+			className="mt-1.5 flex h-16 items-stretch gap-px"
+		>
+			{slots.map((date) => {
+				const day = byDate.get(date);
+				const empty = !day || day.commits === 0;
+				const title = day
+					? `${date}: +${fmtCount(day.additions)} added, -${fmtCount(day.removals)} removed, ${fmtCount(day.commits)} ${day.commits === 1 ? "commit" : "commits"}`
+					: `${date}: no measured day`;
+				return (
+					<span
+						key={date}
+						data-day={date}
+						data-empty={empty ? "true" : undefined}
+						title={title}
+						className="flex min-w-0.5 flex-1 flex-col"
+					>
+						<span className="flex flex-1 items-end">
+							{!empty && (
+								<i
+									className="block w-full min-h-px"
+									style={{ height: height(day.additions), background: ACCENT }}
+								/>
+							)}
+						</span>
+						<i
+							className="block h-px w-full shrink-0"
+							style={{
+								background: empty ? "var(--stroke-strong)" : "var(--fg-muted)",
+							}}
+						/>
+						<span className="flex flex-1 items-start">
+							{!empty && (
+								<i
+									className="block w-full min-h-px"
+									style={{
+										height: height(day.removals),
+										background: "var(--destructive-fill)",
+									}}
+								/>
+							)}
+						</span>
+					</span>
+				);
+			})}
 		</div>
 	);
 }


### PR DESCRIPTION
Closes #288 (map #200).

## What changed

- `packages/workflow-rules`: `WorkflowWindow.gitDays`, one dated entry of `additions`, `removals` and `commits` per stored day, sorted by date, computed in `foldWorkflowDays`. No new atom on the wire.
- `convex/workflow.ts`: the `WorkflowWindow` return validator carries `gitDays`; `emptyWorkflowWindow` holds an empty list.
- `src/features/workflow/components.tsx`: the Lines changed body draws `DayBars`, additions up in the accent and removals down in the destructive fill, one slot per calendar day from `window.from` to `window.to`. A day with no reading or no commit keeps its slot as a hairline tick. The body's duplicated additions-against-removals strip is gone (the head already holds it). The per-commit dot axis stays.

## Decisions

- **Derived list, not raw days.** The page reads nothing else per day, and raw days would put every harness atom into the validator for one picture.
- **Calendar axis, not active-day axis.** Stored days side by side would collapse a two-week gap into one pixel. The gap is part of the reading.
- **One scale for both halves**, set by the tallest single side.

## Checks

- `pnpm vitest run`: 162 files, 2442 tests pass.
- Local `convex dev` push accepted; `function-spec` serves `gitDays`.
- Not checked in a browser: the local database holds no `measuredWorkflowDays`. An owner sync against localhost (`AGENTS.md`, "Publishing a measured reading") renders it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Xu3ep3ZAr8kXvcJCiKqrg