### PR TITLE
Dim an extra harness in the by-harness rows (#293)

### DIFF
--- a/src/features/measured/MeasuredSection.tsx
+++ b/src/features/measured/MeasuredSection.tsx
@@ -63,11 +63,13 @@ export function MeasuredSection({
 	slug,
 	stackId,
 	isOwner,
+	stackToolSlugs,
 }: {
 	index: number;
 	slug: string;
 	stackId: Id<"stacks">;
 	isOwner: boolean;
+	stackToolSlugs: string[];
 }) {
 	const [machineSelection, setMachineSelection] = useState<{
 		slug: string;
@@ -151,6 +153,7 @@ export function MeasuredSection({
 					snapshot={snapshot}
 					points={history?.points ?? []}
 					showFreshness={hasMachineDropdown}
+					stackToolSlugs={stackToolSlugs}
 				/>
 			)}
 			{placed && staleSince === null && (
@@ -334,10 +337,12 @@ function Reading({
 	snapshot,
 	points,
 	showFreshness,
+	stackToolSlugs,
 }: {
 	snapshot: MeasuredSnapshot;
 	points: readonly MeasuredHistoryPoint[];
 	showFreshness: boolean;
+	stackToolSlugs: string[];
 }) {
 	// The COMBINED headline (#66 decision 2, #243): tokens, sessions and dollars
 	// sum honestly across every source, a source being one harness on one
@@ -389,7 +394,7 @@ function Reading({
 				</div>
 
 				<ModelShareRows trails={trails} firstAt={firstAt} />
-				<HarnessShareRows snapshot={snapshot} />
+				<HarnessShareRows snapshot={snapshot} stackToolSlugs={stackToolSlugs} />
 
 				<div className="mt-8 grid grid-cols-2 gap-px border border-stroke-subtle bg-stroke-subtle sm:grid-cols-5">
 					<Stat
@@ -433,7 +438,19 @@ const HARNESS_LABELS: Record<string, string> = {
 	"pi-mono": "Pi",
 };
 
-function HarnessShareRows({ snapshot }: { snapshot: MeasuredSnapshot }) {
+/**
+ * A harness that produced a snapshot but is not a stack tool is EXTRA (#293):
+ * its label and bar fill sit at half opacity, its figures stay at full
+ * contrast, and the only word is for screen readers. The treatment marks
+ * extra, never unused. The catalog's tool slugs are the harness names.
+ */
+function HarnessShareRows({
+	snapshot,
+	stackToolSlugs,
+}: {
+	snapshot: MeasuredSnapshot;
+	stackToolSlugs: string[];
+}) {
 	const byHarness = new Map<string, number>();
 	for (const harness of snapshot.harnesses) {
 		byHarness.set(
@@ -450,6 +467,7 @@ function HarnessShareRows({ snapshot }: { snapshot: MeasuredSnapshot }) {
 				snapshot.activity.totalTokens > 0
 					? tokens / snapshot.activity.totalTokens
 					: 0,
+			extra: !stackToolSlugs.includes(name),
 		}))
 		.sort((a, b) => {
 			if (a.name === "claude-code") return -1;
@@ -466,14 +484,24 @@ function HarnessShareRows({ snapshot }: { snapshot: MeasuredSnapshot }) {
 				className="divide-y divide-stroke-subtle border-y border-stroke-subtle"
 			>
 				{rows.map((row, index) => (
-					<li key={row.name} className="flex items-center gap-3 py-2">
-						<span className="w-40 shrink-0 truncate text-sm text-fg-secondary">
+					<li
+						key={row.name}
+						data-extra={row.extra || undefined}
+						className="flex items-center gap-3 py-2"
+					>
+						<span
+							className={cn(
+								"w-40 shrink-0 truncate text-sm text-fg-secondary",
+								row.extra && "opacity-50",
+							)}
+						>
 							{row.label}
+							{row.extra && <span className="sr-only"> (extra)</span>}
 						</span>
 						<span className="h-3 flex-1 bg-bg-panel">
 							<span
 								data-testid="source-paint"
-								className="block h-full"
+								className={cn("block h-full", row.extra && "opacity-50")}
 								style={{
 									width: `${Math.max(1, row.share * 100)}%`,
 									background: SOURCE_PAINTS[index % SOURCE_PAINTS.length],

--- a/src/features/measured/__tests__/measured-section.test.tsx
+++ b/src/features/measured/__tests__/measured-section.test.tsx
@@ -58,8 +58,10 @@ function setup(
 		isOwner = false,
 		autoSync = { autoSync: null, lastAutoSyncAt: null },
 		selected,
+		stackToolSlugs = ["claude-code", "codex"],
 	}: {
 		isOwner?: boolean;
+		stackToolSlugs?: string[];
 		autoSync?: AutoSyncFlag;
 		selected?: {
 			machineOrdinal: number;
@@ -99,6 +101,7 @@ function setup(
 			slug="alps-stack-ab12"
 			stackId={"stack_ab12" as never}
 			isOwner={isOwner}
+			stackToolSlugs={stackToolSlugs}
 		/>,
 	);
 }
@@ -203,6 +206,7 @@ describe("the reading", () => {
 				slug="first-stack"
 				stackId={"stack_ab12" as never}
 				isOwner={false}
+				stackToolSlugs={["claude-code"]}
 			/>,
 		);
 
@@ -215,6 +219,7 @@ describe("the reading", () => {
 				slug="second-stack"
 				stackId={"stack_cd34" as never}
 				isOwner={false}
+				stackToolSlugs={["claude-code"]}
 			/>,
 		);
 
@@ -315,6 +320,35 @@ describe("the reading", () => {
 			list.compareDocumentPosition(screen.getByText("sessions")) &
 				Node.DOCUMENT_POSITION_FOLLOWING,
 		).toBeTruthy();
+	});
+
+	it("dims the label and bar of a harness that is not a stack tool, figures untouched", () => {
+		const { current, history } = live();
+		setup(
+			{
+				...current,
+				harnesses: current.harnesses.map((h) => ({
+					...h,
+					machineOrdinal: 1,
+				})),
+			},
+			history,
+			{ stackToolSlugs: ["codex"] },
+		);
+
+		const list = screen.getByRole("list", { name: "Harness token shares" });
+		const extra = within(list).getByText("Claude Code").closest("li");
+		const kept = within(list).getByText("Codex").closest("li");
+		if (!extra || !kept) throw new Error("rows missing");
+		expect(extra).toHaveAttribute("data-extra", "true");
+		expect(kept).not.toHaveAttribute("data-extra");
+		expect(within(extra).getByText("Claude Code")).toHaveClass("opacity-50");
+		expect(within(extra).getByText("(extra)")).toHaveClass("sr-only");
+		expect(within(extra).getByTestId("source-paint")).toHaveClass("opacity-50");
+		expect(within(extra).getByText("99.8%")).not.toHaveClass("opacity-50");
+		expect(within(kept).getByTestId("source-paint")).not.toHaveClass(
+			"opacity-50",
+		);
 	});
 
 	it("uses a neutral source ramp for machines and harnesses", () => {

--- a/src/routes/stacks.$slug.tsx
+++ b/src/routes/stacks.$slug.tsx
@@ -38,6 +38,7 @@ import { api } from "../../convex/_generated/api";
 type ViewTool = {
 	_id: string;
 	name: string;
+	slug: string;
 	categories: string[];
 	iconUrl?: string;
 	price: {
@@ -413,6 +414,7 @@ function StackDetailsPage() {
 						slug={stack.slug}
 						stackId={stack._id}
 						isOwner={upvoteStatus?.isOwner ?? false}
+						stackToolSlugs={stack.tools.map((t: ViewTool) => t.slug)}
 					/>
 
 					<ProjectsSection


### PR DESCRIPTION
Closes alp82/aistack#293. Part of map #292.

A harness that produced a snapshot but is not a stack tool stays in the by-harness rows. Its label and bar fill sit at half opacity; the figures stay at full contrast. Only an sr-only "(extra)" names it. Extra is computed as harness name not in the stack's tool slugs (the catalog slugs equal the harness names).

Prototype with the three candidate treatments: branch `prototype/293-extra-harness`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UX3EwpV7eYAW4MNQsnzZ5