### PR TITLE
Merge the duplicate OpenAI model rows and resolve authored slugs through aliases (alp82/aistack#294)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -63,6 +63,7 @@ import type * as migrations_20260823_measured_machine_ordinals from "../migratio
 import type * as migrations_20260823_news_hn_lane from "../migrations/20260823_news_hn_lane.js";
 import type * as migrations_20260823_news_phase1_sources from "../migrations/20260823_news_phase1_sources.js";
 import type * as migrations_20260826_workflow_daily_rows from "../migrations/20260826_workflow_daily_rows.js";
+import type * as migrations_20260827_merge_duplicate_models from "../migrations/20260827_merge_duplicate_models.js";
 import type * as migrations__archived_migrateBlockToReference from "../migrations/_archived/migrateBlockToReference.js";
 import type * as migrations__archived_migrateNotesToDescription from "../migrations/_archived/migrateNotesToDescription.js";
 import type * as migrations__archived_migrateStackDescriptions from "../migrations/_archived/migrateStackDescriptions.js";
@@ -153,6 +154,7 @@ declare const fullApi: ApiFromModules<{
   "migrations/20260823_news_hn_lane": typeof migrations_20260823_news_hn_lane;
   "migrations/20260823_news_phase1_sources": typeof migrations_20260823_news_phase1_sources;
   "migrations/20260826_workflow_daily_rows": typeof migrations_20260826_workflow_daily_rows;
+  "migrations/20260827_merge_duplicate_models": typeof migrations_20260827_merge_duplicate_models;
   "migrations/_archived/migrateBlockToReference": typeof migrations__archived_migrateBlockToReference;
   "migrations/_archived/migrateNotesToDescription": typeof migrations__archived_migrateNotesToDescription;
   "migrations/_archived/migrateStackDescriptions": typeof migrations__archived_migrateStackDescriptions;

--- a/convex/lib/modelLookup.ts
+++ b/convex/lib/modelLookup.ts
@@ -1,0 +1,22 @@
+import type { Doc } from '../_generated/dataModel'
+import type { QueryCtx } from '../_generated/server'
+
+/**
+ * Find a catalog model by slug, then by alias.
+ *
+ * The authored side (`modelSubscriptions[].modelSlug`) and the measured side
+ * both go through the catalog's aliases, so a stack that stored an older
+ * spelling shows the model and is not asked to add it again (#294).
+ */
+export async function findModelBySlugOrAlias(
+  ctx: QueryCtx,
+  slug: string
+): Promise<Doc<'models'> | null> {
+  const exact = await ctx.db
+    .query('models')
+    .withIndex('by_slug', (q) => q.eq('slug', slug))
+    .first()
+  if (exact) return exact
+  const all = await ctx.db.query('models').collect()
+  return all.find((m) => m.aliases?.includes(slug)) ?? null
+}

--- a/convex/measured.ts
+++ b/convex/measured.ts
@@ -1534,11 +1534,17 @@ export const getReconcileSuggestions = query({
     // Measured-side: a model that resolves to the catalog but is absent from
     // the authored model list. Across harnesses the first (freshest-ordered)
     // sighting wins - the suggestion is "you ran this", not a share ranking.
+    // Authored slugs go through the same alias resolution as measured ids, so
+    // a stack that stored an older spelling is not asked to add it again (#294).
+    const catalog = await loadModelCatalog(ctx)
     const authoredModels = new Set(
-      (stack.modelSubscriptions ?? []).map((m) => m.modelSlug)
+      (stack.modelSubscriptions ?? []).map(
+        (m) =>
+          (catalog.bySlug.get(m.modelSlug) ?? catalog.byAlias.get(m.modelSlug))?.slug ??
+          m.modelSlug
+      )
     )
     const suggestedSlugs = new Set<string>()
-    const catalog = await loadModelCatalog(ctx)
     for (const snapshot of snapshots) {
       const resolved = resolveModels(catalog, snapshot.payload.models)
       const { models: repriced } = repriceSnapshot({

--- a/convex/measuredRead.test.ts
+++ b/convex/measuredRead.test.ts
@@ -182,3 +182,36 @@ describe('getCurrentByStackSlug reads what the CLI publishes', () => {
     })
   })
 })
+
+describe('getReconcileSuggestions resolves authored slugs through aliases (#294)', () => {
+  test('a stack listing an older spelling is not asked to add the model again', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    await t.run(async (ctx) => {
+      await ctx.db.insert('models', {
+        name: 'Claude Opus 5',
+        slug: 'claude-opus-5',
+        shortId: 'sid-opus5',
+        aliases: ['claude-opus-50'],
+        provider: 'Anthropic',
+        category: 'coding',
+        reviewStatus: 'approved',
+        createdAt: 1,
+        updatedAt: 1,
+      })
+      await ctx.db.patch(stackId, {
+        modelSubscriptions: [{ modelSlug: 'claude-opus-50', role: 'primary' }],
+      })
+    })
+    await t.mutation(internal.measured.publishSnapshot, {
+      stackId,
+      payload: payloadWithCounts(),
+    })
+
+    const result = await t
+      .withIdentity({ tokenIdentifier: `convex|${USER}`, subject: USER })
+      .query(api.measured.getReconcileSuggestions, { stackId })
+
+    expect(result.suggestions.filter((s) => s.atomKind === 'model')).toEqual([])
+  })
+})

--- a/convex/migrations/20260827_merge_duplicate_models.test.ts
+++ b/convex/migrations/20260827_merge_duplicate_models.test.ts
@@ -1,0 +1,101 @@
+/// <reference types="vite/client" />
+import { convexTest } from 'convex-test'
+import { describe, expect, test } from 'vitest'
+import { internal } from '../_generated/api'
+import schema from '../schema'
+
+const modules = Object.fromEntries(
+  Object.entries(import.meta.glob('../**/*.{js,ts}')).map(([key, loader]) => [
+    key.replace(/^\.\//, '../migrations/'),
+    loader,
+  ])
+)
+
+const MIGRATION = internal.migrations['20260827_merge_duplicate_models']
+
+function modelRow(slug: string, name: string, iconUrl?: string) {
+  return {
+    name,
+    slug,
+    shortId: `sid-${slug}`.slice(0, 12),
+    iconUrl,
+    provider: 'OpenAI',
+    category: 'coding' as const,
+    reviewStatus: 'approved' as const,
+    createdAt: 1,
+    updatedAt: 1,
+  }
+}
+
+describe('20260827_merge_duplicate_models', () => {
+  test('merges pairs, rewrites stacks and dismissals, and is idempotent', async () => {
+    const t = convexTest(schema, modules)
+    const stackId = await t.run(async (ctx) => {
+      await ctx.db.insert('models', modelRow('gpt-5.6-sol', 'GPT-5.6 Sol'))
+      await ctx.db.insert('models', modelRow('gpt-56-sol', 'GPT 5.6 Sol', 'https://x/sol.png'))
+      await ctx.db.insert('models', modelRow('gpt-5.5', 'GPT-5.5'))
+      await ctx.db.insert('models', modelRow('gpt-55', 'GPT 5.5'))
+      const creatorId = await ctx.db.insert('creators', {
+        name: 'Owner',
+        slug: 'owner',
+        userId: 'user_owner',
+        verified: false,
+        personalPages: [],
+        projectPages: [],
+        createdAt: 1,
+      })
+      const stackId = await ctx.db.insert('stacks', {
+        name: 'S',
+        slug: 's',
+        shortId: 'sid-s',
+        creatorId,
+        oneLiner: 'A stack',
+        toolSubscriptions: [],
+        modelSubscriptions: [
+          { modelSlug: 'gpt-56-sol', role: 'primary' },
+          { modelSlug: 'gpt-5.6-sol', role: 'secondary' },
+          { modelSlug: 'gpt-55', role: 'secondary' },
+          { modelSlug: 'fable-5', role: 'primary' },
+        ],
+        hasUsageComponent: false,
+        published: true,
+        createdAt: 1,
+        updatedAt: 1,
+      })
+      await ctx.db.insert('reconcileDismissals', {
+        stackId,
+        atomKind: 'model',
+        atomKey: 'gpt-55',
+        dismissedAt: 1,
+      })
+      return stackId
+    })
+
+    const first = await t.mutation(MIGRATION.run, {})
+    expect(first.merged).toEqual(['gpt-56-sol -> gpt-5.6-sol', 'gpt-55 -> gpt-5.5'])
+    expect(first.stacksRewritten).toBe(1)
+    expect(first.dismissalsRewritten).toBe(1)
+
+    await t.run(async (ctx) => {
+      const rows = await ctx.db.query('models').collect()
+      expect(rows.map((r) => r.slug).sort()).toEqual(['gpt-5.5', 'gpt-5.6-sol'])
+      const sol = rows.find((r) => r.slug === 'gpt-5.6-sol')
+      expect(sol?.aliases).toEqual(['gpt-56-sol'])
+      expect(sol?.iconUrl).toBe('https://x/sol.png')
+      const stack = await ctx.db.get(stackId)
+      // The first spelling keeps its slot and role; the duplicate is dropped.
+      expect(stack?.modelSubscriptions).toEqual([
+        { modelSlug: 'gpt-5.6-sol', role: 'primary' },
+        { modelSlug: 'gpt-5.5', role: 'secondary' },
+        { modelSlug: 'fable-5', role: 'primary' },
+      ])
+      const dismissals = await ctx.db.query('reconcileDismissals').collect()
+      expect(dismissals.map((d) => d.atomKey)).toEqual(['gpt-5.5'])
+    })
+
+    const second = await t.mutation(MIGRATION.run, {})
+    expect(second.merged).toEqual([])
+    expect(second.stacksRewritten).toBe(0)
+    expect(second.dismissalsRewritten).toBe(0)
+  })
+})

--- a/convex/migrations/20260827_merge_duplicate_models.ts
+++ b/convex/migrations/20260827_merge_duplicate_models.ts
@@ -1,0 +1,111 @@
+import { v } from 'convex/values'
+import { internalMutation } from '../_generated/server'
+
+/**
+ * Merge the duplicate OpenAI catalog rows (#294, map #292).
+ *
+ * The catalog held two rows per model: an older, user-created spelling
+ * (`gpt-56-sol`, "GPT 5.6 Sol") and the seeded canonical one (`gpt-5.6-sol`,
+ * "GPT-5.6 Sol") from 20260801_openai_models and 20260802_gpt56_models. The
+ * measured side resolves to the canonical slug, the authored side stored the
+ * old one, so a listed model was re-suggested while it sat in the accordion.
+ *
+ * For each pair, the canonical row survives. The old slug becomes an alias on
+ * it, the icon carries over when the canonical row has none, every stack's
+ * `modelSubscriptions` and every model dismissal is rewritten to the canonical
+ * slug (deduplicated when a stack already listed both), and the old row is
+ * deleted.
+ *
+ * IDEMPOTENT. A pair whose old row is gone is skipped; the alias is still
+ * ensured so the read-side alias lookup keeps working.
+ */
+export const MERGES: Array<{ keep: string; drop: string }> = [
+  { keep: 'gpt-5.6-sol', drop: 'gpt-56-sol' },
+  { keep: 'gpt-5.6-terra', drop: 'gpt-56-terra' },
+  { keep: 'gpt-5.6-luna', drop: 'gpt-56-luna' },
+  { keep: 'gpt-5.5', drop: 'gpt-55' },
+  { keep: 'gpt-5.4', drop: 'gpt-54' },
+  { keep: 'gpt-5.3-codex', drop: 'gpt-5-3-codex' },
+]
+
+export const run = internalMutation({
+  args: {},
+  returns: v.object({
+    merged: v.array(v.string()),
+    skipped: v.array(v.string()),
+    stacksRewritten: v.number(),
+    dismissalsRewritten: v.number(),
+  }),
+  handler: async (ctx) => {
+    const merged: string[] = []
+    const skipped: string[] = []
+    const canonicalOf = new Map<string, string>()
+
+    for (const { keep, drop } of MERGES) {
+      const keepRow = await ctx.db
+        .query('models')
+        .withIndex('by_slug', (q) => q.eq('slug', keep))
+        .first()
+      if (!keepRow) {
+        skipped.push(`${drop}: no ${keep} row`)
+        continue
+      }
+      canonicalOf.set(drop, keep)
+      if (!keepRow.aliases?.includes(drop)) {
+        await ctx.db.patch(keepRow._id, {
+          aliases: [...(keepRow.aliases ?? []), drop],
+        })
+      }
+      const dropRow = await ctx.db
+        .query('models')
+        .withIndex('by_slug', (q) => q.eq('slug', drop))
+        .first()
+      if (!dropRow) {
+        skipped.push(`${drop}: already gone`)
+        continue
+      }
+      if (!keepRow.iconStorageId && !keepRow.iconUrl) {
+        await ctx.db.patch(keepRow._id, {
+          iconStorageId: dropRow.iconStorageId,
+          iconUrl: dropRow.iconUrl,
+        })
+      }
+      await ctx.db.delete(dropRow._id)
+      merged.push(`${drop} -> ${keep}`)
+    }
+
+    let stacksRewritten = 0
+    for (const stack of await ctx.db.query('stacks').collect()) {
+      const subs = stack.modelSubscriptions ?? []
+      if (!subs.some((s) => canonicalOf.has(s.modelSlug))) continue
+      const seen = new Set<string>()
+      const next = []
+      for (const s of subs) {
+        const slug = canonicalOf.get(s.modelSlug) ?? s.modelSlug
+        if (seen.has(slug)) continue
+        seen.add(slug)
+        next.push({ ...s, modelSlug: slug })
+      }
+      await ctx.db.patch(stack._id, { modelSubscriptions: next })
+      stacksRewritten++
+    }
+
+    let dismissalsRewritten = 0
+    for (const d of await ctx.db.query('reconcileDismissals').collect()) {
+      if (d.atomKind !== 'model') continue
+      const slug = canonicalOf.get(d.atomKey)
+      if (!slug) continue
+      const clash = await ctx.db
+        .query('reconcileDismissals')
+        .withIndex('by_stack_atom', (q) =>
+          q.eq('stackId', d.stackId).eq('atomKind', 'model').eq('atomKey', slug)
+        )
+        .first()
+      if (clash) await ctx.db.delete(d._id)
+      else await ctx.db.patch(d._id, { atomKey: slug })
+      dismissalsRewritten++
+    }
+
+    return { merged, skipped, stacksRewritten, dismissalsRewritten }
+  },
+})

--- a/convex/stacks.ts
+++ b/convex/stacks.ts
@@ -1,5 +1,6 @@
 import { mutation, query } from './_generated/server'
 import { v } from 'convex/values'
+import { findModelBySlugOrAlias } from './lib/modelLookup'
 import type { MutationCtx, QueryCtx } from './_generated/server'
 import type { Id } from './_generated/dataModel'
 import { type FixedPrice, orderToolsForDisplay, sumNormalizedMonthlyAmounts } from '../src/lib/pricing'
@@ -698,10 +699,7 @@ export const getForEdit = query({
 
     const modelSubEntries = await Promise.all(
       (stack.modelSubscriptions ?? []).map(async (ms) => {
-        const model = await ctx.db
-          .query('models')
-          .withIndex('by_slug', (q) => q.eq('slug', ms.modelSlug))
-          .first()
+        const model = await findModelBySlugOrAlias(ctx, ms.modelSlug)
         if (!model) return null
         const resolvedModelUrl = model.iconStorageId
           ? await ctx.storage.getUrl(model.iconStorageId)
@@ -1070,10 +1068,7 @@ export const getBySlug = query({
 
     const modelEntries = await Promise.all(
       (stack.modelSubscriptions ?? []).map(async (ms) => {
-        const model = await ctx.db
-          .query('models')
-          .withIndex('by_slug', (q) => q.eq('slug', ms.modelSlug))
-          .first()
+        const model = await findModelBySlugOrAlias(ctx, ms.modelSlug)
         if (!model) return null
         const resolvedModelUrl = model.iconStorageId
           ? await ctx.storage.getUrl(model.iconStorageId)
@@ -1186,10 +1181,7 @@ export const getPublicSummary = query({
     ).map((t) => t.name)
 
     const models = await resolveNames(stack.modelSubscriptions ?? [], async (ms) => {
-      const model = await ctx.db
-        .query('models')
-        .withIndex('by_slug', (q) => q.eq('slug', ms.modelSlug))
-        .first()
+      const model = await findModelBySlugOrAlias(ctx, ms.modelSlug)
       return model?.name ?? null
     })
 


### PR DESCRIPTION
Closes #294. Part of map #292.

## What
- Migration `20260827_merge_duplicate_models`: six pairs (`gpt-56-sol`/`gpt-5.6-sol`, Terra, Luna, `gpt-55`/`gpt-5.5`, `gpt-54`/`gpt-5.4`, `gpt-5-3-codex`/`gpt-5.3-codex`). The canonical row survives with the old slug as an alias and the old icon when it has none. Stack `modelSubscriptions` and model dismissals are rewritten to the canonical slug (deduplicated when a stack listed both). Old rows are deleted. Idempotent.
- `convex/lib/modelLookup.ts`: `findModelBySlugOrAlias`, used by the accordion (`getBySlug`), the editor read, and the summary in `stacks.ts`.
- `getReconcileSuggestions` maps authored slugs through the catalog aliases before the "missing from authored" check.

## After merge
Deploy runs through the workflow, then on the server:
`scripts/convex-prod.sh run migrations/20260827_merge_duplicate_models:run`

Expected on prod: 6 merges, about 18 stacks rewritten.

## Tests
Migration test (merge, rewrite, dedupe, idempotency) and a suggestion test for an aliased authored slug. `npx vitest run convex`: 869 passed. `tsc` clean.

`convex/_generated/api.d.ts` was updated by hand because the local `convex dev` push is refusing on a Node version check; the deploy regenerates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UX3EwpV7eYAW4MNQsnzZ5