### PR TITLE
Carry the stack accent into portaled hover cards and dialogs (alp82/aistack#298)

### DIFF
--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -1,6 +1,7 @@
-import { createPortal } from "react-dom";
-import { useId } from "react";
 import { X } from "lucide-react";
+import { useId, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { accentClassOf } from "@/lib/accentClassOf";
 
 interface DialogProps {
 	open: boolean;
@@ -33,8 +34,17 @@ export function Dialog({
 	scrollable = false,
 }: DialogProps) {
 	const titleId = useId();
+	// The dialog portals to body, outside the stack page's `.accent-<key>`
+	// wrapper. A sentinel stays in the tree so the nearest accent class can be
+	// read and carried into the portal (alp82/aistack#298).
+	const sentinelRef = useRef<HTMLSpanElement>(null);
+	const [accentClass, setAccentClass] = useState<string | undefined>();
+	useLayoutEffect(() => {
+		if (open) setAccentClass(accentClassOf(sentinelRef.current));
+	}, [open]);
 
-	if (!open) return null;
+	const sentinel = <span ref={sentinelRef} hidden data-dialog-anchor="" />;
+	if (!open) return sentinel;
 
 	const defaultPadding = size === "lg" ? "p-8" : "p-6";
 	const paddingClass = padding ?? defaultPadding;
@@ -42,55 +52,62 @@ export function Dialog({
 
 	// TODO(a11y): focus trap + focus return on close
 
-	return createPortal(
-		<div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-			<div
-				className="absolute inset-0 bg-bg-canvas/80 backdrop-blur-md"
-				onClick={onClose}
-				onKeyDown={(e) => e.key === "Escape" && onClose()}
-			/>
-			<div
-				role="dialog"
-				aria-modal="true"
-				aria-labelledby={title ? titleId : undefined}
-				className={`relative w-full ${sizeClasses[size]} ${scrollClass} border-2 border-stroke-strong bg-bg-panel ${paddingClass} shadow-[6px_6px_0_var(--stroke-strong)]`}
-			>
-				{title && (
+	return (
+		<>
+			{sentinel}
+			{createPortal(
+				<div
+					className={`fixed inset-0 z-50 flex items-center justify-center p-4 ${accentClass ?? ""}`}
+				>
 					<div
-						className={`mb-4 flex items-center justify-between ${paddingClass === "p-0" ? "px-6 pt-5" : ""}`}
-					>
-						<div className="flex items-center gap-3">
-							{titleIcon}
-							<h3
-								id={titleId}
-								className="font-mono text-lg font-bold text-fg-primary"
-							>
-								{title}
-							</h3>
-						</div>
-						<button
-							type="button"
-							onClick={onClose}
-							aria-label="Close"
-							className="flex size-8 shrink-0 items-center justify-center border border-stroke-subtle text-fg-muted transition-colors hover:border-accent-lime hover:text-accent-lime cursor-pointer"
-						>
-							<X className="size-4" />
-						</button>
-					</div>
-				)}
-				{!title && (
-					<button
-						type="button"
+						className="absolute inset-0 bg-bg-canvas/80 backdrop-blur-md"
 						onClick={onClose}
-						aria-label="Close"
-						className="absolute right-4 top-4 flex size-8 shrink-0 items-center justify-center border border-stroke-subtle text-fg-muted transition-colors hover:border-accent-lime hover:text-accent-lime cursor-pointer"
+						onKeyDown={(e) => e.key === "Escape" && onClose()}
+					/>
+					<div
+						role="dialog"
+						aria-modal="true"
+						aria-labelledby={title ? titleId : undefined}
+						className={`relative w-full ${sizeClasses[size]} ${scrollClass} border-2 border-stroke-strong bg-bg-panel ${paddingClass} shadow-[6px_6px_0_var(--stroke-strong)]`}
 					>
-						<X className="size-4" />
-					</button>
-				)}
-				{children}
-			</div>
-		</div>,
-		document.body,
+						{title && (
+							<div
+								className={`mb-4 flex items-center justify-between ${paddingClass === "p-0" ? "px-6 pt-5" : ""}`}
+							>
+								<div className="flex items-center gap-3">
+									{titleIcon}
+									<h3
+										id={titleId}
+										className="font-mono text-lg font-bold text-fg-primary"
+									>
+										{title}
+									</h3>
+								</div>
+								<button
+									type="button"
+									onClick={onClose}
+									aria-label="Close"
+									className="flex size-8 shrink-0 items-center justify-center border border-stroke-subtle text-fg-muted transition-colors hover:border-accent-lime hover:text-accent-lime cursor-pointer"
+								>
+									<X className="size-4" />
+								</button>
+							</div>
+						)}
+						{!title && (
+							<button
+								type="button"
+								onClick={onClose}
+								aria-label="Close"
+								className="absolute right-4 top-4 flex size-8 shrink-0 items-center justify-center border border-stroke-subtle text-fg-muted transition-colors hover:border-accent-lime hover:text-accent-lime cursor-pointer"
+							>
+								<X className="size-4" />
+							</button>
+						)}
+						{children}
+					</div>
+				</div>,
+				document.body,
+			)}
+		</>
 	);
 }

--- a/src/components/ui/__tests__/Dialog.accent.test.tsx
+++ b/src/components/ui/__tests__/Dialog.accent.test.tsx
@@ -1,0 +1,19 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Dialog } from "@/components/ui/Dialog";
+
+afterEach(cleanup);
+
+describe("Dialog carries the nearest .accent-<key> class into its portal (alp82/aistack#298)", () => {
+	it("wraps the portaled overlay in accent-cyan", () => {
+		render(
+			<div className="accent-cyan">
+				<Dialog open onClose={() => {}} title="T">
+					<p>body</p>
+				</Dialog>
+			</div>,
+		);
+		const dialog = document.body.querySelector('[role="dialog"]');
+		expect(dialog?.closest(".accent-cyan")).not.toBeNull();
+	});
+});

--- a/src/components/ui/__tests__/hover-card.test.tsx
+++ b/src/components/ui/__tests__/hover-card.test.tsx
@@ -322,3 +322,39 @@ describe("TC-HC-08: content shows on focus and hides on blur", () => {
 		expect(screen.queryByTestId("focus-content")).toBeNull();
 	});
 });
+
+// ---------------------------------------------------------------------------
+// TC-HC-07  (wrapper) - the portaled surface carries the stack accent class
+//
+// The surface leaves the `.accent-<key>` wrapper when it portals to body, so
+// `--accent-lime` would fall back to brand lime. The nearest accent class of
+// the trigger travels with the surface (alp82/aistack#298).
+// ---------------------------------------------------------------------------
+describe("TC-HC-07: surface inherits the nearest .accent-<key> class", () => {
+	it("copies accent-cyan from the trigger's ancestor onto the surface", () => {
+		render(
+			<div className="accent-cyan">
+				<HoverCard mode="wrapper" renderContent={() => <div />}>
+					<span data-testid="trigger">T</span>
+				</HoverCard>
+			</div>,
+		);
+		act(() => {
+			fireEvent.mouseEnter(screen.getByTestId("trigger"));
+		});
+		expect(getSurface()?.classList.contains("accent-cyan")).toBe(true);
+	});
+
+	it("adds no accent class when no ancestor sets one", () => {
+		render(
+			<HoverCard mode="wrapper" renderContent={() => <div />}>
+				<span data-testid="trigger">T</span>
+			</HoverCard>,
+		);
+		act(() => {
+			fireEvent.mouseEnter(screen.getByTestId("trigger"));
+		});
+		const cls = Array.from(getSurface()?.classList ?? []);
+		expect(cls.some((c) => c.startsWith("accent-"))).toBe(false);
+	});
+});

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -9,6 +9,7 @@ import {
 } from "motion/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { accentClassOf } from "@/lib/accentClassOf";
 import { cn } from "@/lib/utils";
 
 export interface HoverTarget {
@@ -123,6 +124,7 @@ const HoverCard = (props: HoverCardProps) => {
 	const [isVisible, setIsVisible] = useState(false);
 	const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
 	const [mounted, setMounted] = useState(false);
+	const rootRef = useRef<HTMLDivElement>(null);
 	const triggerRef = useRef<HTMLDivElement>(null);
 	const targetRefs = useRef<(HTMLSpanElement | null)[]>([]);
 	const hideTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -425,9 +427,15 @@ const HoverCard = (props: HoverCardProps) => {
 
 	const selfTranslate = SELF_TRANSLATE[position];
 
+	// The surface portals to body, outside the stack page's `.accent-<key>`
+	// wrapper. Carry the nearest accent class along so the card wears the stack
+	// accent instead of brand lime (alp82/aistack#298). Read after mount only.
+	const accentClass = mounted ? accentClassOf(rootRef.current) : undefined;
+
 	const previewSurface = (
 		<motion.div
 			data-testid="hover-card-surface"
+			className={accentClass}
 			style={{
 				position: "fixed",
 				left: 0,
@@ -468,7 +476,7 @@ const HoverCard = (props: HoverCardProps) => {
 
 	if (props.mode === "wrapper") {
 		return (
-			<div className={cn("relative inline-block", className)}>
+			<div ref={rootRef} className={cn("relative inline-block", className)}>
 				{/* Focus opens the card as hover does, so a keyboard reader reaches
 				    content a mouse reader gets for free. React's onFocus is focusin,
 				    so a focusable child inside the trigger counts. */}
@@ -489,7 +497,7 @@ const HoverCard = (props: HoverCardProps) => {
 	}
 
 	return (
-		<div className={cn("relative", className)}>
+		<div ref={rootRef} className={cn("relative", className)}>
 			{renderInlineContent()}
 			{mounted ? createPortal(previewSurface, document.body) : null}
 		</div>

--- a/src/lib/__tests__/accentClassOf.test.ts
+++ b/src/lib/__tests__/accentClassOf.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { accentClassOf } from "@/lib/accentClassOf";
+
+describe("accentClassOf", () => {
+	it("returns the nearest ancestor's accent-<key> class", () => {
+		const outer = document.createElement("div");
+		outer.className = "accent-teal";
+		const inner = document.createElement("div");
+		inner.className = "accent-cyan p-2";
+		const leaf = document.createElement("span");
+		outer.append(inner);
+		inner.append(leaf);
+		expect(accentClassOf(leaf)).toBe("accent-cyan");
+	});
+
+	it("skips a utility class such as hover:text-accent-lime on the way up", () => {
+		const wrapper = document.createElement("div");
+		wrapper.className = "accent-cyan";
+		const link = document.createElement("a");
+		link.className = "font-bold hover:text-accent-lime";
+		const leaf = document.createElement("span");
+		wrapper.append(link);
+		link.append(leaf);
+		expect(accentClassOf(leaf)).toBe("accent-cyan");
+	});
+
+	it("returns undefined when no ancestor carries one", () => {
+		const leaf = document.createElement("span");
+		document.body.append(leaf);
+		expect(accentClassOf(leaf)).toBeUndefined();
+		expect(accentClassOf(null)).toBeUndefined();
+	});
+});

--- a/src/lib/accentClassOf.ts
+++ b/src/lib/accentClassOf.ts
@@ -1,0 +1,21 @@
+const ACCENT_CLASS = /^accent-[a-z]+$/;
+
+/**
+ * The `.accent-<key>` class nearest to an element, walking up from the
+ * element itself. Portaled surfaces (hover cards, dialogs) mount on
+ * `document.body`, outside the stack page's accent wrapper, so they read
+ * the class here and carry it along (alp82/aistack#298).
+ *
+ * Walks every ancestor: a utility such as `hover:text-accent-lime` on the
+ * way up is not a wrapper and must not stop the search.
+ */
+export function accentClassOf(
+	el: Element | null | undefined,
+): string | undefined {
+	for (let node = el; node; node = node.parentElement) {
+		for (const c of node.classList) {
+			if (ACCENT_CLASS.test(c)) return c;
+		}
+	}
+	return undefined;
+}


### PR DESCRIPTION
Closes #298. Part of #292.

\`HoverCard\` and \`Dialog\` portal into \`document.body\`, outside the \`.accent-<key>\` wrapper on the stack page, so the cost breakdown, token tips, and upvoters cards rendered in brand lime on a cyan stack.

- New \`src/lib/accentClassOf.ts\` walks an element's ancestors for the nearest \`accent-<key>\` class. It ignores utilities such as \`hover:text-accent-lime\` on the way up (a real page element tripped the first \`closest()\` version).
- \`HoverCard\` reads the class from its in-tree root and sets it on the portaled surface.
- \`Dialog\` keeps a hidden sentinel in the tree and wraps the portaled overlay in the class.
- Tests: hover-card surface carries the class, dialog overlay carries it, helper unit tests.

Verified with headless Chrome on a local stack for all 12 presets in dark and light: the surface's \`--accent-lime\` resolves to the preset's token every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UX3EwpV7eYAW4MNQsnzZ5