### PR TITLE
By harness: a harness with 0% is not measured

### DIFF
--- a/src/features/usage/__tests__/usage-section.test.tsx
+++ b/src/features/usage/__tests__/usage-section.test.tsx
@@ -237,6 +237,37 @@ describe("the days path", () => {
 		expect(within(list).getByText("Codex")).toBeInTheDocument();
 	});
 
+	it("does not count a harness with no tokens in the range as measured", () => {
+		const current = reading();
+		setup({
+			usage: usage({
+				current: {
+					...current,
+					harnesses: [
+						{
+							harness: "claude-code",
+							sessions: 0,
+							totalTokens: 0,
+							tokenShare: 0,
+						},
+						{
+							harness: "codex",
+							sessions: 20,
+							totalTokens: 100_000_000,
+							tokenShare: 1,
+						},
+					],
+				},
+			}),
+		});
+		fireEvent.click(screen.getByRole("tab", { name: /Harness/ }));
+		expect(screen.getByText("harness measured")).toBeInTheDocument();
+		expect(screen.queryByText("harnesses measured")).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("list", { name: "Harness token shares" }),
+		).not.toBeInTheDocument();
+	});
+
 	it("says when the range holds no day", () => {
 		setup({ usage: usage({ current: null, previous: null }) });
 		expect(

--- a/src/features/usage/items.tsx
+++ b/src/features/usage/items.tsx
@@ -214,7 +214,9 @@ function statItems(
 		compare((s) => s.subagentShare),
 	);
 
-	const harnesses =
+	// A harness with no tokens in the range is not measured: it neither counts
+	// nor draws a bar.
+	const harnesses = (
 		source.kind === "days"
 			? source.current.harnesses.map((h) => ({
 					name: h.harness,
@@ -223,7 +225,8 @@ function statItems(
 			: source.snapshot.harnesses.map((h) => ({
 					name: h.harness.name,
 					tokens: h.activity.totalTokens,
-				}));
+				}))
+	).filter((h) => h.tokens > 0);
 	const names = new Set(harnesses.map((h) => h.name));
 	if (names.size === 0) return;
 	items.set("harness", {


### PR DESCRIPTION
The By harness card counted every harness the range knew, so a harness with no tokens showed as measured with a 0.0% bar. The count and the rows now skip harnesses with no tokens in the range. Owner request on #307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UX3EwpV7eYAW4MNQsnzZ5