### PR TITLE
An old-CLI publish writes the legacy figure itself; the retirement migration needs no gate (alp82/aistack#321)

### DIFF
--- a/convex/lib/measuredDays.ts
+++ b/convex/lib/measuredDays.ts
@@ -18,6 +18,7 @@ import type { Infer } from 'convex/values'
 import type { Doc, Id } from '../_generated/dataModel'
 import type { MutationCtx, QueryCtx } from '../_generated/server'
 import type { MeasuredDayWire, MeasuredPayload, WorkflowWire } from '../schema'
+import { repriceSnapshot } from './reprice'
 import { sourceOrder, visibleSources } from './sources'
 import {
   MODEL_ID_MAX,
@@ -290,6 +291,34 @@ export async function measuredDaysForMachine(
     .collect()
 }
 
+export type LegacyFigure = NonNullable<Doc<'measuredInventory'>['legacy']>
+
+/**
+ * The 30-day totals of one payload as a LEGACY figure (ADR-0011): what a
+ * stack's page prints while it has no measured days. Written by the
+ * retirement migration for the snapshots it copies, and by every publish from
+ * a client that sends no day wire, so an old CLI keeps its stack readable.
+ */
+export function legacyOf(payload: Payload, publishCost: boolean): LegacyFigure {
+  const { cost } = repriceSnapshot({
+    models: payload.models,
+    window: payload.window,
+    publishedTable: payload.pricingTable,
+    publishCost,
+  })
+  return {
+    tokens: payload.activity.totalTokens,
+    sessions: payload.activity.sessions,
+    activeDays:
+      payload.schemaVersion === 2
+        ? payload.activity.activeDayDates.length
+        : payload.activity.activeDays,
+    ...(cost ? { usd: cost.lowerBoundUSD } : {}),
+    capturedAt: payload.capturedAt,
+    windowDays: payload.window.days,
+  }
+}
+
 export type UpsertInventoryArgs = {
   stackId: Id<'stacks'>
   machine: string | undefined
@@ -297,6 +326,8 @@ export type UpsertInventoryArgs = {
   capturedAt: number
   receivedAt: number
   cliVersion: string | undefined
+  /** Present on a publish that carries no day wire. Absent clears the field. */
+  legacy?: LegacyFigure
 }
 
 /**
@@ -327,6 +358,7 @@ export async function upsertInventory(
     inventory: args.payload.inventory,
     modelsSeen: [...new Set(args.payload.models.map((m) => m.id))].sort(),
     pricingTable: args.payload.pricingTable,
+    ...(args.legacy === undefined ? {} : { legacy: args.legacy }),
   }
   if (existing) {
     await ctx.db.replace(existing._id, doc)

--- a/convex/measured.ts
+++ b/convex/measured.ts
@@ -43,6 +43,7 @@ import {
   inventoryForStack,
   newestInventoryPerSource,
   storeMeasuredDays,
+  legacyOf,
   upsertInventory,
   workflowWireOf,
 } from './lib/measuredDays'
@@ -459,6 +460,9 @@ export const publishSnapshot = internalMutation({
       capturedAt: args.payload.capturedAt,
       receivedAt: inserted.receivedAt,
       cliVersion: undefined,
+      ...(args.measuredDays
+        ? {}
+        : { legacy: legacyOf(args.payload, stack.publishCost !== false) }),
     })
     await storeDayArgs(ctx, args, {
       stackId: args.stackId,
@@ -1951,6 +1955,9 @@ export const publishForToken = internalMutation({
       receivedAt = accepted.receivedAt
       // The live inventory row for this (machine, harness), replaced on every
       // sync (ADR-0011).
+      // A client that sends no day wire is an old CLI: its stack has no days
+      // to fold, so the payload's 30-day totals ride on the row as the legacy
+      // figure (ADR-0011). A client on the day wire clears it.
       await upsertInventory(ctx, {
         stackId: stack._id,
         machine: token.name,
@@ -1958,6 +1965,9 @@ export const publishForToken = internalMutation({
         capturedAt: payload.capturedAt,
         receivedAt,
         cliVersion,
+        ...(args.measuredDays
+          ? {}
+          : { legacy: legacyOf(payload, stack.publishCost !== false) }),
       })
     }
 

--- a/convex/measuredDays.test.ts
+++ b/convex/measuredDays.test.ts
@@ -369,6 +369,26 @@ describe('storing measured days', () => {
   })
 })
 
+describe('the legacy figure on the inventory row', () => {
+  test('a publish without a day wire writes it, and a day wire clears it', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seedStack(t)
+    const inventory = () => t.run((ctx) => ctx.db.query('measuredInventory').collect())
+
+    await publish(t, stackId, { machine: 'laptop' })
+    const legacy = (await inventory())[0]?.legacy
+    expect(legacy?.tokens).toBe(payload().activity.totalTokens)
+    expect(legacy?.sessions).toBe(payload().activity.sessions)
+    expect(legacy?.windowDays).toBe(payload().window.days)
+
+    await publish(t, stackId, {
+      machine: 'laptop',
+      measuredDays: dayWire([{ date: '2026-08-28', usage: usageDay() }]),
+    })
+    expect((await inventory())[0]?.legacy).toBeUndefined()
+  })
+})
+
 describe('the day manifest', () => {
   test('lists the machine’s dates with fingerprints, stable across an identical re-publish', async () => {
     const t = convexTest(schema, modules)

--- a/convex/migrations/20260829_retire_snapshots.test.ts
+++ b/convex/migrations/20260829_retire_snapshots.test.ts
@@ -126,12 +126,16 @@ async function day(t: Ctx, stackId: Id<'stacks'>, machine?: string) {
 
 const inventory = (t: Ctx) => t.run((ctx) => ctx.db.query('measuredInventory').collect())
 
-test('refuses while a living stack has no days, naming it', async () => {
+test('converts a living stack without days too: its old CLI keeps the figure current', async () => {
   const t = convexTest(schema, modules)
   const living = await seedStack(t)
-  await snapshot(t, living, { receivedAgo: DAY })
-  await expect(t.mutation(MIGRATION.run, {})).rejects.toThrow(/stack-1-sid1/)
-  expect(await inventory(t)).toHaveLength(0)
+  await snapshot(t, living, { receivedAgo: DAY, tokens: 5 })
+  expect(await t.mutation(MIGRATION.run, {})).toEqual({
+    inventoryWritten: 1,
+    legacyWritten: 1,
+    skipped: 0,
+  })
+  expect((await inventory(t))[0]?.legacy?.tokens).toBe(5)
 })
 
 test('copies the newest snapshot per source into a missing inventory row, with the legacy figure for a stack without days', async () => {

--- a/convex/migrations/20260829_retire_snapshots.ts
+++ b/convex/migrations/20260829_retire_snapshots.ts
@@ -1,8 +1,7 @@
 import { v } from 'convex/values'
 import type { Doc, Id } from '../_generated/dataModel'
 import { internalMutation, type MutationCtx } from '../_generated/server'
-import { measuredDaysForStack } from '../lib/measuredDays'
-import { repriceSnapshot } from '../lib/reprice'
+import { legacyOf, measuredDaysForStack } from '../lib/measuredDays'
 import { newestBySource } from '../lib/sources'
 
 /**
@@ -21,37 +20,15 @@ import { newestBySource } from '../lib/sources'
  * none exists yet (a source that synced on CLI 0.10 already has one, and that
  * row is never touched). A stack with no measured days gets the snapshot's
  * 30-day totals as a LEGACY figure on each of its inventory rows, so its page
- * still prints an approximate 30d reading. It REFUSES while any living stack
- * (a snapshot received in the last 7 days) has no days: such a machine converts
- * itself on its next session start, and only a stack that never syncs again
- * should fall back to the legacy figure.
+ * still prints an approximate 30d reading. A living stack on an old CLI needs
+ * no gate: every publish without a day wire rewrites the legacy figure from
+ * its own payload (`publishForToken`), and a machine that upgrades clears it
+ * by sending days.
  */
 
-const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
 const CLEAR_BATCH = 500
 
 type Snapshot = Doc<'measuredSnapshots'>
-
-function legacyOf(snapshot: Snapshot, publishCost: boolean) {
-  const p = snapshot.payload
-  const { cost } = repriceSnapshot({
-    models: p.models,
-    window: p.window,
-    publishedTable: p.pricingTable,
-    publishCost,
-  })
-  return {
-    tokens: p.activity.totalTokens,
-    sessions: p.activity.sessions,
-    activeDays:
-      p.schemaVersion === 2
-        ? p.activity.activeDayDates.length
-        : p.activity.activeDays,
-    ...(cost ? { usd: cost.lowerBoundUSD } : {}),
-    capturedAt: p.capturedAt,
-    windowDays: p.window.days,
-  }
-}
 
 async function inventoryRowFor(
   ctx: MutationCtx,
@@ -75,7 +52,6 @@ export const run = internalMutation({
     skipped: v.number(),
   }),
   handler: async (ctx) => {
-    const now = Date.now()
     const snapshots = await ctx.db.query('measuredSnapshots').collect()
     const byStack = new Map<Id<'stacks'>, Snapshot[]>()
     for (const row of snapshots) {
@@ -84,23 +60,10 @@ export const run = internalMutation({
       else byStack.set(row.stackId, [row])
     }
 
-    // The refusal comes first, before any row is written, so a partial run
-    // cannot leave one stack converted and the next one blocked.
-    const blocking: string[] = []
     const hasDays = new Map<Id<'stacks'>, boolean>()
-    for (const [stackId, rows] of byStack) {
+    for (const stackId of byStack.keys()) {
       const days = await measuredDaysForStack(ctx, stackId)
       hasDays.set(stackId, days.length > 0)
-      const newest = Math.max(...rows.map((r) => r.receivedAt))
-      if (now - newest <= SEVEN_DAYS_MS && days.length === 0) {
-        const stack = await ctx.db.get(stackId)
-        blocking.push(stack ? `${stack.slug}-${stack.shortId}` : String(stackId))
-      }
-    }
-    if (blocking.length > 0) {
-      throw new Error(
-        `Refusing to retire snapshots: living stacks without measured days: ${blocking.join(', ')}. Sync them on CLI 0.10 or wait for them to go quiet.`
-      )
     }
 
     let inventoryWritten = 0
@@ -121,7 +84,7 @@ export const run = internalMutation({
           snapshot.machine,
           snapshot.harness
         )
-        const legacy = stackHasDays ? undefined : legacyOf(snapshot, publishCost)
+        const legacy = stackHasDays ? undefined : legacyOf(snapshot.payload, publishCost)
         if (existing) {
           if (legacy !== undefined && existing.legacy === undefined) {
             await ctx.db.patch(existing._id, { legacy })


### PR DESCRIPTION
Follow-up to #322 (ticket #321). On prod, `rocinante` and one other machine sync from a CLI that sends no day wire; the retirement migration refused on them by design, and even after it wrote their legacy figure the next old-CLI sync would replace the inventory row and wipe it. Now `publishForToken` writes the legacy figure from the payload whenever no `measuredDays` wire is present (a day wire clears it), and the migration converts every stack with no refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UX3EwpV7eYAW4MNQsnzZ5