### PR TITLE
Legacy active days merge as the largest count, not a sum (alp82/aistack#321)

### DIFF
--- a/convex/measured.ts
+++ b/convex/measured.ts
@@ -2467,10 +2467,10 @@ export const getUsageByStackSlug = query({
         : {
             tokens: legacyRows.reduce((a, r) => a + (r.legacy?.tokens ?? 0), 0),
             sessions: legacyRows.reduce((a, r) => a + (r.legacy?.sessions ?? 0), 0),
-            activeDays: legacyRows.reduce(
-              (a, r) => a + (r.legacy?.activeDays ?? 0),
-              0
-            ),
+            // Tokens and sessions are disjoint across sources and sum. Active
+            // days are not: two harnesses on one machine share their days, so
+            // the merge is the largest count, a lower bound.
+            activeDays: Math.max(...legacyRows.map((r) => r.legacy?.activeDays ?? 0)),
             usd:
               publishCost && legacyRows.some((r) => r.legacy?.usd !== undefined)
                 ? round2(legacyRows.reduce((a, r) => a + (r.legacy?.usd ?? 0), 0))

--- a/convex/measuredDays.test.ts
+++ b/convex/measuredDays.test.ts
@@ -387,6 +387,23 @@ describe('the legacy figure on the inventory row', () => {
     })
     expect((await inventory())[0]?.legacy).toBeUndefined()
   })
+
+  test('the read sums tokens and sessions across sources and takes the largest active-day count', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, slug } = await seedStack(t)
+    const withDays = (over: Partial<StoredPayload>, activeDays: number): StoredPayload => {
+      const base = payload(over)
+      return { ...base, activity: { ...base.activity, activeDays } } as StoredPayload
+    }
+    await publish(t, stackId, { machine: 'laptop', payload: withDays({}, 2) })
+    await publish(t, stackId, {
+      machine: 'laptop',
+      payload: withDays({ harness: { ...payload().harness, name: 'codex' } }, 3),
+    })
+    const read = await t.query(api.measured.getUsageByStackSlug, { slug })
+    expect(read?.legacy?.activeDays).toBe(3)
+    expect(read?.legacy?.sessions).toBe(payload().activity.sessions * 2)
+  })
 })
 
 describe('the day manifest', () => {


### PR DESCRIPTION
Follow-up to #324 (ticket #321). The legacy figure summed active days across harness rows on one machine and printed 82 of 30 on prod. Days overlap across harnesses, so the merge is the largest count, a lower bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UX3EwpV7eYAW4MNQsnzZ5