### PR TITLE
Build and secure the Discord interactions endpoint (alp82/aistack#229)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ BETTER_AUTH_SECRET=
 BETTER_AUTH_URL=http://localhost:3019
 APP_URL=http://localhost:3019
 
+# Discord bot. The app's public key from the Developer Portal, hex. Set it on
+# the Convex deployment; the interactions endpoint answers 503 without it.
+DISCORD_PUBLIC_KEY=
+
 # SSO
 GOOGLE_OAUTH_CLIENT_ID= 
 GOOGLE_OAUTH_CLIENT_SECRET= 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -19,6 +19,7 @@ import type * as cliSessions from "../cliSessions.js";
 import type * as cliTokens from "../cliTokens.js";
 import type * as creators from "../creators.js";
 import type * as crons from "../crons.js";
+import type * as discordInteractions from "../discordInteractions.js";
 import type * as discordLink from "../discordLink.js";
 import type * as discordLinkToken from "../discordLinkToken.js";
 import type * as email from "../email.js";
@@ -112,6 +113,7 @@ declare const fullApi: ApiFromModules<{
   cliTokens: typeof cliTokens;
   creators: typeof creators;
   crons: typeof crons;
+  discordInteractions: typeof discordInteractions;
   discordLink: typeof discordLink;
   discordLinkToken: typeof discordLinkToken;
   email: typeof email;

--- a/convex/discordInteractions.test.ts
+++ b/convex/discordInteractions.test.ts
@@ -1,0 +1,271 @@
+/// <reference types="vite/client" />
+import { convexTest } from 'convex-test'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import { internal } from './_generated/api'
+import schema from './schema'
+import {
+  DISCORD_USER_MAX_REQUESTS,
+  INTERACTIONS_PATH,
+  verifyDiscordSignature,
+} from './discordInteractions'
+import { bytesToHex, encodeUtf8 } from './lib/webCrypto'
+
+/**
+ * The Discord interactions endpoint - wayfinder #229 (map #199).
+ *
+ * The tests run the real `httpAction` through `t.fetch` with bodies signed by
+ * a key generated per test, because the property under test lives at the HTTP
+ * edge: an unsigned or mis-signed body must never reach a handler.
+ */
+
+const modules = import.meta.glob('./**/*.{js,ts}')
+
+type Ctx = Awaited<ReturnType<typeof convexTest>>
+
+const savedEnv = {
+  DISCORD_PUBLIC_KEY: process.env.DISCORD_PUBLIC_KEY,
+  BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
+  APP_URL: process.env.APP_URL,
+}
+
+let keyPair: CryptoKeyPair
+
+async function generateKeyPair(): Promise<{ pair: CryptoKeyPair; publicKeyHex: string }> {
+  const pair = (await crypto.subtle.generateKey('Ed25519', true, [
+    'sign',
+    'verify',
+  ])) as CryptoKeyPair
+  const raw = await crypto.subtle.exportKey('raw', pair.publicKey)
+  return { pair, publicKeyHex: bytesToHex(raw) }
+}
+
+async function sign(body: string, timestamp: string, key = keyPair.privateKey) {
+  const signature = await crypto.subtle.sign(
+    'Ed25519',
+    key,
+    encodeUtf8(`${timestamp}${body}`),
+  )
+  return bytesToHex(signature)
+}
+
+async function post(
+  t: Ctx,
+  body: string,
+  opts: { timestamp?: string; signature?: string } = {},
+) {
+  const timestamp = opts.timestamp ?? String(Math.floor(Date.now() / 1000))
+  const signature = opts.signature ?? (await sign(body, timestamp))
+  return await t.fetch(INTERACTIONS_PATH, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Signature-Ed25519': signature,
+      'X-Signature-Timestamp': timestamp,
+    },
+    body,
+  })
+}
+
+function command(
+  name: string,
+  options: Array<{ name: string; type: number; value: string | number | boolean }> = [],
+  userId = '105048063873126400',
+) {
+  return JSON.stringify({
+    id: '1',
+    application_id: '1540381573243736116',
+    type: 2,
+    token: 'interaction-token',
+    data: { id: '2', name, type: 1, options },
+    member: { user: { id: userId } },
+  })
+}
+
+beforeEach(async () => {
+  const generated = await generateKeyPair()
+  keyPair = generated.pair
+  process.env.DISCORD_PUBLIC_KEY = generated.publicKeyHex
+  process.env.BETTER_AUTH_SECRET = 'discord-link-test-secret-at-least-32-characters'
+  process.env.APP_URL = 'https://aistack.test'
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  for (const [name, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+})
+
+test('verifyDiscordSignature accepts a valid signature and rejects a tampered body', async () => {
+  const body = '{"type":1}'
+  const timestamp = '1700000000'
+  const signature = await sign(body, timestamp)
+  const publicKeyHex = process.env.DISCORD_PUBLIC_KEY as string
+
+  await expect(
+    verifyDiscordSignature(publicKeyHex, signature, timestamp, body),
+  ).resolves.toBe(true)
+  await expect(
+    verifyDiscordSignature(publicKeyHex, signature, timestamp, '{"type":2}'),
+  ).resolves.toBe(false)
+  await expect(
+    verifyDiscordSignature(publicKeyHex, signature, '1700000001', body),
+  ).resolves.toBe(false)
+  await expect(
+    verifyDiscordSignature('not-hex', signature, timestamp, body),
+  ).resolves.toBe(false)
+  await expect(
+    verifyDiscordSignature(publicKeyHex, 'zz', timestamp, body),
+  ).resolves.toBe(false)
+})
+
+test('a registration ping answers pong', async () => {
+  const t = convexTest(schema, modules)
+  const res = await post(t, '{"type":1}')
+  expect(res.status).toBe(200)
+  expect(await res.json()).toEqual({ type: 1 })
+})
+
+test('a missing, malformed, or foreign signature is refused with 401 before parsing', async () => {
+  const t = convexTest(schema, modules)
+  const body = '{"type":1}'
+
+  const unsigned = await t.fetch(INTERACTIONS_PATH, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  })
+  expect(unsigned.status).toBe(401)
+
+  const garbage = await post(t, body, { signature: 'not-a-signature' })
+  expect(garbage.status).toBe(401)
+
+  const other = await generateKeyPair()
+  const timestamp = '1700000000'
+  const foreign = await post(t, body, {
+    timestamp,
+    signature: await sign(body, timestamp, other.pair.privateKey),
+  })
+  expect(foreign.status).toBe(401)
+
+  // Even an unparseable body is refused by signature first, never by parse.
+  const notJson = await t.fetch(INTERACTIONS_PATH, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: 'not json',
+  })
+  expect(notJson.status).toBe(401)
+})
+
+test('a signed but unparseable body is a 400', async () => {
+  const t = convexTest(schema, modules)
+  const res = await post(t, 'not json')
+  expect(res.status).toBe(400)
+})
+
+test('the endpoint answers 503 when the public key is not configured', async () => {
+  delete process.env.DISCORD_PUBLIC_KEY
+  const t = convexTest(schema, modules)
+  const res = await t.fetch(INTERACTIONS_PATH, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: '{"type":1}',
+  })
+  expect(res.status).toBe(503)
+})
+
+test('a slash command defers within the request and schedules the reply patch', async () => {
+  vi.useFakeTimers()
+  const t = convexTest(schema, modules)
+  const fetchMock = vi.fn(async () => new Response(null, { status: 200 }))
+  vi.stubGlobal('fetch', fetchMock)
+
+  const res = await post(t, command('link'))
+  expect(res.status).toBe(200)
+  // /link is ephemeral, and the deferral is where the flag has to be set.
+  expect(await res.json()).toEqual({ type: 5, data: { flags: 64 } })
+
+  await t.finishAllScheduledFunctions(vi.runAllTimers)
+
+  expect(fetchMock).toHaveBeenCalledTimes(1)
+  const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+  expect(url).toBe(
+    'https://discord.com/api/v10/webhooks/1540381573243736116/interaction-token/messages/@original',
+  )
+  expect(init.method).toBe('PATCH')
+  const patched = JSON.parse(init.body as string)
+  expect(patched.embeds[0].title).toBe('Link your aistack account')
+  expect(patched.components[0].components[0].url).toMatch(
+    /^https:\/\/aistack\.test\/link\/discord\?token=/,
+  )
+})
+
+test('an unknown command patches an ephemeral error and never throws', async () => {
+  vi.useFakeTimers()
+  const t = convexTest(schema, modules)
+  const fetchMock = vi.fn(async () => new Response(null, { status: 200 }))
+  vi.stubGlobal('fetch', fetchMock)
+
+  const res = await post(t, command('nope'))
+  expect(await res.json()).toEqual({ type: 5, data: { flags: 64 } })
+  await t.finishAllScheduledFunctions(vi.runAllTimers)
+
+  const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+  expect(JSON.parse(init.body as string).content).toMatch(/Unknown command/)
+})
+
+test('a handler failure patches a fallback message instead of leaving the deferral hanging', async () => {
+  vi.useFakeTimers()
+  delete process.env.BETTER_AUTH_SECRET // makes /link throw inside the handler
+  const t = convexTest(schema, modules)
+  const fetchMock = vi.fn(async () => new Response(null, { status: 200 }))
+  vi.stubGlobal('fetch', fetchMock)
+
+  await post(t, command('link'))
+  await t.finishAllScheduledFunctions(vi.runAllTimers)
+
+  expect(fetchMock).toHaveBeenCalledTimes(1)
+  const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+  expect(JSON.parse(init.body as string).content).toMatch(/did not answer/)
+})
+
+test('a user over the per-minute cap gets an ephemeral reply and no scheduled work', async () => {
+  vi.useFakeTimers()
+  const t = convexTest(schema, modules)
+  const fetchMock = vi.fn(async () => new Response(null, { status: 200 }))
+  vi.stubGlobal('fetch', fetchMock)
+
+  for (let index = 0; index < DISCORD_USER_MAX_REQUESTS; index++) {
+    const res = await post(t, command('link'))
+    expect((await res.json()).type).toBe(5)
+  }
+  const limited = await post(t, command('link'))
+  expect(limited.status).toBe(200)
+  const body = await limited.json()
+  expect(body.type).toBe(4)
+  expect(body.data.flags).toBe(64)
+  expect(body.data.content).toMatch(/Too many commands/)
+
+  // Another user is unaffected: the bucket is per Discord user.
+  const other = await post(t, command('link', [], '105048063873126401'))
+  expect((await other.json()).type).toBe(5)
+
+  await t.finishAllScheduledFunctions(vi.runAllTimers)
+  expect(fetchMock).toHaveBeenCalledTimes(DISCORD_USER_MAX_REQUESTS + 1)
+})
+
+test('component and autocomplete interactions get a harmless answer', async () => {
+  const t = convexTest(schema, modules)
+  const component = await post(t, JSON.stringify({ type: 3, token: 'x', application_id: '1' }))
+  expect((await component.json()).type).toBe(4)
+  const autocomplete = await post(t, JSON.stringify({ type: 4, token: 'x', application_id: '1' }))
+  expect(await autocomplete.json()).toEqual({ type: 8, data: { choices: [] } })
+})
+
+test('the fulfill action is unreachable from the public API', async () => {
+  // Compile-time: `internal.discordInteractions.fulfill` exists and there is
+  // no `api.discordInteractions.fulfill`. The reference below is the check.
+  expect(internal.discordInteractions.fulfill).toBeDefined()
+})

--- a/convex/discordInteractions.ts
+++ b/convex/discordInteractions.ts
@@ -1,0 +1,294 @@
+import { v } from 'convex/values'
+import { internal } from './_generated/api'
+import { httpAction, internalAction } from './_generated/server'
+import type { ActionCtx } from './_generated/server'
+import { SHARED_BUCKET_MAX_REQUESTS } from './rateLimit'
+import { encodeUtf8, hexToBytes } from './lib/webCrypto'
+
+/**
+ * The Discord interactions endpoint (wayfinder #229, map #199).
+ *
+ * Discord POSTs every slash command here. The handler runs in three steps,
+ * each bounded by a Discord rule:
+ *
+ * 1. Verify the Ed25519 signature over `timestamp + raw body` BEFORE parsing.
+ *    Discord probes the endpoint with bad signatures and removes one that
+ *    answers anything but 401.
+ * 2. Answer inside the 3-second window: PONG for the registration ping, and a
+ *    deferred response (type 5) for a command. The deferral is the only place
+ *    the ephemeral flag can be set, so a command declares it up front.
+ * 3. A scheduled action computes the reply and PATCHes `@original` through the
+ *    webhook, well inside the 15-minute token life.
+ *
+ * Commands plug in through `COMMANDS`. The stack, tokens, leaderboard, and
+ * model commands land on their own tickets (#226, #223); `/link` is here
+ * because its reply already exists.
+ */
+
+export const INTERACTIONS_PATH = '/api/discord/interactions'
+
+/** Slash commands one Discord user may run per minute. */
+export const DISCORD_USER_MAX_REQUESTS = 20
+
+const DISCORD_API = 'https://discord.com/api/v10'
+const EPHEMERAL = 64
+
+const InteractionType = {
+  PING: 1,
+  APPLICATION_COMMAND: 2,
+  MESSAGE_COMPONENT: 3,
+  APPLICATION_COMMAND_AUTOCOMPLETE: 4,
+} as const
+
+const CallbackType = {
+  PONG: 1,
+  CHANNEL_MESSAGE_WITH_SOURCE: 4,
+  DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE: 5,
+  AUTOCOMPLETE_RESULT: 8,
+} as const
+
+const OptionValue = v.union(v.string(), v.number(), v.boolean())
+const CommandOption = v.object({ name: v.string(), value: OptionValue })
+
+export type CommandOption = { name: string; value: string | number | boolean }
+
+/** What a command handler receives: the parsed, already-verified call. */
+export interface CommandCall {
+  discordUserId: string
+  options: CommandOption[]
+}
+
+/** A Discord message payload, as sent to the webhook PATCH. */
+export type ReplyData = Record<string, unknown>
+
+interface CommandSpec {
+  /** Set at deferral time, because a deferral fixes the reply's visibility. */
+  ephemeral: boolean
+  reply: (ctx: ActionCtx, call: CommandCall) => Promise<ReplyData>
+}
+
+/** The command registry. Later tickets add their entries here. */
+const COMMANDS: Record<string, CommandSpec> = {
+  link: {
+    ephemeral: true,
+    reply: async (ctx, call) =>
+      await ctx.runAction(internal.discordLink.createCommandResponse, {
+        discordUserId: call.discordUserId,
+      }),
+  },
+}
+
+const FALLBACK_REPLY: ReplyData = {
+  flags: EPHEMERAL,
+  content: 'The site did not answer. Try again in a minute.',
+}
+
+export function optionValue(
+  options: CommandOption[],
+  name: string,
+): string | number | boolean | undefined {
+  return options.find((option) => option.name === name)?.value
+}
+
+/**
+ * Verify Discord's Ed25519 signature over `timestamp + rawBody`.
+ *
+ * Every input is untrusted. Malformed hex, a key of the wrong length, and a
+ * runtime without Ed25519 all return false rather than throw.
+ */
+export async function verifyDiscordSignature(
+  publicKeyHex: string,
+  signatureHex: string,
+  timestamp: string,
+  rawBody: string,
+): Promise<boolean> {
+  if (!/^[0-9a-f]{64}$/i.test(publicKeyHex)) return false
+  if (!/^[0-9a-f]{128}$/i.test(signatureHex)) return false
+  try {
+    const key = await crypto.subtle.importKey(
+      'raw',
+      hexToBytes(publicKeyHex),
+      { name: 'Ed25519' },
+      false,
+      ['verify'],
+    )
+    return await crypto.subtle.verify(
+      'Ed25519',
+      key,
+      hexToBytes(signatureHex),
+      encodeUtf8(`${timestamp}${rawBody}`),
+    )
+  } catch {
+    return false
+  }
+}
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function message(content: string): Response {
+  return json(200, {
+    type: CallbackType.CHANNEL_MESSAGE_WITH_SOURCE,
+    data: { flags: EPHEMERAL, content },
+  })
+}
+
+interface RawInteraction {
+  type?: number
+  application_id?: string
+  token?: string
+  data?: {
+    name?: string
+    options?: Array<{ name?: string; value?: unknown }>
+  }
+  member?: { user?: { id?: string } }
+  user?: { id?: string }
+}
+
+function parseOptions(raw: RawInteraction['data']): CommandOption[] {
+  const options: CommandOption[] = []
+  for (const option of raw?.options ?? []) {
+    if (typeof option.name !== 'string') continue
+    const value = option.value
+    if (
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean'
+    ) {
+      options.push({ name: option.name, value })
+    }
+  }
+  return options
+}
+
+export const interactions = httpAction(async (ctx, request) => {
+  const publicKey = process.env.DISCORD_PUBLIC_KEY
+  if (!publicKey) return json(503, { error: 'Discord is not configured' })
+
+  const rawBody = await request.text()
+  const signature = request.headers.get('x-signature-ed25519') ?? ''
+  const timestamp = request.headers.get('x-signature-timestamp') ?? ''
+  if (!(await verifyDiscordSignature(publicKey, signature, timestamp, rawBody))) {
+    return json(401, { error: 'invalid request signature' })
+  }
+
+  let interaction: RawInteraction
+  try {
+    interaction = JSON.parse(rawBody) as RawInteraction
+  } catch {
+    return json(400, { error: 'invalid JSON' })
+  }
+
+  if (interaction.type === InteractionType.PING) {
+    return json(200, { type: CallbackType.PONG })
+  }
+
+  if (interaction.type === InteractionType.APPLICATION_COMMAND_AUTOCOMPLETE) {
+    return json(200, { type: CallbackType.AUTOCOMPLETE_RESULT, data: { choices: [] } })
+  }
+
+  if (interaction.type !== InteractionType.APPLICATION_COMMAND) {
+    return message('This app only answers slash commands.')
+  }
+
+  const discordUserId = interaction.member?.user?.id ?? interaction.user?.id
+  const command = interaction.data?.name
+  const applicationId = interaction.application_id
+  const token = interaction.token
+  if (!discordUserId || !command || !applicationId || !token) {
+    return json(400, { error: 'incomplete interaction' })
+  }
+
+  // Abuse limits. One bucket per Discord user, and one app-wide bucket that
+  // bounds a flood from many users. Interaction responses are exempt from
+  // Discord's global rate limit, so the reply is a message, not a 429.
+  const perUser = await ctx.runMutation(internal.rateLimit.checkRateLimit, {
+    key: `discord-user:${discordUserId}`,
+    limit: DISCORD_USER_MAX_REQUESTS,
+  })
+  if (!perUser.allowed) {
+    return message(
+      `Too many commands. Try again in ${perUser.retryAfterSeconds} seconds.`,
+    )
+  }
+  const shared = await ctx.runMutation(internal.rateLimit.checkRateLimit, {
+    key: 'discord-app:all',
+    limit: SHARED_BUCKET_MAX_REQUESTS,
+  })
+  if (!shared.allowed) {
+    return message(
+      `The bot is busy. Try again in ${shared.retryAfterSeconds} seconds.`,
+    )
+  }
+
+  const ephemeral = COMMANDS[command]?.ephemeral ?? true
+  await ctx.scheduler.runAfter(0, internal.discordInteractions.fulfill, {
+    applicationId,
+    token,
+    command,
+    discordUserId,
+    options: parseOptions(interaction.data),
+  })
+
+  return json(200, {
+    type: CallbackType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,
+    data: ephemeral ? { flags: EPHEMERAL } : {},
+  })
+})
+
+/**
+ * Compute the reply and patch it into the deferred message.
+ *
+ * A thrown handler still patches: the alternative is a "did not respond"
+ * message from Discord fifteen minutes later.
+ */
+export const fulfill = internalAction({
+  args: {
+    applicationId: v.string(),
+    token: v.string(),
+    command: v.string(),
+    discordUserId: v.string(),
+    options: v.array(CommandOption),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const spec = COMMANDS[args.command]
+    let data: ReplyData
+    if (!spec) {
+      data = { flags: EPHEMERAL, content: `Unknown command: /${args.command}` }
+    } else {
+      try {
+        data = await spec.reply(ctx, {
+          discordUserId: args.discordUserId,
+          options: args.options,
+        })
+      } catch (error) {
+        console.error(`discord /${args.command} failed`, error)
+        data = FALLBACK_REPLY
+      }
+    }
+    await patchOriginal(args.applicationId, args.token, data)
+    return null
+  },
+})
+
+/** PATCH the deferred reply. The webhook route needs no bot token. */
+export async function patchOriginal(
+  applicationId: string,
+  token: string,
+  data: ReplyData,
+): Promise<void> {
+  const url = `${DISCORD_API}/webhooks/${applicationId}/${token}/messages/@original`
+  const res = await fetch(url, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) {
+    console.error(`discord patch failed: ${res.status} ${await res.text()}`)
+  }
+}

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -11,6 +11,7 @@ import {
   syncPublish,
 } from './httpCli'
 import { unsubscribe } from './emailUnsubscribe'
+import { INTERACTIONS_PATH, interactions } from './discordInteractions'
 
 const http = httpRouter()
 
@@ -26,5 +27,6 @@ http.route({ path: '/api/cli/sync-manifest', method: 'GET', handler: syncManifes
 http.route({ path: '/api/cli/auto-sync', method: 'POST', handler: autoSyncSet })
 http.route({ path: '/api/email/unsubscribe', method: 'GET', handler: unsubscribe })
 http.route({ path: '/api/email/unsubscribe', method: 'POST', handler: unsubscribe })
+http.route({ path: INTERACTIONS_PATH, method: 'POST', handler: interactions })
 
 export default http


### PR DESCRIPTION
Closes #229. Part of map #199.

## What

- \`POST /api/discord/interactions\` (\`convex/discordInteractions.ts\`): verifies the Ed25519 signature over \`timestamp + raw body\` with \`crypto.subtle\` before any parse (401 on failure, 503 when \`DISCORD_PUBLIC_KEY\` is unset), answers PING with PONG, and defers a slash command (type 5) inside the 3-second window. The deferral carries the ephemeral flag when the command declares it.
- \`fulfill\` (\`internalAction\`) computes the reply and PATCHes \`webhooks/{app}/{token}/messages/@original\`. A handler that throws still patches a fallback message.
- Abuse limits reuse \`rateLimit.consume\`: 20 commands per Discord user per minute, plus one app-wide bucket at the shared cap. Over the cap, the reply is an ephemeral message, not a 429.
- Commands plug into one \`COMMANDS\` table. \`/link\` is the first entry (it reuses \`discordLink.createCommandResponse\`). #226 and #223 add the rest.
- \`DISCORD_PUBLIC_KEY\` documented in \`.env.example\`. It has to be set on the prod deployment before the endpoint URL is registered (#228).

## Verified

- 11 new tests through \`t.fetch\` with per-test generated keys; full convex project green (43 files).
- Live probe against the local Convex runtime: ping 200 PONG, bad signature 401, \`/link\` 200 type 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UX3EwpV7eYAW4MNQsnzZ5