### PR TITLE
Build the /stack and /tokens Discord commands (#226)

### DIFF
--- a/convex/discordCommands.test.ts
+++ b/convex/discordCommands.test.ts
@@ -1,0 +1,316 @@
+/// <reference types="vite/client" />
+import { convexTest } from 'convex-test'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { Infer } from 'convex/values'
+import { internal } from './_generated/api'
+import type { Id } from './_generated/dataModel'
+import schema, { UsageDay } from './schema'
+import { INTERACTIONS_PATH } from './discordInteractions'
+import { bytesToHex, encodeUtf8 } from './lib/webCrypto'
+
+/**
+ * The /stack and /tokens commands - wayfinder #226 (map #199).
+ *
+ * The embeds are the ones the showcase (#181) proved. The tests seed real
+ * rows and run the commands through the endpoint, because the visibility
+ * rule lives there: an error state answers inside the request as an
+ * ephemeral message, a good reply defers publicly and patches in.
+ */
+
+const modules = import.meta.glob('./**/*.{js,ts}')
+type Ctx = Awaited<ReturnType<typeof convexTest>>
+type UsageDayDoc = Infer<typeof UsageDay>
+
+const LINKED_USER = '105048063873126400'
+const STRANGER = '205048063873126400'
+const NOW = Date.parse('2026-08-29T12:00:00Z')
+
+const savedEnv = {
+  DISCORD_PUBLIC_KEY: process.env.DISCORD_PUBLIC_KEY,
+  APP_URL: process.env.APP_URL,
+}
+let keyPair: CryptoKeyPair
+
+async function post(t: Ctx, body: string) {
+  const timestamp = '1700000000'
+  const signature = bytesToHex(
+    await crypto.subtle.sign('Ed25519', keyPair.privateKey, encodeUtf8(`${timestamp}${body}`)),
+  )
+  return await t.fetch(INTERACTIONS_PATH, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Signature-Ed25519': signature,
+      'X-Signature-Timestamp': timestamp,
+    },
+    body,
+  })
+}
+
+function command(name: string, userId: string, slug?: string) {
+  return JSON.stringify({
+    id: '1',
+    application_id: '1540381573243736116',
+    type: 2,
+    token: 'interaction-token',
+    data: {
+      id: '2',
+      name,
+      type: 1,
+      options: slug === undefined ? [] : [{ name: 'stack', type: 3, value: slug }],
+    },
+    member: { user: { id: userId } },
+  })
+}
+
+function usageDay(model: string, input: number, usd?: number, harness = 'claude-code'): UsageDayDoc {
+  return {
+    harnesses: [
+      {
+        harness,
+        sessions: 2,
+        projectKeys: ['AAAAAAAAAAAAAAAAAAAAAA'],
+        models: [
+          {
+            model,
+            tokens: { input, output: 0, cacheWrite: 0, cacheRead: 0 },
+            ...(usd === undefined ? {} : { usd, pricingTable: 'anthropic-list-2026-07-25' }),
+          },
+        ],
+        subagentTokens: 0,
+        excludedTokens: { unpriced: 0, synthetic: 0 },
+      },
+    ],
+  }
+}
+
+async function seed(t: Ctx, over: { publishCost?: boolean; published?: boolean } = {}) {
+  return await t.run(async (ctx) => {
+    const creatorId = await ctx.db.insert('creators', {
+      name: 'Alper',
+      slug: 'alper',
+      userId: 'user_alper',
+      discordUserId: LINKED_USER,
+      verified: false,
+      personalPages: [],
+      projectPages: [],
+      createdAt: NOW,
+    })
+    const stackId = await ctx.db.insert('stacks', {
+      name: "Alper's Agent Stack",
+      slug: 'alpers-agent-stack',
+      shortId: 'unw0sl',
+      creatorId,
+      oneLiner: 'A stack',
+      toolSubscriptions: [],
+      hasUsageComponent: false,
+      published: over.published ?? true,
+      publishCost: over.publishCost,
+      createdAt: NOW,
+      updatedAt: NOW,
+    })
+    await ctx.db.insert('models', {
+      name: 'Claude Opus 5',
+      slug: 'claude-opus-5',
+      shortId: 'sidopus5',
+      provider: 'Anthropic',
+      category: 'coding',
+      reviewStatus: 'approved',
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    return { stackId }
+  })
+}
+
+async function seedDays(t: Ctx, stackId: Id<'stacks'>) {
+  await t.run(async (ctx) => {
+    const days = [
+      { date: '2026-08-27', usage: usageDay('claude-opus-5', 3_000_000_000, 3_000) },
+      { date: '2026-08-28', usage: usageDay('claude-opus-5', 1_000_000_000, 1_000) },
+      { date: '2026-08-28', usage: usageDay('gpt-5.6-sol', 500_000_000, 380, 'codex') },
+    ]
+    for (const day of days) {
+      await ctx.db.insert('measuredDays', {
+        stackId,
+        machine: 'laptop',
+        date: day.date,
+        capturedAt: NOW,
+        receivedAt: NOW - 24 * 60 * 60 * 1000,
+        aggregateVersion: 'measured-days/v1',
+        fingerprint: `${day.date}-${day.usage.harnesses[0]?.harness}`,
+        usage: day.usage,
+      })
+    }
+  })
+}
+
+async function patchedReply(t: Ctx, body: string) {
+  const fetchMock = vi.fn(async () => new Response(null, { status: 200 }))
+  vi.stubGlobal('fetch', fetchMock)
+  const res = await post(t, body)
+  const deferral = await res.json()
+  await t.finishAllScheduledFunctions(vi.runAllTimers)
+  const call = fetchMock.mock.calls[0] as unknown as [string, RequestInit] | undefined
+  return { deferral, patched: call ? JSON.parse(call[1].body as string) : null }
+}
+
+beforeEach(async () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+  keyPair = (await crypto.subtle.generateKey('Ed25519', true, ['sign', 'verify'])) as CryptoKeyPair
+  process.env.DISCORD_PUBLIC_KEY = bytesToHex(
+    await crypto.subtle.exportKey('raw', keyPair.publicKey),
+  )
+  process.env.APP_URL = 'https://aistack.test'
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  for (const [name, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+})
+
+describe('/stack', () => {
+  test('posts the stack card publicly for a slug argument', async () => {
+    const t = convexTest(schema, modules)
+    await seed(t)
+    const { deferral, patched } = await patchedReply(
+      t,
+      command('stack', STRANGER, 'alpers-agent-stack-unw0sl'),
+    )
+    expect(deferral).toEqual({ type: 5, data: {} })
+    expect(patched).toEqual({
+      embeds: [
+        {
+          title: "Alper's Agent Stack",
+          url: 'https://aistack.test/stacks/alpers-agent-stack-unw0sl',
+          color: 0xa3e635,
+          image: { url: `https://aistack.test/api/og/stack/alpers-agent-stack-unw0sl?v=${NOW}` },
+        },
+      ],
+      components: [
+        {
+          type: 1,
+          components: [
+            {
+              type: 2,
+              style: 5,
+              label: 'View stack',
+              url: 'https://aistack.test/stacks/alpers-agent-stack-unw0sl',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  test('with no argument uses the linked account\'s own stack', async () => {
+    const t = convexTest(schema, modules)
+    await seed(t)
+    const { patched } = await patchedReply(t, command('stack', LINKED_USER))
+    expect(patched.embeds[0].title).toBe("Alper's Agent Stack")
+  })
+
+  test('with no argument and no linked account answers the unlinked prompt, ephemeral, inside the request', async () => {
+    const t = convexTest(schema, modules)
+    await seed(t)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const res = await post(t, command('stack', STRANGER))
+    const body = await res.json()
+    expect(body.type).toBe(4)
+    expect(body.data.flags).toBe(64)
+    expect(body.data.content).toMatch(/Run `\/link`/)
+    await t.finishAllScheduledFunctions(vi.runAllTimers)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test('an unknown or unpublished slug answers the unknown-stack error, ephemeral', async () => {
+    const t = convexTest(schema, modules)
+    await seed(t, { published: false })
+    for (const slug of ['my-cool-stack', 'alpers-agent-stack-unw0sl']) {
+      const res = await post(t, command('stack', STRANGER, slug))
+      const body = await res.json()
+      expect(body.type).toBe(4)
+      expect(body.data.flags).toBe(64)
+      expect(body.data.content).toContain(`No stack matches "${slug}"`)
+    }
+  })
+})
+
+describe('/tokens', () => {
+  test('posts the measured numbers with spend where the stack consented', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seed(t)
+    await seedDays(t, stackId)
+    const { deferral, patched } = await patchedReply(
+      t,
+      command('tokens', STRANGER, 'alpers-agent-stack-unw0sl'),
+    )
+    expect(deferral).toEqual({ type: 5, data: {} })
+    const embed = patched.embeds[0]
+    expect(embed.title).toBe("Alper's Agent Stack · measured, last 30 days")
+    expect(embed.url).toBe('https://aistack.test/stacks/alpers-agent-stack-unw0sl')
+    expect(embed.fields).toEqual([
+      { name: 'Tokens', value: '`4.50B` on `2` active days', inline: true },
+      { name: 'Synced', value: 'yesterday', inline: true },
+      {
+        name: 'Models',
+        value: 'Claude Opus 5 `89%` of tokens. 1 more model shares the rest.',
+      },
+      { name: 'Harnesses', value: 'Claude Code + Codex' },
+      { name: 'Spend', value: '`$4,380` · `100%` of tokens priced' },
+    ])
+    expect(embed.footer.text).toBe(
+      "Counted on the builder's machine, published by them. Prices: anthropic-list-2026-07-25.",
+    )
+    expect(patched.components[0].components[0].label).toBe('View stack')
+  })
+
+  test('prints no dollar figure when publishCost is off', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seed(t, { publishCost: false })
+    await seedDays(t, stackId)
+    const { patched } = await patchedReply(t, command('tokens', LINKED_USER))
+    const names = patched.embeds[0].fields.map((f: { name: string }) => f.name)
+    expect(names).toEqual(['Tokens', 'Synced', 'Models', 'Harnesses'])
+    expect(JSON.stringify(patched)).not.toContain('$')
+    expect(patched.embeds[0].footer.text).toBe(
+      "Counted on the builder's machine, published by them.",
+    )
+  })
+
+  test('a stack with no measured history answers the no-data error, ephemeral', async () => {
+    const t = convexTest(schema, modules)
+    await seed(t)
+    const res = await post(t, command('tokens', STRANGER, 'alpers-agent-stack-unw0sl'))
+    const body = await res.json()
+    expect(body.type).toBe(4)
+    expect(body.data.flags).toBe(64)
+    expect(body.data.content).toContain('no measured history')
+  })
+
+  test('with no argument and no linked account answers the unlinked prompt', async () => {
+    const t = convexTest(schema, modules)
+    await seed(t)
+    const res = await post(t, command('tokens', STRANGER))
+    const body = await res.json()
+    expect(body.data.flags).toBe(64)
+    expect(body.data.content).toMatch(/Run `\/link`/)
+  })
+})
+
+describe('resolveStack', () => {
+  test('a linked user whose stack is unpublished is told so, not sent to /link', async () => {
+    const t = convexTest(schema, modules)
+    await seed(t, { published: false })
+    const result = await t.query(internal.discordStack.resolveStack, {
+      discordUserId: LINKED_USER,
+    })
+    expect(result).toEqual({ kind: 'unpublished' })
+  })
+})

--- a/convex/discordCommands.ts
+++ b/convex/discordCommands.ts
@@ -1,0 +1,242 @@
+import type { FunctionReturnType } from 'convex/server'
+import { HARNESS_NAMES, type HarnessName, harnessLabel } from '@aistack/workflow-rules'
+import { api, internal } from './_generated/api'
+import type { ActionCtx } from './_generated/server'
+import type { StackTarget } from './discordStack'
+import { getAppUrl } from './httpCli'
+
+/**
+ * The /stack and /tokens commands (wayfinder #226, map #199).
+ *
+ * Both take an optional `stack` slug. Without one they need a linked account
+ * and use the caller's own stack. The embeds are the ones the showcase (#181)
+ * proved in Discord. Every figure comes from the same public reads the web
+ * uses: `publishedStackBySlug` for the card and `getUsageByStackSlug` for the
+ * numbers, so the consent bits (`published`, `publishCost`) apply unchanged.
+ *
+ * `resolveStack` lives in `discordStack.ts`: a module that calls its own
+ * `internal.*` entry degrades the generated API type to `any`.
+ *
+ * Error states answer INSIDE the 3-second window as ephemeral messages. A
+ * public deferral cannot turn ephemeral later, so `check` runs before the
+ * deferral and `reply` only ever builds the public embed.
+ */
+
+const LIME = 0xa3e635
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export const UNLINKED_PROMPT =
+  'No aistack account is linked to your Discord user. Run `/link`, open the URL, and sign in. After that, this command with no argument shows your own stack.'
+
+export const UNPUBLISHED_PROMPT =
+  'Your stack is not published yet. Publish it on the site, then run this command again.'
+
+export const NO_DATA_ERROR =
+  'This stack has no measured history. The owner can publish one with `aistack sync`.'
+
+export function unknownStackError(slug: string): string {
+  return `No stack matches "${slug}". Use the slug from the stack page URL, like \`alpers-agent-stack-unw0sl\`.`
+}
+
+/* Formatting, fixed to en-US: mirrors src/features/leaderboard/format.ts. */
+
+const money = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 0,
+})
+const plain = new Intl.NumberFormat('en-US')
+
+/** 291.4B, 5.9M, 231. */
+export function formatTokens(n: number): string {
+  if (n >= 1e9) return `${(n / 1e9).toFixed(n >= 100e9 ? 1 : 2)}B`
+  if (n >= 1e6) return `${(n / 1e6).toFixed(1)}M`
+  return plain.format(Math.round(n))
+}
+
+function pct(share: number): string {
+  return `${Math.round(share * 100)}%`
+}
+
+/** "2d ago", "today". Rounded down, so it never overstates freshness. */
+export function ago(ms: number, nowMs: number): string {
+  const days = Math.floor((nowMs - ms) / DAY_MS)
+  if (days <= 0) return 'today'
+  if (days === 1) return 'yesterday'
+  if (days < 60) return `${days}d ago`
+  return `${Math.floor(days / 30)}mo ago`
+}
+
+function labelHarness(name: string): string {
+  return (HARNESS_NAMES as readonly string[]).includes(name)
+    ? harnessLabel(name as HarnessName)
+    : name
+}
+
+function linkButton(label: string, url: string) {
+  return { type: 1, components: [{ type: 2, style: 5, label, url }] }
+}
+
+type Target = Extract<StackTarget, { kind: 'stack' }>
+type Usage = NonNullable<FunctionReturnType<typeof api.measured.getUsageByStackSlug>>
+
+/** The stack card: the OG image and one link button. */
+export function stackCard(target: Target, appUrl: string) {
+  const url = `${appUrl}/stacks/${target.slug}`
+  return {
+    embeds: [
+      {
+        title: target.name,
+        url,
+        color: LIME,
+        image: { url: `${appUrl}/api/og/stack/${target.slug}?v=${target.updatedAt}` },
+      },
+    ],
+    components: [linkButton('View stack', url)],
+  }
+}
+
+/**
+ * The measured numbers over the last 30 days. Spend prints only where the
+ * read returned a cost, which is where `publishCost` allowed it, and every
+ * dollar figure carries its price tables and the share of tokens it covers.
+ */
+export function tokensEmbed(target: Target, usage: Usage, appUrl: string, now: number) {
+  const url = `${appUrl}/stacks/${target.slug}`
+  const fields: Array<{ name: string; value: string; inline?: boolean }> = []
+  const tables = new Set<string>()
+
+  const reading = usage.current
+  if (reading) {
+    fields.push({
+      name: 'Tokens',
+      value: `\`${formatTokens(reading.totalTokens)}\` on \`${reading.activeDays}\` active ${
+        reading.activeDays === 1 ? 'day' : 'days'
+      }`,
+      inline: true,
+    })
+    if (usage.receivedAt !== null) {
+      fields.push({ name: 'Synced', value: ago(usage.receivedAt, now), inline: true })
+    }
+    const models = [...reading.models].sort((a, b) => b.totalTokens - a.totalTokens)
+    const lead = models[0]
+    if (lead) {
+      const rest = models.length - 1
+      const tail =
+        rest === 0
+          ? ''
+          : ` ${rest} more ${rest === 1 ? 'model shares' : 'models share'} the rest.`
+      fields.push({
+        name: 'Models',
+        value: `${lead.catalogName ?? lead.id} \`${pct(lead.tokenShare)}\` of tokens.${tail}`,
+      })
+    }
+    const harnesses = [...reading.harnesses]
+      .sort((a, b) => b.totalTokens - a.totalTokens)
+      .map((h) => labelHarness(h.harness))
+    if (harnesses.length > 0) {
+      fields.push({ name: 'Harnesses', value: harnesses.join(' + ') })
+    }
+    if (reading.cost) {
+      const figure = `${reading.cost.estimated ? '≥ ' : ''}${money.format(reading.cost.usd)}`
+      fields.push({
+        name: 'Spend',
+        value: `\`${figure}\` · \`${pct(reading.cost.pricedShare)}\` of tokens priced`,
+      })
+      for (const table of reading.cost.pricingTables) tables.add(table)
+    }
+  } else if (usage.legacy) {
+    // The retirement fallback (ADR-0011): one whole-window total, no per-model split.
+    const legacy = usage.legacy
+    fields.push({
+      name: 'Tokens',
+      value: `\`${formatTokens(legacy.tokens)}\` over \`${legacy.sessions}\` sessions`,
+      inline: true,
+    })
+    fields.push({ name: 'Synced', value: ago(legacy.capturedAt, now), inline: true })
+    if (legacy.usd !== null) {
+      fields.push({ name: 'Spend', value: `\`${money.format(legacy.usd)}\`` })
+    }
+  }
+
+  const footer =
+    tables.size === 0
+      ? "Counted on the builder's machine, published by them."
+      : `Counted on the builder's machine, published by them. Prices: ${[...tables].sort().join(', ')}.`
+
+  return {
+    embeds: [
+      {
+        title: `${target.name} · measured, last 30 days`,
+        url,
+        color: LIME,
+        fields,
+        footer: { text: footer },
+      },
+    ],
+    components: [linkButton('View stack', url)],
+  }
+}
+
+/** True when the read holds a figure to print: a folded window or the legacy total. */
+function hasNumbers(usage: Usage | null): usage is Usage {
+  return usage !== null && (usage.current !== null || usage.legacy !== null)
+}
+
+function slugOption(options: Array<{ name: string; value: unknown }>): string | undefined {
+  const value = options.find((o) => o.name === 'stack')?.value
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined
+}
+
+async function target(
+  ctx: ActionCtx,
+  call: { discordUserId: string; options: Array<{ name: string; value: unknown }> },
+) {
+  return await ctx.runQuery(internal.discordStack.resolveStack, {
+    discordUserId: call.discordUserId,
+    slug: slugOption(call.options),
+  })
+}
+
+function targetError(resolved: Awaited<ReturnType<typeof target>>): string | null {
+  switch (resolved.kind) {
+    case 'unlinked':
+      return UNLINKED_PROMPT
+    case 'unpublished':
+      return UNPUBLISHED_PROMPT
+    case 'unknown':
+      return unknownStackError(resolved.slug)
+    case 'stack':
+      return null
+  }
+}
+
+type Call = { discordUserId: string; options: Array<{ name: string; value: unknown }> }
+
+export const stackCommand = {
+  ephemeral: false,
+  check: async (ctx: ActionCtx, call: Call) => targetError(await target(ctx, call)),
+  reply: async (ctx: ActionCtx, call: Call) => {
+    const resolved = await target(ctx, call)
+    if (resolved.kind !== 'stack') throw new Error(`stack target ${resolved.kind}`)
+    return stackCard(resolved, getAppUrl())
+  },
+}
+
+export const tokensCommand = {
+  ephemeral: false,
+  check: async (ctx: ActionCtx, call: Call) => {
+    const resolved = await target(ctx, call)
+    const error = targetError(resolved)
+    if (error || resolved.kind !== 'stack') return error
+    const usage = await ctx.runQuery(api.measured.getUsageByStackSlug, { slug: resolved.slug })
+    return hasNumbers(usage) ? null : NO_DATA_ERROR
+  },
+  reply: async (ctx: ActionCtx, call: Call) => {
+    const resolved = await target(ctx, call)
+    if (resolved.kind !== 'stack') throw new Error(`stack target ${resolved.kind}`)
+    const usage = await ctx.runQuery(api.measured.getUsageByStackSlug, { slug: resolved.slug })
+    if (!hasNumbers(usage)) throw new Error('no measured history')
+    return tokensEmbed(resolved, usage, getAppUrl(), Date.now())
+  },
+}

--- a/convex/discordInteractions.ts
+++ b/convex/discordInteractions.ts
@@ -4,6 +4,7 @@ import { httpAction, internalAction } from './_generated/server'
 import type { ActionCtx } from './_generated/server'
 import { SHARED_BUCKET_MAX_REQUESTS } from './rateLimit'
 import { encodeUtf8, hexToBytes } from './lib/webCrypto'
+import { stackCommand, tokensCommand } from './discordCommands'
 
 /**
  * The Discord interactions endpoint (wayfinder #229, map #199).
@@ -20,9 +21,9 @@ import { encodeUtf8, hexToBytes } from './lib/webCrypto'
  * 3. A scheduled action computes the reply and PATCHes `@original` through the
  *    webhook, well inside the 15-minute token life.
  *
- * Commands plug in through `COMMANDS`. The stack, tokens, leaderboard, and
- * model commands land on their own tickets (#226, #223); `/link` is here
- * because its reply already exists.
+ * Commands plug in through `COMMANDS`. `/stack` and `/tokens` live in
+ * `discordCommands.ts` (#226); the leaderboard and model commands land on
+ * #223. `/link` is here because its reply already exists.
  */
 
 export const INTERACTIONS_PATH = '/api/discord/interactions'
@@ -64,6 +65,12 @@ export type ReplyData = Record<string, unknown>
 interface CommandSpec {
   /** Set at deferral time, because a deferral fixes the reply's visibility. */
   ephemeral: boolean
+  /**
+   * Runs before the deferral, inside the 3-second window. A returned string
+   * is answered at once as an ephemeral message and `reply` never runs. This
+   * is how a public command keeps its error states private.
+   */
+  check?: (ctx: ActionCtx, call: CommandCall) => Promise<string | null>
   reply: (ctx: ActionCtx, call: CommandCall) => Promise<ReplyData>
 }
 
@@ -76,6 +83,8 @@ const COMMANDS: Record<string, CommandSpec> = {
         discordUserId: call.discordUserId,
       }),
   },
+  stack: stackCommand,
+  tokens: tokensCommand,
 }
 
 const FALLBACK_REPLY: ReplyData = {
@@ -225,13 +234,26 @@ export const interactions = httpAction(async (ctx, request) => {
     )
   }
 
-  const ephemeral = COMMANDS[command]?.ephemeral ?? true
+  const spec = COMMANDS[command]
+  const options = parseOptions(interaction.data)
+  if (spec?.check) {
+    let error: string | null
+    try {
+      error = await spec.check(ctx, { discordUserId, options })
+    } catch (cause) {
+      console.error(`discord /${command} check failed`, cause)
+      error = FALLBACK_REPLY.content as string
+    }
+    if (error) return message(error)
+  }
+
+  const ephemeral = spec?.ephemeral ?? true
   await ctx.scheduler.runAfter(0, internal.discordInteractions.fulfill, {
     applicationId,
     token,
     command,
     discordUserId,
-    options: parseOptions(interaction.data),
+    options,
   })
 
   return json(200, {

--- a/convex/discordStack.ts
+++ b/convex/discordStack.ts
@@ -1,0 +1,61 @@
+import { type Infer, v } from 'convex/values'
+import type { Doc } from './_generated/dataModel'
+import { internalQuery } from './_generated/server'
+import { publishedStackBySlug } from './measured'
+
+/** Which stack a Discord command is about (wayfinder #226). See `discordCommands.ts`. */
+
+export const StackTarget = v.union(
+  v.object({ kind: v.literal('unlinked') }),
+  v.object({ kind: v.literal('unpublished') }),
+  v.object({ kind: v.literal('unknown'), slug: v.string() }),
+  v.object({
+    kind: v.literal('stack'),
+    slug: v.string(),
+    name: v.string(),
+    updatedAt: v.number(),
+  }),
+)
+export type StackTarget = Infer<typeof StackTarget>
+
+function publicSlug(stack: Doc<'stacks'>): string {
+  return `${stack.slug}-${stack.shortId}`
+}
+
+/**
+ * Which stack a command is about. With a slug, that published stack. Without
+ * one, the published stack of the creator linked to the Discord user.
+ */
+export const resolveStack = internalQuery({
+  args: { discordUserId: v.string(), slug: v.optional(v.string()) },
+  returns: StackTarget,
+  handler: async (ctx, args) => {
+    if (args.slug !== undefined) {
+      const stack = await publishedStackBySlug(ctx, args.slug)
+      if (!stack) return { kind: 'unknown' as const, slug: args.slug }
+      return {
+        kind: 'stack' as const,
+        slug: publicSlug(stack),
+        name: stack.name,
+        updatedAt: stack.updatedAt,
+      }
+    }
+    const creator = await ctx.db
+      .query('creators')
+      .withIndex('by_discordUserId', (q) => q.eq('discordUserId', args.discordUserId))
+      .first()
+    if (!creator) return { kind: 'unlinked' as const }
+    const stacks = await ctx.db
+      .query('stacks')
+      .withIndex('by_creatorId', (q) => q.eq('creatorId', creator._id))
+      .collect()
+    const stack = stacks.find((s) => s.published)
+    if (!stack) return { kind: 'unpublished' as const }
+    return {
+      kind: 'stack' as const,
+      slug: publicSlug(stack),
+      name: stack.name,
+      updatedAt: stack.updatedAt,
+    }
+  },
+})


### PR DESCRIPTION
Closes alp82/aistack#226. Part of map #199.

## What

- `convex/discordCommands.ts`: `/stack` posts the stack card (OG image, link button). `/tokens` posts the 30-day measured numbers: tokens on active days, sync freshness, lead model share, harnesses, and spend where `publishCost` allows, with the price tables in the footer. Both take an optional `stack` slug and otherwise use the linked account's own published stack.
- `convex/discordStack.ts`: `resolveStack`, the one internal query that turns (Discord user, optional slug) into a target or an error kind.
- `convex/discordInteractions.ts`: a `check` step on a command spec runs inside the 3-second window and answers an error as an ephemeral message before any deferral. A public deferral can't turn ephemeral later, so this is how a public command keeps its error states private.

## Verified

- 9 new tests through the endpoint with signed bodies; the whole Convex suite passes (869).
- Real local runtime: `/stack <slug>` defers publicly, and unknown slug, unlinked, and no-measured-history all answer type 4 with `flags: 64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UX3EwpV7eYAW4MNQsnzZ5