### PR TITLE
Build the /leaderboard and /model Discord commands (#223)

### DIFF
--- a/convex/discordCommands.test.ts
+++ b/convex/discordCommands.test.ts
@@ -47,7 +47,7 @@ async function post(t: Ctx, body: string) {
   })
 }
 
-function command(name: string, userId: string, slug?: string) {
+function command(name: string, userId: string, slug?: string, option = 'stack') {
   return JSON.stringify({
     id: '1',
     application_id: '1540381573243736116',
@@ -57,7 +57,7 @@ function command(name: string, userId: string, slug?: string) {
       id: '2',
       name,
       type: 1,
-      options: slug === undefined ? [] : [{ name: 'stack', type: 3, value: slug }],
+      options: slug === undefined ? [] : [{ name: option, type: 3, value: slug }],
     },
     member: { user: { id: userId } },
   })
@@ -143,6 +143,71 @@ async function seedDays(t: Ctx, stackId: Id<'stacks'>) {
       })
     }
   })
+}
+
+/** The board reads freshness off the inventory rows, so a ranked stack needs one. */
+async function seedInventory(t: Ctx, stackId: Id<'stacks'>, harness = 'claude-code') {
+  await t.run(async (ctx) => {
+    await ctx.db.insert('measuredInventory', {
+      stackId,
+      machine: 'laptop',
+      harness,
+      harnessVersion: '2.1.220',
+      capturedAt: NOW,
+      receivedAt: NOW - 24 * 60 * 60 * 1000,
+      inventory: {
+        builtinTools: [],
+        mcpServers: [],
+        skills: [],
+        subagents: [],
+        slashCommands: [],
+        withheld: { builtinTools: 0, mcpServers: 0, skills: 0, subagents: 0, slashCommands: 0 },
+      },
+      modelsSeen: ['claude-opus-5'],
+      pricingTable: 'anthropic-list-2026-07-25',
+    })
+  })
+}
+
+async function seedSecondStack(t: Ctx) {
+  const stackId = await t.run(async (ctx) => {
+    const creatorId = await ctx.db.insert('creators', {
+      name: 'Sol',
+      slug: 'sol',
+      userId: 'user_sol',
+      verified: false,
+      personalPages: [],
+      projectPages: [],
+      createdAt: NOW,
+    })
+    return await ctx.db.insert('stacks', {
+      name: 'Solomon',
+      slug: 'solomon',
+      shortId: 'qmqzh8',
+      creatorId,
+      oneLiner: 'A stack',
+      toolSubscriptions: [],
+      hasUsageComponent: false,
+      published: true,
+      publishCost: false,
+      createdAt: NOW,
+      updatedAt: NOW,
+    })
+  })
+  await t.run(async (ctx) => {
+    await ctx.db.insert('measuredDays', {
+      stackId,
+      machine: 'desk',
+      date: '2026-08-28',
+      capturedAt: NOW,
+      receivedAt: NOW,
+      aggregateVersion: 'measured-days/v1',
+      fingerprint: 'sol-day',
+      usage: usageDay('gpt-5.6-sol', 6_000_000_000, 5_000, 'codex'),
+    })
+  })
+  await seedInventory(t, stackId, 'codex')
+  return stackId
 }
 
 async function patchedReply(t: Ctx, body: string) {
@@ -301,6 +366,126 @@ describe('/tokens', () => {
     const body = await res.json()
     expect(body.data.flags).toBe(64)
     expect(body.data.content).toMatch(/Run `\/link`/)
+  })
+})
+
+describe('/leaderboard', () => {
+  test('posts the ranked rows, the population line, and the price tables', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seed(t)
+    await seedDays(t, stackId)
+    await seedInventory(t, stackId)
+    await seedSecondStack(t)
+    const { deferral, patched } = await patchedReply(t, command('leaderboard', STRANGER))
+    expect(deferral).toEqual({ type: 5, data: {} })
+    const embed = patched.embeds[0]
+    expect(embed.title).toBe('AI coding leaderboard · measured, last 30 days')
+    expect(embed.url).toBe('https://aistack.test/leaderboard')
+    expect(embed.description).toBe(
+      [
+        '**1** [Solomon](https://aistack.test/stacks/solomon-qmqzh8) · `6.00B` · gpt-5.6-sol 100%',
+        "**2** [Alper's Agent Stack](https://aistack.test/stacks/alpers-agent-stack-unw0sl) · `4.50B` · Claude Opus 5 89% · `$4,380`",
+      ].join('\n'),
+    )
+    expect(embed.fields).toEqual([
+      {
+        name: 'All measured stacks',
+        value: '`10.50B` tokens · `2` stacks · `$4,380` at least, 1 of 2 publish cost',
+      },
+    ])
+    expect(embed.footer.text).toBe(
+      'Spend is a lower bound. Prices: anthropic-list-2026-07-25.',
+    )
+    expect(patched.components[0].components[0]).toEqual({
+      type: 2,
+      style: 5,
+      label: 'View leaderboard',
+      url: 'https://aistack.test/leaderboard',
+    })
+  })
+
+  test('prints no dollar figure when no stack publishes cost', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seed(t, { publishCost: false })
+    await seedDays(t, stackId)
+    await seedInventory(t, stackId)
+    const { patched } = await patchedReply(t, command('leaderboard', STRANGER))
+    expect(JSON.stringify(patched)).not.toContain('$')
+    expect(patched.embeds[0].fields[0].value).toBe('`4.50B` tokens · `1` stack')
+    expect(patched.embeds[0].footer.text).toBe(
+      "Counted on the builders' machines, published by them.",
+    )
+  })
+
+  test('with no living stack answers the empty-board error, ephemeral', async () => {
+    const t = convexTest(schema, modules)
+    await seed(t)
+    const res = await post(t, command('leaderboard', STRANGER))
+    const body = await res.json()
+    expect(body.type).toBe(4)
+    expect(body.data.flags).toBe(64)
+    expect(body.data.content).toContain('No stack has synced')
+  })
+})
+
+describe('/model', () => {
+  test('posts the share, adoption, and lead counts for a catalog model', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seed(t)
+    await seedDays(t, stackId)
+    await seedInventory(t, stackId)
+    await seedSecondStack(t)
+    const { patched } = await patchedReply(
+      t,
+      command('model', STRANGER, 'claude opus 5', 'model'),
+    )
+    const embed = patched.embeds[0]
+    expect(embed.title).toBe('Claude Opus 5 · measured, last 30 days')
+    expect(embed.url).toBe('https://aistack.test/leaderboard')
+    expect(embed.fields).toEqual([
+      { name: 'Token share', value: '`38%` of attributed tokens', inline: true },
+      { name: 'Measured on', value: '`1` stack', inline: true },
+      { name: 'Leads', value: '`1` stack', inline: true },
+    ])
+    expect(embed.footer.text).toBe(
+      'Share of tokens that carry a model name, across all measured stacks.',
+    )
+    expect(patched.components[0].components[0].label).toBe('View leaderboard')
+  })
+
+  test('resolves a raw measured id the catalog does not know', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seed(t)
+    await seedDays(t, stackId)
+    await seedInventory(t, stackId)
+    const { patched } = await patchedReply(t, command('model', STRANGER, 'GPT-5.6-SOL', 'model'))
+    expect(patched.embeds[0].title).toBe('gpt-5.6-sol · measured, last 30 days')
+    expect(patched.embeds[0].fields[0].value).toBe('`11%` of attributed tokens')
+  })
+
+  test('an unknown model answers the unknown-model error, ephemeral', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seed(t)
+    await seedDays(t, stackId)
+    await seedInventory(t, stackId)
+    const res = await post(t, command('model', STRANGER, 'gpt-9', 'model'))
+    const body = await res.json()
+    expect(body.type).toBe(4)
+    expect(body.data.flags).toBe(64)
+    expect(body.data.content).toBe(
+      'No model matches "gpt-9". Use a model name from the leaderboard, like `GPT-5.6 Sol` or `Claude Opus 5`.',
+    )
+  })
+
+  test('a catalog model no stack measured answers the no-measurement error', async () => {
+    const t = convexTest(schema, modules)
+    await seed(t)
+    const res = await post(t, command('model', STRANGER, 'claude-opus-5', 'model'))
+    const body = await res.json()
+    expect(body.data.flags).toBe(64)
+    expect(body.data.content).toBe(
+      'No measured stack ran Claude Opus 5 in the last 30 days.',
+    )
   })
 })
 

--- a/convex/discordCommands.ts
+++ b/convex/discordCommands.ts
@@ -3,10 +3,12 @@ import { HARNESS_NAMES, type HarnessName, harnessLabel } from '@aistack/workflow
 import { api, internal } from './_generated/api'
 import type { ActionCtx } from './_generated/server'
 import type { StackTarget } from './discordStack'
+import type { BoardReading as Board, ModelRanking } from './leaderboard'
 import { getAppUrl } from './httpCli'
 
 /**
- * The /stack and /tokens commands (wayfinder #226, map #199).
+ * The /stack and /tokens commands (wayfinder #226, map #199), and the
+ * /leaderboard and /model commands (#223).
  *
  * Both take an optional `stack` slug. Without one they need a linked account
  * and use the caller's own stack. The embeds are the ones the showcase (#181)
@@ -33,6 +35,17 @@ export const UNPUBLISHED_PROMPT =
 
 export const NO_DATA_ERROR =
   'This stack has no measured history. The owner can publish one with `aistack sync`.'
+
+export const EMPTY_BOARD_ERROR =
+  'No stack has synced in the last 7 days, so there is nothing to rank yet.'
+
+export function unknownModelError(name: string): string {
+  return `No model matches "${name}". Use a model name from the leaderboard, like \`GPT-5.6 Sol\` or \`Claude Opus 5\`.`
+}
+
+export function unmeasuredModelError(name: string): string {
+  return `No measured stack ran ${name} in the last 30 days.`
+}
 
 export function unknownStackError(slug: string): string {
   return `No stack matches "${slug}". Use the slug from the stack page URL, like \`alpers-agent-stack-unw0sl\`.`
@@ -213,6 +226,92 @@ function targetError(resolved: Awaited<ReturnType<typeof target>>): string | nul
 
 type Call = { discordUserId: string; options: Array<{ name: string; value: unknown }> }
 
+function plural(n: number, noun: string): string {
+  return `\`${n}\` ${noun}${n === 1 ? '' : 's'}`
+}
+
+/**
+ * The top builders by 30-day token volume: the board's first page, one line
+ * per row. A row prints dollars only where the board priced it, which is
+ * where `publishCost` allowed it; a partial price wears the lower-bound sign.
+ */
+export function leaderboardEmbed(board: Board, appUrl: string) {
+  const url = `${appUrl}/leaderboard`
+  const lines = board.rows.map((row) => {
+    const parts = [
+      `**${row.rank}** [${row.name}](${appUrl}/stacks/${row.slug})`,
+      `\`${formatTokens(row.tokens)}\``,
+    ]
+    if (row.topModel) parts.push(`${row.topModel.name} ${pct(row.topModel.share)}`)
+    if (row.spend) {
+      const figure = money.format(row.spend.lowerBoundUSD)
+      parts.push(`\`${row.spend.exact ? figure : `≥ ${figure}`}\``)
+    }
+    return parts.join(' · ')
+  })
+
+  const population = [
+    `\`${formatTokens(board.totalTokens)}\` tokens`,
+    plural(board.stackCount, 'stack'),
+  ]
+  if (board.costPublishers > 0) {
+    population.push(
+      `\`${money.format(board.spendLowerBoundUSD)}\` at least, ${board.costPublishers} of ${board.stackCount} publish cost`,
+    )
+  }
+
+  const footer =
+    board.pricingTables.length === 0
+      ? "Counted on the builders' machines, published by them."
+      : `Spend is a lower bound. Prices: ${board.pricingTables.join(', ')}.`
+
+  return {
+    embeds: [
+      {
+        title: 'AI coding leaderboard · measured, last 30 days',
+        url,
+        color: LIME,
+        description: lines.join('\n'),
+        fields: [{ name: 'All measured stacks', value: population.join(' · ') }],
+        footer: { text: footer },
+      },
+    ],
+    components: [linkButton('View leaderboard', url)],
+  }
+}
+
+/** One model's adoption over every measured stack. */
+export function modelEmbed(ranking: ModelRanking, appUrl: string) {
+  const url = `${appUrl}/leaderboard`
+  return {
+    embeds: [
+      {
+        title: `${ranking.name} · measured, last 30 days`,
+        url,
+        color: LIME,
+        fields: [
+          {
+            name: 'Token share',
+            value: `\`${pct(ranking.tokenShare)}\` of attributed tokens`,
+            inline: true,
+          },
+          { name: 'Measured on', value: plural(ranking.stackCount, 'stack'), inline: true },
+          { name: 'Leads', value: plural(ranking.leadsCount, 'stack'), inline: true },
+        ],
+        footer: {
+          text: 'Share of tokens that carry a model name, across all measured stacks.',
+        },
+      },
+    ],
+    components: [linkButton('View leaderboard', url)],
+  }
+}
+
+function modelOption(options: Array<{ name: string; value: unknown }>): string {
+  const value = options.find((o) => o.name === 'model')?.value
+  return typeof value === 'string' ? value.trim() : ''
+}
+
 export const stackCommand = {
   ephemeral: false,
   check: async (ctx: ActionCtx, call: Call) => targetError(await target(ctx, call)),
@@ -238,5 +337,33 @@ export const tokensCommand = {
     const usage = await ctx.runQuery(api.measured.getUsageByStackSlug, { slug: resolved.slug })
     if (!hasNumbers(usage)) throw new Error('no measured history')
     return tokensEmbed(resolved, usage, getAppUrl(), Date.now())
+  },
+}
+
+export const leaderboardCommand = {
+  ephemeral: false,
+  check: async (ctx: ActionCtx) => {
+    const board = await ctx.runQuery(api.leaderboard.get, {})
+    return board.rows.length === 0 ? EMPTY_BOARD_ERROR : null
+  },
+  reply: async (ctx: ActionCtx) => {
+    const board = await ctx.runQuery(api.leaderboard.get, {})
+    if (board.rows.length === 0) throw new Error('empty board')
+    return leaderboardEmbed(board, getAppUrl())
+  },
+}
+
+export const modelCommand = {
+  ephemeral: false,
+  check: async (ctx: ActionCtx, call: Call) => {
+    const name = modelOption(call.options)
+    const ranking = await ctx.runQuery(api.leaderboard.model, { name })
+    if (ranking === null) return unknownModelError(name)
+    return ranking.stackCount === 0 ? unmeasuredModelError(ranking.name) : null
+  },
+  reply: async (ctx: ActionCtx, call: Call) => {
+    const ranking = await ctx.runQuery(api.leaderboard.model, { name: modelOption(call.options) })
+    if (ranking === null || ranking.stackCount === 0) throw new Error('model not measured')
+    return modelEmbed(ranking, getAppUrl())
   },
 }

--- a/convex/discordInteractions.ts
+++ b/convex/discordInteractions.ts
@@ -4,7 +4,12 @@ import { httpAction, internalAction } from './_generated/server'
 import type { ActionCtx } from './_generated/server'
 import { SHARED_BUCKET_MAX_REQUESTS } from './rateLimit'
 import { encodeUtf8, hexToBytes } from './lib/webCrypto'
-import { stackCommand, tokensCommand } from './discordCommands'
+import {
+  leaderboardCommand,
+  modelCommand,
+  stackCommand,
+  tokensCommand,
+} from './discordCommands'
 
 /**
  * The Discord interactions endpoint (wayfinder #229, map #199).
@@ -22,8 +27,8 @@ import { stackCommand, tokensCommand } from './discordCommands'
  *    webhook, well inside the 15-minute token life.
  *
  * Commands plug in through `COMMANDS`. `/stack` and `/tokens` live in
- * `discordCommands.ts` (#226); the leaderboard and model commands land on
- * #223. `/link` is here because its reply already exists.
+ * `discordCommands.ts` (#226), and so do `/leaderboard` and `/model` (#223).
+ * `/link` is here because its reply already exists.
  */
 
 export const INTERACTIONS_PATH = '/api/discord/interactions'
@@ -85,6 +90,8 @@ const COMMANDS: Record<string, CommandSpec> = {
   },
   stack: stackCommand,
   tokens: tokensCommand,
+  leaderboard: leaderboardCommand,
+  model: modelCommand,
 }
 
 const FALLBACK_REPLY: ReplyData = {

--- a/convex/leaderboard.test.ts
+++ b/convex/leaderboard.test.ts
@@ -509,3 +509,66 @@ describe('leaderboard.get', () => {
     expect(row.creatorName).toMatch(/^Creator /)
   })
 })
+
+describe('leaderboard.model', () => {
+  test('resolves a catalog name case-insensitively and a raw id as itself', async () => {
+    const t = convexTest(schema, modules)
+    await t.run(async (ctx) => {
+      await ctx.db.insert('models', {
+        name: 'GPT X',
+        slug: 'gpt-x',
+        shortId: 'gptx1',
+        provider: 'openai',
+        category: 'coding',
+        reviewStatus: 'approved',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      })
+    })
+    const one = await seedStack(t)
+    await sync(t, one.stackId, {
+      totalTokens: 300,
+      models: [
+        { id: 'gpt-x', tokens: 100 },
+        { id: 'claude-y', tokens: 200 },
+      ],
+    })
+    expect(await t.query(api.leaderboard.model, { name: 'gpt x' })).toEqual({
+      key: 'gpt-x',
+      name: 'GPT X',
+      tokenShare: 100 / 300,
+      stackCount: 1,
+      leadsCount: 0,
+    })
+    expect(await t.query(api.leaderboard.model, { name: 'Claude-Y' })).toMatchObject({
+      key: 'claude-y',
+      leadsCount: 1,
+    })
+    expect(await t.query(api.leaderboard.model, { name: 'unknown' })).toBeNull()
+    expect(await t.query(api.leaderboard.model, { name: 'gpt-9' })).toBeNull()
+  })
+
+  test('a catalog model no stack ran answers with zero stacks, not null', async () => {
+    const t = convexTest(schema, modules)
+    await t.run(async (ctx) => {
+      await ctx.db.insert('models', {
+        name: 'GPT X',
+        slug: 'gpt-x',
+        shortId: 'gptx1',
+        provider: 'openai',
+        category: 'coding',
+        reviewStatus: 'approved',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      })
+    })
+    expect(await t.query(api.leaderboard.model, { name: 'GPT X' })).toEqual({
+      key: 'gpt-x',
+      name: 'GPT X',
+      tokenShare: 0,
+      stackCount: 0,
+      leadsCount: 0,
+    })
+  })
+})
+

--- a/convex/leaderboard.ts
+++ b/convex/leaderboard.ts
@@ -4,7 +4,7 @@ import {
   totalOfTokens,
   type UsageDay,
 } from '@aistack/workflow-rules'
-import { v } from 'convex/values'
+import { type Infer, v } from 'convex/values'
 import type { Doc } from './_generated/dataModel'
 import type { QueryCtx } from './_generated/server'
 import { query } from './_generated/server'
@@ -103,11 +103,16 @@ const Board = v.object({
   models: v.array(Ranking),
   harnesses: v.array(Ranking),
   quiet: v.object({ count: v.number(), tokens: v.number() }),
+  /** Every price table behind `spendLowerBoundUSD`, sorted. */
+  pricingTables: v.array(v.string()),
   page: v.number(),
   pageSize: v.number(),
   totalPages: v.number(),
   rows: v.array(Row),
 })
+
+export type BoardReading = Infer<typeof Board>
+export type ModelRanking = Infer<typeof Ranking>
 
 type StackReading = {
   stack: Doc<'stacks'>
@@ -122,6 +127,7 @@ type StackReading = {
   /** Over the 30-day fold; `unknown` kept for totals. */
   modelTokens: Map<string, number>
   spend: { lowerBoundUSD: number; coverage: number; exact: boolean } | null
+  pricingTables: string[]
 }
 
 /**
@@ -174,6 +180,7 @@ async function readStack(
       })).filter((h) => h.tokens > 0),
       modelTokens: new Map(),
       spend: null,
+      pricingTables: [],
     }
   }
 
@@ -215,6 +222,7 @@ async function readStack(
           exact: !reading.cost.estimated && reading.cost.pricedShare >= 1,
         }
       : null,
+    pricingTables: reading.cost?.pricingTables ?? [],
   }
 }
 
@@ -233,28 +241,116 @@ function bump(
   map.set(key, cur)
 }
 
+/**
+ * The measured population: published, not flagged. `by_published` narrows to
+ * the public set; the quality flag is enforced HERE, not left to the client -
+ * the board is discovery (#82), and a filter the frontend applies is a filter
+ * a crawler does not. `/model` (#223) reads the same population, so the two
+ * can never disagree on a share.
+ */
+async function readPopulation(ctx: QueryCtx, now: number) {
+  const stacks = await ctx.db
+    .query('stacks')
+    .withIndex('by_published', (q) => q.eq('published', true))
+    .collect()
+
+  const catalog = await loadModelCatalog(ctx)
+  const readings: StackReading[] = []
+  for (const stack of stacks) {
+    if (stack.isLowQuality === true) continue
+    const reading = await readStack(ctx, stack, now, catalog)
+    if (reading) readings.push(reading)
+  }
+  return { readings, catalog }
+}
+
+function namedModels(r: StackReading): [string, number][] {
+  return [...r.modelTokens.entries()].filter(([id]) => id !== 'unknown')
+}
+
+function leadOf(named: [string, number][]): [string, number] | null {
+  return named.reduce(
+    (a, b) => (a === null || b[1] > a[1] ? b : a),
+    null as [string, number] | null
+  )
+}
+
+/** Every named model over the population, token-weighted over attributed tokens. */
+function rankModels(readings: StackReading[], catalog: ModelCatalog) {
+  let attributed = 0
+  const models = new Map<string, Bucket>()
+  for (const r of readings) {
+    const named = namedModels(r)
+    const lead = leadOf(named)
+    for (const [id, tokens] of named) {
+      attributed += tokens
+      bump(models, id, tokens, lead !== null && lead[0] === id)
+    }
+  }
+  const modelName = (id: string) =>
+    (catalog.bySlug.get(id) ?? catalog.byAlias.get(id))?.name ?? id
+  return {
+    attributed,
+    models: [...models.entries()]
+      .map(([key, b]) => ({
+        key,
+        name: modelName(key),
+        tokenShare: attributed > 0 ? b.tokens / attributed : 0,
+        stackCount: b.stacks,
+        leadsCount: b.leads,
+      }))
+      .sort((a, b) => b.tokenShare - a.tokenShare || b.stackCount - a.stackCount),
+  }
+}
+
+/**
+ * One model's adoption, for `/model` (#223). The name resolves against the
+ * catalog (slug, alias, or display name, case-insensitive) and then against
+ * the raw measured ids, so a model the catalog has not filed still answers.
+ * `null` means no model of that name exists anywhere; a catalog model no
+ * stack ran comes back with a zero `stackCount`.
+ */
+export const model = query({
+  args: { name: v.string() },
+  returns: v.union(Ranking, v.null()),
+  handler: async (ctx, args) => {
+    const wanted = args.name.trim().toLowerCase()
+    if (wanted === '' || wanted === 'unknown') return null
+    const { readings, catalog } = await readPopulation(ctx, Date.now())
+    const ranked = rankModels(readings, catalog)
+
+    const catalogRow =
+      catalog.bySlug.get(wanted) ??
+      catalog.byAlias.get(wanted) ??
+      [...catalog.bySlug.values()].find((m) => m.name.toLowerCase() === wanted)
+    const keys = new Set<string>()
+    if (catalogRow) {
+      keys.add(catalogRow.slug)
+      for (const [alias, row] of catalog.byAlias) {
+        if (row._id === catalogRow._id) keys.add(alias)
+      }
+    }
+    const hit =
+      ranked.models.find((m) => keys.has(m.key)) ??
+      ranked.models.find((m) => m.key.toLowerCase() === wanted)
+    if (hit) return hit
+    if (!catalogRow) return null
+    return {
+      key: catalogRow.slug,
+      name: catalogRow.name,
+      tokenShare: 0,
+      stackCount: 0,
+      leadsCount: 0,
+    }
+  },
+})
+
 export const get = query({
   args: { page: v.optional(v.number()) },
   returns: Board,
   handler: async (ctx, args) => {
     const now = Date.now()
-
-    // The population: published, not flagged. `by_published` narrows to the
-    // public set; the quality flag is enforced HERE, not left to the client -
-    // the board is discovery (#82), and a filter the frontend applies is a
-    // filter a crawler does not.
-    const stacks = await ctx.db
-      .query('stacks')
-      .withIndex('by_published', (q) => q.eq('published', true))
-      .collect()
-
-    const catalog = await loadModelCatalog(ctx)
-    const readings: StackReading[] = []
-    for (const stack of stacks) {
-      if (stack.isLowQuality === true) continue
-      const reading = await readStack(ctx, stack, now, catalog)
-      if (reading) readings.push(reading)
-    }
+    const { readings, catalog } = await readPopulation(ctx, now)
 
     const byTokens = (a: StackReading, b: StackReading) =>
       b.tokens - a.tokens || a.stack.name.localeCompare(b.stack.name)
@@ -265,11 +361,11 @@ export const get = query({
 
     let totalTokens = 0
     let totalSessions = 0
-    let attributed = 0
     let spendLowerBoundUSD = 0
     let costPublishers = 0
-    const models = new Map<string, Bucket>()
+    const pricingTables = new Set<string>()
     const harnesses = new Map<string, Bucket>()
+    const { attributed, models } = rankModels(readings, catalog)
 
     for (const r of readings) {
       totalTokens += r.tokens
@@ -277,17 +373,7 @@ export const get = query({
       if (r.spend) {
         spendLowerBoundUSD += r.spend.lowerBoundUSD
         costPublishers += 1
-      }
-      const named = [...r.modelTokens.entries()].filter(
-        ([id]) => id !== 'unknown'
-      )
-      const lead = named.reduce(
-        (a, b) => (a === null || b[1] > a[1] ? b : a),
-        null as [string, number] | null
-      )
-      for (const [id, tokens] of named) {
-        attributed += tokens
-        bump(models, id, tokens, lead !== null && lead[0] === id)
+        for (const table of r.pricingTables) pricingTables.add(table)
       }
       const leadHarness = r.activeHarnesses.reduce(
         (a, b) => (a === null || b.tokens > a.tokens ? b : a),
@@ -331,13 +417,7 @@ export const get = query({
     const rows = living
       .slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
       .map((r, i) => {
-        const named = [...r.modelTokens.entries()].filter(
-          ([id]) => id !== 'unknown'
-        )
-        const top = named.reduce(
-          (a, b) => (a === null || b[1] > a[1] ? b : a),
-          null as [string, number] | null
-        )
+        const top = leadOf(namedModels(r))
         return {
           rank: (page - 1) * PAGE_SIZE + i + 1,
           slug: `${r.stack.slug}-${r.stack.shortId}`,
@@ -366,7 +446,7 @@ export const get = query({
       unattributedShare:
         totalTokens > 0 ? (totalTokens - attributed) / totalTokens : 0,
       windowSpreadDays,
-      models: rankOf(models, attributed, modelName).slice(0, MAX_RAIL_MODELS),
+      models: models.slice(0, MAX_RAIL_MODELS),
       harnesses: rankOf(harnesses, totalTokens, (k) => k).slice(
         0,
         MAX_RAIL_HARNESSES
@@ -375,6 +455,7 @@ export const get = query({
         count: quiet.length,
         tokens: quiet.reduce((a, r) => a + r.tokens, 0),
       },
+      pricingTables: [...pricingTables].sort(),
       page,
       pageSize: PAGE_SIZE,
       totalPages,


### PR DESCRIPTION
Closes #223 (map #199).

## What

- `/leaderboard` posts the first page of the board as a classic embed: one line per living stack (rank, linked name, 30-day tokens, top model share, spend only where `publishCost` allowed it, `>=` sign on a partial price), an "All measured stacks" field, and the price tables in the footer. An empty board answers ephemerally inside the request.
- `/model <name>` posts token share of attributed tokens, stacks measured on, and stacks led. The name resolves against the catalog (slug, alias, display name, case-insensitive) and then the raw measured ids. Unknown model and catalog-model-never-measured both answer ephemerally.
- New query `leaderboard.model`, built on the same population read as `leaderboard.get` (extracted `readPopulation` and `rankModels`). `leaderboard.get` now also returns `pricingTables`.
- Both commands register in `COMMANDS` with the `check` before deferral pattern from #226.

Embed shapes follow `prototypes/discord-showcase/payloads.mjs`.

## Tests

`pnpm test`: 173 files, 2459 passed. New tests in `convex/discordCommands.test.ts` (7) and `convex/leaderboard.test.ts` (2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UX3EwpV7eYAW4MNQsnzZ5