### PR TITLE
Register the Discord commands globally with both install contexts (alp82/aistack#224)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,10 +12,6 @@ BETTER_AUTH_SECRET=
 BETTER_AUTH_URL=http://localhost:3019
 APP_URL=http://localhost:3019
 
-# Discord bot. The app's public key from the Developer Portal, hex. Set it on
-# the Convex deployment; the interactions endpoint answers 503 without it.
-DISCORD_PUBLIC_KEY=
-
 # SSO
 GOOGLE_OAUTH_CLIENT_ID= 
 GOOGLE_OAUTH_CLIENT_SECRET= 
@@ -43,4 +39,10 @@ VIEW_HASH_SECRET=
 # Resend
 RESEND_API_KEY= 
 EMAIL_FROM="AI Stack <hello@yourdomain.com>"
-https://github.com/alp82/
+
+# Discord
+DISCORD_PUBLIC_KEY=
+# Registration only: scripts/discord-register-commands.ts PUTs the command set
+# with these two. The deployment never reads the bot token.
+DISCORD_APP_ID=
+DISCORD_BOT_TOKEN=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,26 @@ The Workflow section on the stack page. Spec:
   records what a session was for, so `playbook-rules/v1` names its two tracks the shorter
   and the longer sessions. A receipt card's head names both sides and claims no direction.
 
+## Discord bot
+
+Spec: [docs/specs/discord-bot.md](docs/specs/discord-bot.md). The interactions endpoint is
+a Convex `httpAction` (`convex/discordInteractions.ts`); there is no gateway process and
+the app needs zero privileged intents.
+
+* **Register the commands** after changing `scripts/lib/discordCommandDefinitions.ts`:
+  `DISCORD_APP_ID=... DISCORD_BOT_TOKEN=... pnpm tsx scripts/discord-register-commands.ts`.
+  It PUTs the global set; `--dry-run` prints the payload, and `DISCORD_GUILD_ID=...`
+  registers on one guild for instant testing (global takes up to an hour). The bot token
+  is used only there and is never a deployment variable.
+* Command names must equal the keys of `COMMANDS` in `convex/discordInteractions.ts`.
+  `convex/discordCommandDefinitions.test.ts` fails when they drift.
+* Every command sets `integration_types: [0, 1]` (guild install, user install) and
+  `contexts: [0, 1, 2]` (guild, bot DM, private channel).
+* The owner sets the Developer Portal by hand: Installation > Install contexts, both
+  User Install and Guild Install enabled; General Information > Interactions Endpoint URL
+  pointing at the Convex site URL plus `/api/discord/interactions`; Bot > Privileged Gateway Intents
+  all off.
+
 ## News
 
 Everything about the news pipeline starts here.

--- a/convex/discordCommandDefinitions.test.ts
+++ b/convex/discordCommandDefinitions.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+import { DISCORD_COMMAND_DEFINITIONS } from '../scripts/lib/discordCommandDefinitions'
+import { COMMANDS } from './discordInteractions'
+
+describe('the registered command set matches the COMMANDS registry', () => {
+  test('the names are the registry keys', () => {
+    const names = DISCORD_COMMAND_DEFINITIONS.map((c) => c.name).sort()
+    expect(names).toEqual(Object.keys(COMMANDS).sort())
+  })
+
+  test('the option names are the ones the handlers read', () => {
+    const optionNames = (name: string) =>
+      DISCORD_COMMAND_DEFINITIONS.find((c) => c.name === name)?.options?.map((o) => o.name)
+    expect(optionNames('stack')).toEqual(['stack'])
+    expect(optionNames('tokens')).toEqual(['stack'])
+    expect(optionNames('model')).toEqual(['model'])
+    expect(optionNames('leaderboard')).toBeUndefined()
+    expect(optionNames('link')).toBeUndefined()
+  })
+
+  test('every command allows both installs and all three contexts', () => {
+    for (const c of DISCORD_COMMAND_DEFINITIONS) {
+      expect(c.integration_types).toEqual([0, 1])
+      expect(c.contexts).toEqual([0, 1, 2])
+    }
+  })
+})

--- a/convex/discordInteractions.ts
+++ b/convex/discordInteractions.ts
@@ -80,7 +80,7 @@ interface CommandSpec {
 }
 
 /** The command registry. Later tickets add their entries here. */
-const COMMANDS: Record<string, CommandSpec> = {
+export const COMMANDS: Record<string, CommandSpec> = {
   link: {
     ephemeral: true,
     reply: async (ctx, call) =>

--- a/scripts/discord-register-commands.ts
+++ b/scripts/discord-register-commands.ts
@@ -1,0 +1,53 @@
+/**
+ * Register the Discord slash commands (alp82/aistack#224).
+ *
+ * PUTs the whole command set, so a removed command disappears and a changed one
+ * updates. Global by default; set DISCORD_GUILD_ID to register on one guild for
+ * instant testing (global commands can take up to an hour to appear).
+ *
+ *   pnpm tsx scripts/discord-register-commands.ts [--dry-run]
+ *
+ * Needs DISCORD_APP_ID and DISCORD_BOT_TOKEN. The bot token is used here only;
+ * the deployment never holds it.
+ */
+
+import {
+  commandsUrl,
+  DISCORD_COMMAND_DEFINITIONS,
+} from './lib/discordCommandDefinitions'
+
+const dryRun = process.argv.includes('--dry-run')
+const { DISCORD_APP_ID, DISCORD_BOT_TOKEN, DISCORD_GUILD_ID } = process.env
+
+if (!DISCORD_APP_ID || (!dryRun && !DISCORD_BOT_TOKEN)) {
+  console.error('Set DISCORD_APP_ID and DISCORD_BOT_TOKEN (DISCORD_GUILD_ID optional).')
+  process.exit(1)
+}
+
+const url = commandsUrl(DISCORD_APP_ID, DISCORD_GUILD_ID || undefined)
+const scope = DISCORD_GUILD_ID ? `guild ${DISCORD_GUILD_ID}` : 'global'
+
+if (dryRun) {
+  console.log(`PUT ${url} (${scope})`)
+  console.log(JSON.stringify(DISCORD_COMMAND_DEFINITIONS, null, 2))
+  process.exit(0)
+}
+
+const res = await fetch(url, {
+  method: 'PUT',
+  headers: {
+    authorization: `Bot ${DISCORD_BOT_TOKEN}`,
+    'content-type': 'application/json',
+  },
+  body: JSON.stringify(DISCORD_COMMAND_DEFINITIONS),
+})
+
+const text = await res.text()
+console.log(`${res.status} ${res.statusText} (${scope})`)
+if (!res.ok) {
+  console.error(text)
+  process.exit(1)
+}
+
+const registered = JSON.parse(text) as Array<{ name: string }>
+console.log(`Registered: ${registered.map((c) => `/${c.name}`).join(' ')}`)

--- a/scripts/lib/discordCommandDefinitions.ts
+++ b/scripts/lib/discordCommandDefinitions.ts
@@ -1,0 +1,77 @@
+/**
+ * The Discord command set the registration script PUTs (alp82/aistack#224).
+ *
+ * Names and option names must match the `COMMANDS` registry in
+ * convex/discordInteractions.ts and the option lookups in
+ * convex/discordCommands.ts. `discordCommandDefinitions.test.ts` asserts that.
+ *
+ * Discord API constants (docs.discord.com/developers/interactions/application-commands):
+ *   option type 3 = STRING
+ *   integration_types 0 = GUILD_INSTALL, 1 = USER_INSTALL
+ *   contexts 0 = GUILD, 1 = BOT_DM, 2 = PRIVATE_CHANNEL
+ */
+
+export const GUILD_INSTALL = 0
+export const USER_INSTALL = 1
+export const CONTEXT_GUILD = 0
+export const CONTEXT_BOT_DM = 1
+export const CONTEXT_PRIVATE_CHANNEL = 2
+const STRING_OPTION = 3
+
+export interface CommandOptionDefinition {
+  type: number
+  name: string
+  description: string
+  required: boolean
+}
+
+export interface CommandDefinition {
+  name: string
+  description: string
+  options?: CommandOptionDefinition[]
+  integration_types: number[]
+  contexts: number[]
+}
+
+const stackOption: CommandOptionDefinition = {
+  type: STRING_OPTION,
+  name: 'stack',
+  description: 'Stack slug, like alpers-agent-stack-unw0sl. Empty: your own stack.',
+  required: false,
+}
+
+const everywhere = {
+  integration_types: [GUILD_INSTALL, USER_INSTALL],
+  contexts: [CONTEXT_GUILD, CONTEXT_BOT_DM, CONTEXT_PRIVATE_CHANNEL],
+}
+
+export const DISCORD_COMMAND_DEFINITIONS: CommandDefinition[] = [
+  { name: 'stack', description: 'Post a stack card', options: [stackOption], ...everywhere },
+  {
+    name: 'tokens',
+    description: 'Post the measured numbers for a stack',
+    options: [stackOption],
+    ...everywhere,
+  },
+  { name: 'leaderboard', description: 'Top builders by 30-day token volume', ...everywhere },
+  {
+    name: 'model',
+    description: 'Adoption and token share for a model',
+    options: [
+      {
+        type: STRING_OPTION,
+        name: 'model',
+        description: 'Model name, like gpt-5.6-sol',
+        required: true,
+      },
+    ],
+    ...everywhere,
+  },
+  { name: 'link', description: 'Link your aistack account', ...everywhere },
+]
+
+/** The endpoint for the command set: global, or one guild when `guildId` is given. */
+export function commandsUrl(appId: string, guildId?: string): string {
+  const base = `https://discord.com/api/v10/applications/${appId}`
+  return guildId ? `${base}/guilds/${guildId}/commands` : `${base}/commands`
+}


### PR DESCRIPTION
Closes alp82/aistack#224 (map #199).

- `scripts/discord-register-commands.ts` PUTs the global command set (`/stack`, `/tokens`, `/leaderboard`, `/model`, `/link`) with `integration_types: [0, 1]` and `contexts: [0, 1, 2]`. `--dry-run` prints the payload; `DISCORD_GUILD_ID` registers on one guild.
- Definitions live in `scripts/lib/discordCommandDefinitions.ts`; `convex/discordCommandDefinitions.test.ts` asserts they match the `COMMANDS` registry (now exported).
- `.env.example` gains `DISCORD_APP_ID` and `DISCORD_BOT_TOKEN` (registration only).
- AGENTS.md gains a Discord bot section with the owner's Developer Portal checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UX3EwpV7eYAW4MNQsnzZ5