### PR TITLE
Build the price and model import (alp82/aistack#337)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,16 @@ free is a zero-rate period cited `local-no-charge`.
 * **Priced lanes** (`codex-auto-review`) and the `#fast` variants stay in the
   bundled constants only: they are rates without a catalog row, and the seed
   skips them.
+* **The import** (`convex/modelImport.ts`, rules in `convex/lib/modelImport.ts`,
+  #337) runs daily at 05:00 UTC and from the admin Import tab. It reads
+  models.dev (`api.json`), LiteLLM as fallback, and compares each catalog row's
+  rate under its OWN vendor (a gateway listing never prices a vendor row). A
+  changed rate is a new period dated to the run, cited `models.dev@<date>`; an
+  unchanged rate writes nothing. It creates `pending` rows for dataset models
+  of the allowlisted vendors (`VENDOR_ALLOWLIST`) released in the last 180
+  days that read and write text only, and for any measured id with tokens on
+  a day that resolves to no row. Never for a priced lane, a `#fast` or dated
+  variant, or an inventory-only id. Every write is a line in `importLog`.
 
 ## Charts
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -48,6 +48,7 @@ import type * as lib_machineOrdinals from "../lib/machineOrdinals.js";
 import type * as lib_mailer from "../lib/mailer.js";
 import type * as lib_measuredDays from "../lib/measuredDays.js";
 import type * as lib_modelCatalog from "../lib/modelCatalog.js";
+import type * as lib_modelImport from "../lib/modelImport.js";
 import type * as lib_modelLookup from "../lib/modelLookup.js";
 import type * as lib_names from "../lib/names.js";
 import type * as lib_reprice from "../lib/reprice.js";
@@ -78,6 +79,7 @@ import type * as migrations__archived_migrateStackDescriptions from "../migratio
 import type * as migrations__archived_populateShortIds from "../migrations/_archived/populateShortIds.js";
 import type * as migrations_backup from "../migrations/backup.js";
 import type * as migrations_icons from "../migrations/icons.js";
+import type * as modelImport from "../modelImport.js";
 import type * as models from "../models.js";
 import type * as news from "../news.js";
 import type * as newsDrafting from "../newsDrafting.js";
@@ -148,6 +150,7 @@ declare const fullApi: ApiFromModules<{
   "lib/mailer": typeof lib_mailer;
   "lib/measuredDays": typeof lib_measuredDays;
   "lib/modelCatalog": typeof lib_modelCatalog;
+  "lib/modelImport": typeof lib_modelImport;
   "lib/modelLookup": typeof lib_modelLookup;
   "lib/names": typeof lib_names;
   "lib/reprice": typeof lib_reprice;
@@ -178,6 +181,7 @@ declare const fullApi: ApiFromModules<{
   "migrations/_archived/populateShortIds": typeof migrations__archived_populateShortIds;
   "migrations/backup": typeof migrations_backup;
   "migrations/icons": typeof migrations_icons;
+  modelImport: typeof modelImport;
   models: typeof models;
   news: typeof news;
   newsDrafting: typeof newsDrafting;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -82,4 +82,14 @@ crons.daily(
 // after a deploy seeds the baselines and adds nothing, which is the point.
 crons.cron('news-scrape', '30 */6 * * *', internal.newsScrapers.scrape)
 
+// The price and model import (#337). Daily: models.dev has no dated history,
+// so the run is what dates a rate change, and a day is the grain the catalog
+// cites. 05:00 UTC, after the icon GC and before the owner's morning. A run
+// that finds nothing changed writes one log line and nothing else.
+crons.daily(
+  'model-price-import',
+  { hourUTC: 5, minuteUTC: 0 },
+  internal.modelImport.run,
+)
+
 export default crons

--- a/convex/lib/modelImport.test.ts
+++ b/convex/lib/modelImport.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, test } from 'vitest'
+import type { Doc, Id } from '../_generated/dataModel'
+import { catalogFrom } from './modelCatalog'
+import {
+  type DatasetModel,
+  datasetProviderOf,
+  mergedRates,
+  parseLiteLlm,
+  parseModelsDev,
+  periodInEffect,
+  planImport,
+  ratesDiffer,
+} from './modelImport'
+
+const NOW = Date.UTC(2026, 7, 29, 12)
+const DAY = 24 * 60 * 60 * 1000
+
+function model(over: Partial<Doc<'models'>> & { slug: string }): Doc<'models'> {
+  return {
+    _id: `m_${over.slug}` as Id<'models'>,
+    _creationTime: 1,
+    name: over.slug,
+    shortId: over.slug.slice(0, 6),
+    provider: 'Anthropic',
+    category: 'coding',
+    reviewStatus: 'approved',
+    createdAt: 1,
+    updatedAt: 1,
+    ...over,
+  }
+}
+
+function period(
+  over: Partial<Doc<'modelPrices'>> & { modelSlug: string; input: number; output: number }
+): Doc<'modelPrices'> {
+  return {
+    _id: `p_${over.modelSlug}_${over.from ?? 0}` as Id<'modelPrices'>,
+    _creationTime: 1,
+    from: 0,
+    source: 'anthropic-list-2026-07-25',
+    createdAt: 1,
+    ...over,
+  }
+}
+
+function dm(over: Partial<DatasetModel> & { id: string; providerId: string }): DatasetModel {
+  return {
+    name: over.id,
+    input: 5,
+    output: 25,
+    textOnly: true,
+    releaseDate: '2026-08-01',
+    iconUrl: `https://models.dev/logos/${over.providerId}.svg`,
+    ...over,
+  }
+}
+
+function plan(args: {
+  models?: Doc<'models'>[]
+  prices?: Doc<'modelPrices'>[]
+  dataset?: DatasetModel[]
+  measuredIds?: string[]
+}) {
+  const models = args.models ?? []
+  const prices = args.prices ?? []
+  return planImport({
+    catalog: catalogFrom(models, prices),
+    models,
+    prices,
+    dataset: args.dataset ?? [],
+    measuredIds: args.measuredIds ?? [],
+    source: 'models.dev@2026-08-29',
+    now: NOW,
+  })
+}
+
+describe('parseModelsDev', () => {
+  test('reads cost, limit, modalities and the provider logo', () => {
+    const rows = parseModelsDev({
+      anthropic: {
+        id: 'anthropic',
+        models: {
+          'claude-opus-4-7': {
+            id: 'claude-opus-4-7',
+            name: 'Claude Opus 4.7',
+            release_date: '2026-04-14',
+            modalities: { input: ['text', 'image'], output: ['text'] },
+            limit: { context: 1000000, output: 128000 },
+            cost: { input: 5, output: 25, cache_read: 0.5, cache_write: 6.25 },
+          },
+          'claude-tts': {
+            id: 'claude-tts',
+            modalities: { input: ['text'], output: ['audio'] },
+            cost: { input: 1, output: 2 },
+          },
+          'no-cost': { id: 'no-cost' },
+        },
+      },
+    })
+    expect(rows).toEqual([
+      {
+        id: 'claude-opus-4-7',
+        providerId: 'anthropic',
+        name: 'Claude Opus 4.7',
+        input: 5,
+        output: 25,
+        cacheRead: 0.5,
+        cacheWrite5m: 6.25,
+        contextWindow: 1000000,
+        releaseDate: '2026-04-14',
+        textOnly: true,
+        iconUrl: 'https://models.dev/logos/anthropic.svg',
+      },
+      {
+        id: 'claude-tts',
+        providerId: 'anthropic',
+        name: 'claude-tts',
+        input: 1,
+        output: 2,
+        textOnly: false,
+        iconUrl: 'https://models.dev/logos/anthropic.svg',
+      },
+    ])
+  })
+})
+
+describe('parseLiteLlm', () => {
+  test('keeps bare chat keys, converts per-token to per-million, maps providers', () => {
+    const rows = parseLiteLlm({
+      sample_spec: { input_cost_per_token: 0 },
+      'claude-opus-4-7': {
+        litellm_provider: 'anthropic',
+        mode: 'chat',
+        input_cost_per_token: 0.000005,
+        output_cost_per_token: 0.000025,
+        cache_read_input_token_cost: 5e-7,
+        cache_creation_input_token_cost: 0.00000625,
+        cache_creation_input_token_cost_above_1hr: 0.00001,
+        max_input_tokens: 1000000,
+      },
+      'vertex_ai/claude-opus-4-7': { litellm_provider: 'vertex_ai', input_cost_per_token: 1, output_cost_per_token: 1 },
+      'gemini-3.6-flash': { litellm_provider: 'gemini', mode: 'chat', input_cost_per_token: 7.5e-7, output_cost_per_token: 0.00000375 },
+      'text-embedding-3-large': { litellm_provider: 'openai', mode: 'embedding', input_cost_per_token: 1e-7, output_cost_per_token: 0 },
+    })
+    expect(rows).toEqual([
+      {
+        id: 'claude-opus-4-7',
+        providerId: 'anthropic',
+        name: 'claude-opus-4-7',
+        input: 5,
+        output: 25,
+        cacheRead: 0.5,
+        cacheWrite5m: 6.25,
+        cacheWrite1h: 10,
+        contextWindow: 1000000,
+        textOnly: true,
+      },
+      { id: 'gemini-3.6-flash', providerId: 'google', name: 'gemini-3.6-flash', input: 0.75, output: 3.75, textOnly: true },
+    ])
+  })
+})
+
+describe('rates', () => {
+  test('a field the dataset is silent on is not a difference', () => {
+    expect(ratesDiffer({ input: 5, output: 25, cacheWrite1h: 10 }, { input: 5, output: 25 })).toBe(false)
+    expect(ratesDiffer({ input: 5, output: 25 }, { input: 5, output: 25, cacheRead: 0.5 })).toBe(false)
+    expect(ratesDiffer({ input: 5, output: 25 }, { input: 4, output: 25 })).toBe(true)
+    expect(ratesDiffer({ input: 5, output: 25, cacheRead: 0.5 }, { input: 5, output: 25, cacheRead: 0.6 })).toBe(true)
+  })
+
+  test('mergedRates carries the previous period into what the dataset omits', () => {
+    expect(mergedRates({ input: 5, output: 25, cacheWrite1h: 10 }, { input: 4, output: 20, cacheRead: 0.4 })).toEqual({
+      input: 4,
+      output: 20,
+      cacheRead: 0.4,
+      cacheWrite1h: 10,
+    })
+  })
+
+  test('periodInEffect picks the latest period at or before now, ignoring gateway rows', () => {
+    const prices = [
+      period({ modelSlug: 'a', from: 0, input: 2, output: 10 }),
+      period({ modelSlug: 'a', from: NOW + DAY, input: 3, output: 15 }),
+      period({ modelSlug: 'a', from: 0, input: 9, output: 9, provider: 'openrouter' }),
+    ]
+    expect(periodInEffect(prices, 'a', NOW)?.input).toBe(2)
+    expect(periodInEffect(prices, 'a', NOW + 2 * DAY)?.input).toBe(3)
+    expect(periodInEffect(prices, 'b', NOW)).toBeNull()
+  })
+
+  test('datasetProviderOf maps the catalog spellings', () => {
+    expect(datasetProviderOf('Anthropic')).toBe('anthropic')
+    expect(datasetProviderOf('Google DeepMind')).toBe('google')
+    expect(datasetProviderOf('Moonshot AI')).toBe('moonshotai')
+    expect(datasetProviderOf('Zhipu AI')).toBe('zai')
+    expect(datasetProviderOf('ElevenLabs')).toBeNull()
+  })
+})
+
+describe('planImport', () => {
+  test('an unchanged rate plans nothing', () => {
+    const p = plan({
+      models: [model({ slug: 'claude-opus-4-7' })],
+      prices: [period({ modelSlug: 'claude-opus-4-7', input: 5, output: 25, cacheRead: 0.5, cacheWrite5m: 6.25, cacheWrite1h: 10 })],
+      dataset: [dm({ id: 'claude-opus-4-7', providerId: 'anthropic', cacheRead: 0.5, cacheWrite5m: 6.25 })],
+    })
+    expect(p.periods).toEqual([])
+    expect(p.models).toEqual([])
+  })
+
+  test('a changed rate plans one period dated now, cited to the dataset, keeping the 1h tier', () => {
+    const p = plan({
+      models: [model({ slug: 'gpt-5.6-sol', provider: 'OpenAI' })],
+      prices: [period({ modelSlug: 'gpt-5.6-sol', input: 5, output: 30, cacheWrite1h: 10, source: 'openai-list-2026-08-02' })],
+      dataset: [dm({ id: 'gpt-5.6-sol', providerId: 'openai', input: 4, output: 20, cacheRead: 0.4 })],
+    })
+    expect(p.periods).toEqual([
+      {
+        modelSlug: 'gpt-5.6-sol',
+        from: NOW,
+        rates: { input: 4, output: 20, cacheRead: 0.4, cacheWrite1h: 10 },
+        source: 'models.dev@2026-08-29',
+        before: { input: 5, output: 30, cacheWrite1h: 10 },
+      },
+    ])
+  })
+
+  test('matches by alias under the row vendor only; a gateway listing never prices a vendor row', () => {
+    const p = plan({
+      models: [
+        model({ slug: 'glm-5.2', aliases: ['GLM-5.2'], provider: 'Zhipu AI' }),
+        model({ slug: 'gemini-3-pro-preview', provider: 'Google' }),
+      ],
+      dataset: [
+        dm({ id: 'GLM-5.2', providerId: 'alibaba', input: 9, output: 9 }),
+        dm({ id: 'glm-5.2', providerId: 'zai', input: 1, output: 3 }),
+        dm({ id: 'gemini-3-pro-preview', providerId: 'jiekou', input: 1.8, output: 10.8 }),
+      ],
+    })
+    expect(p.periods.map((x) => [x.modelSlug, x.rates.input])).toEqual([['glm-5.2', 1]])
+    expect(p.periods[0].before).toBeNull()
+  })
+
+  test('creates a pending row for an allowlisted, recent, text-only dataset model with no row', () => {
+    const p = plan({
+      models: [model({ slug: 'claude-opus-4-7' })],
+      dataset: [
+        dm({ id: 'claude-opus-4-7', providerId: 'anthropic' }),
+        dm({ id: 'MiniMax-M2.7', providerId: 'minimax', name: 'MiniMax M2.7', input: 0.3, output: 1.2, contextWindow: 200000 }),
+        // Kept out, each by one rule:
+        dm({ id: 'claude-opus-4-7-20260416', providerId: 'anthropic' }),
+        dm({ id: 'claude-haiku-4-5-20251001', providerId: 'anthropic' }),
+        dm({ id: 'gpt-4o', providerId: 'openai', releaseDate: '2024-05-13' }),
+        dm({ id: 'gemini-live', providerId: 'google', textOnly: false }),
+        dm({ id: 'mistral-large', providerId: 'mistral' }),
+        dm({ id: 'codex-auto-review', providerId: 'openai' }),
+        dm({ id: 'claude-opus-5#fast', providerId: 'anthropic' }),
+        dm({ id: 'undated', providerId: 'openai', releaseDate: undefined }),
+        dm({ id: 'gemini-flash-latest', providerId: 'google' }),
+        dm({ id: 'gemini-embedding-2', providerId: 'google' }),
+      ],
+    })
+    expect(p.models).toEqual([
+      {
+        name: 'MiniMax M2.7',
+        slug: 'minimax-m2.7',
+        provider: 'MiniMax',
+        aliases: ['MiniMax-M2.7'],
+        iconUrl: 'https://models.dev/logos/minimax.svg',
+        contextWindow: 200000,
+        reason: 'dataset',
+        rates: { input: 0.3, output: 1.2 },
+      },
+    ])
+    // Provider outside the allowlist is not counted as skipped; the rule-outs are.
+    expect(p.skipped).toBe(9)
+  })
+
+  test('a dated variant that strips to an existing slug creates no row and repices nothing twice', () => {
+    const p = plan({
+      models: [model({ slug: 'claude-haiku-4-5' })],
+      prices: [period({ modelSlug: 'claude-haiku-4-5', input: 1, output: 5 })],
+      dataset: [dm({ id: 'claude-haiku-4-5-20251001', providerId: 'anthropic', input: 1, output: 5 })],
+    })
+    expect(p.models).toEqual([])
+    expect(p.periods).toEqual([])
+  })
+
+  test('a measured id with tokens and no row becomes a pending row, from dataset metadata when it has some', () => {
+    const p = plan({
+      models: [model({ slug: 'claude-opus-4-7' })],
+      dataset: [dm({ id: 'kimi-k2.7-code', providerId: 'moonshotai', name: 'Kimi K2.7 Code', input: 0.6, output: 2.5, releaseDate: '2025-01-01' })],
+      measuredIds: [
+        'claude-opus-4-7',
+        'opencode-go:kimi-k2.7-code',
+        'gpt-daybreak-blue',
+        'codex-auto-review',
+        'claude-opus-5#fast',
+        'anthropic:claude-opus-4-7-20260416',
+      ],
+    })
+    expect(p.models).toEqual([
+      {
+        name: 'Kimi K2.7 Code',
+        slug: 'kimi-k2.7-code',
+        provider: 'Moonshot AI',
+        aliases: [],
+        iconUrl: 'https://models.dev/logos/moonshotai.svg',
+        reason: 'measured',
+        rates: { input: 0.6, output: 2.5 },
+      },
+      {
+        name: 'gpt-daybreak-blue',
+        slug: 'gpt-daybreak-blue',
+        provider: 'unknown',
+        aliases: [],
+        reason: 'measured',
+        rates: null,
+      },
+    ])
+  })
+
+  test('one slug is created once even when the dataset and the days both name it', () => {
+    const p = plan({
+      dataset: [dm({ id: 'deepseek-v4-pro', providerId: 'deepseek' })],
+      measuredIds: ['deepseek-v4-pro', 'opencode-go:deepseek-v4-pro'],
+    })
+    expect(p.models.map((m) => m.slug)).toEqual(['deepseek-v4-pro'])
+  })
+
+  test('a rejected row is left alone', () => {
+    const p = plan({
+      models: [model({ slug: 'claude-opus-4-7', reviewStatus: 'rejected' })],
+      dataset: [dm({ id: 'claude-opus-4-7', providerId: 'anthropic', input: 1, output: 1 })],
+    })
+    expect(p.periods).toEqual([])
+  })
+})

--- a/convex/lib/modelImport.ts
+++ b/convex/lib/modelImport.ts
@@ -1,0 +1,402 @@
+import { PRICED_LANES, vendorModelId } from '@aistack/pricing'
+import type { Doc } from '../_generated/dataModel'
+import { type ModelCatalog, resolveModelId } from './modelCatalog'
+
+/**
+ * The price and model import, as pure rules (#337). `planImport` takes what
+ * the database holds and what the dataset says and returns the writes; the
+ * Convex action fetches, and the mutation applies. Nothing in here touches IO,
+ * so this is where a rule gets tested.
+ *
+ * Two datasets are understood. models.dev `api.json` is primary; LiteLLM's
+ * `model_prices_and_context_window.json` is the fallback when models.dev does
+ * not answer. Neither carries dated history, so the import dates a change to
+ * the run that saw it (ADR-0012, #333).
+ */
+
+export const MODELS_DEV_URL = 'https://models.dev/api.json'
+export const LITELLM_URL =
+  'https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json'
+
+/** One dataset model in the shape the planner compares. USD per million tokens. */
+export type DatasetModel = {
+  /** The vendor's bare API id as the dataset spells it. */
+  id: string
+  /** The dataset's provider id (`anthropic`, `moonshotai`, ...). */
+  providerId: string
+  name: string
+  input: number
+  output: number
+  cacheRead?: number
+  cacheWrite5m?: number
+  cacheWrite1h?: number
+  contextWindow?: number
+  /** `YYYY-MM-DD` where the dataset has one. */
+  releaseDate?: string
+  /** True when the model reads text and writes only text. */
+  textOnly: boolean
+  /** An https icon the dataset offers, if any. */
+  iconUrl?: string
+}
+
+/**
+ * The vendors whose unknown models become pending rows. Keys are the dataset
+ * provider ids; values are the catalog's `models.provider` spelling. A vendor
+ * outside this list still gets price updates for rows the catalog already
+ * holds, but the import never creates a row for it.
+ */
+export const VENDOR_ALLOWLIST: Record<string, string> = {
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  google: 'Google',
+  xai: 'xAI',
+  moonshotai: 'Moonshot AI',
+  deepseek: 'DeepSeek',
+  zai: 'Zhipu AI',
+  minimax: 'MiniMax',
+}
+
+/** A dataset model older than this is not created. Rate updates ignore it. */
+export const CREATE_WINDOW_DAYS = 180
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/** The catalog's provider name as a dataset provider id, or null. */
+export function datasetProviderOf(provider: string | undefined): string | null {
+  const p = (provider ?? '').trim().toLowerCase()
+  if (!p) return null
+  for (const [id, name] of Object.entries(VENDOR_ALLOWLIST)) {
+    if (p === id || p === name.toLowerCase()) return id
+  }
+  if (p === 'google deepmind') return 'google'
+  if (p === 'moonshot' || p === 'moonshotai') return 'moonshotai'
+  if (p === 'z.ai' || p === 'zhipu') return 'zai'
+  return null
+}
+
+function num(x: unknown): number | undefined {
+  return typeof x === 'number' && Number.isFinite(x) ? x : undefined
+}
+
+/** Parse models.dev `api.json`: `{ [providerId]: { models: { [id]: {...} } } }`. */
+export function parseModelsDev(json: unknown): DatasetModel[] {
+  const out: DatasetModel[] = []
+  if (!json || typeof json !== 'object') return out
+  for (const [providerId, provider] of Object.entries(json as Record<string, any>)) {
+    const models = provider?.models
+    if (!models || typeof models !== 'object') continue
+    for (const [id, m] of Object.entries(models as Record<string, any>)) {
+      const input = num(m?.cost?.input)
+      const output = num(m?.cost?.output)
+      if (input === undefined || output === undefined) continue
+      const inputs: string[] = Array.isArray(m?.modalities?.input) ? m.modalities.input : []
+      const outputs: string[] = Array.isArray(m?.modalities?.output) ? m.modalities.output : []
+      const cacheRead = num(m.cost.cache_read)
+      const cacheWrite5m = num(m.cost.cache_write)
+      out.push({
+        id,
+        providerId,
+        name: typeof m?.name === 'string' && m.name.trim() ? m.name.trim() : id,
+        input,
+        output,
+        ...(cacheRead !== undefined ? { cacheRead } : {}),
+        ...(cacheWrite5m !== undefined ? { cacheWrite5m } : {}),
+        ...(num(m?.limit?.context) !== undefined ? { contextWindow: m.limit.context } : {}),
+        ...(typeof m?.release_date === 'string' ? { releaseDate: m.release_date } : {}),
+        textOnly: inputs.includes('text') && outputs.length === 1 && outputs[0] === 'text',
+        iconUrl: `https://models.dev/logos/${providerId}.svg`,
+      })
+    }
+  }
+  return out
+}
+
+/**
+ * Parse LiteLLM's table: `{ [key]: { litellm_provider, input_cost_per_token,
+ * ... } }`. Per-token costs become per-million. Only the bare keys are kept: a
+ * `vertex_ai/...` or `us.anthropic....` key is a re-serving, and the planner
+ * wants the vendor's own id. Provider ids are mapped onto the models.dev
+ * spelling where the two differ.
+ */
+export function parseLiteLlm(json: unknown): DatasetModel[] {
+  const out: DatasetModel[] = []
+  if (!json || typeof json !== 'object') return out
+  const providerMap: Record<string, string> = {
+    gemini: 'google',
+    vertex_ai: 'google',
+    moonshot: 'moonshotai',
+  }
+  for (const [key, m] of Object.entries(json as Record<string, any>)) {
+    if (key === 'sample_spec' || key.includes('/') || !m || typeof m !== 'object') continue
+    const input = num(m.input_cost_per_token)
+    const output = num(m.output_cost_per_token)
+    if (input === undefined || output === undefined) continue
+    if (m.mode !== undefined && m.mode !== 'chat' && m.mode !== 'responses') continue
+    const providerRaw = typeof m.litellm_provider === 'string' ? m.litellm_provider : ''
+    const providerId = providerMap[providerRaw] ?? providerRaw
+    if (!providerId) continue
+    const perMillion = (x: number | undefined) =>
+      x === undefined ? undefined : Math.round(x * 1e6 * 1e6) / 1e6
+    const cacheRead = perMillion(num(m.cache_read_input_token_cost))
+    const cacheWrite5m = perMillion(num(m.cache_creation_input_token_cost))
+    const cacheWrite1h = perMillion(num(m.cache_creation_input_token_cost_above_1hr))
+    out.push({
+      id: key,
+      providerId,
+      name: key,
+      input: perMillion(input) as number,
+      output: perMillion(output) as number,
+      ...(cacheRead !== undefined ? { cacheRead } : {}),
+      ...(cacheWrite5m !== undefined ? { cacheWrite5m } : {}),
+      ...(cacheWrite1h !== undefined ? { cacheWrite1h } : {}),
+      ...(num(m.max_input_tokens) !== undefined ? { contextWindow: m.max_input_tokens } : {}),
+      textOnly: true,
+    })
+  }
+  return out
+}
+
+/** The rates a period holds, for comparison and insertion. */
+export type Rates = {
+  input: number
+  output: number
+  cacheRead?: number
+  cacheWrite5m?: number
+  cacheWrite1h?: number
+}
+
+const RATE_KEYS = ['input', 'output', 'cacheRead', 'cacheWrite5m', 'cacheWrite1h'] as const
+
+function same(a: number | undefined, b: number | undefined): boolean {
+  if (a === undefined || b === undefined) return true
+  return Math.abs(a - b) < 1e-9
+}
+
+/**
+ * True when the dataset states a rate the period does not hold. A field the
+ * dataset is silent on is never a difference: models.dev has no 1-hour
+ * cache-write rate, and its silence must not open a new period.
+ */
+export function ratesDiffer(period: Rates, dataset: Rates): boolean {
+  return RATE_KEYS.some((k) => !same(period[k], dataset[k]))
+}
+
+/** The dataset's rates, with the previous period filling what it is silent on. */
+export function mergedRates(previous: Rates | null, dataset: Rates): Rates {
+  const out: Rates = { input: dataset.input, output: dataset.output }
+  for (const k of ['cacheRead', 'cacheWrite5m', 'cacheWrite1h'] as const) {
+    const value = dataset[k] ?? previous?.[k]
+    if (value !== undefined) out[k] = value
+  }
+  return out
+}
+
+/** The period in effect at `now` for a slug's vendor rate, else the earliest. */
+export function periodInEffect(
+  prices: readonly Doc<'modelPrices'>[],
+  slug: string,
+  now: number
+): Doc<'modelPrices'> | null {
+  const own = prices
+    .filter((p) => p.modelSlug === slug && p.provider === undefined)
+    .sort((a, b) => a.from - b.from)
+  if (own.length === 0) return null
+  const current = own.filter((p) => p.from <= now)
+  return current.length > 0 ? current[current.length - 1] : own[0]
+}
+
+export type PeriodInsert = {
+  modelSlug: string
+  from: number
+  rates: Rates
+  source: string
+  /** For the log line. */
+  before: Rates | null
+}
+
+export type ModelInsert = {
+  name: string
+  slug: string
+  provider: string
+  aliases: string[]
+  iconUrl?: string
+  contextWindow?: number
+  /** Why the row exists, for the log line. */
+  reason: 'dataset' | 'measured'
+  /** The first period, when the dataset priced it. */
+  rates: Rates | null
+}
+
+export type ImportPlan = {
+  periods: PeriodInsert[]
+  models: ModelInsert[]
+  /** Dataset models the allowlist and the window kept out, for the run line. */
+  skipped: number
+}
+
+/**
+ * A dataset id that is a variant or a non-chat product, never a row of its
+ * own: `#fast`, a dated snapshot, a priced lane, a `-latest` pointer, an
+ * embedding or a robotics model.
+ */
+function isVariantId(id: string): boolean {
+  const lower = id.toLowerCase()
+  return (
+    id.includes('#') ||
+    /-\d{8}$/.test(id) ||
+    PRICED_LANES.has(id) ||
+    lower.endsWith('-latest') ||
+    lower.includes('embedding') ||
+    lower.includes('robotics')
+  )
+}
+
+function withinWindow(releaseDate: string | undefined, now: number): boolean {
+  if (!releaseDate) return false
+  const at = Date.parse(`${releaseDate}T00:00:00Z`)
+  return Number.isFinite(at) && now - at <= CREATE_WINDOW_DAYS * DAY_MS
+}
+
+function ratesOf(m: DatasetModel): Rates {
+  return {
+    input: m.input,
+    output: m.output,
+    ...(m.cacheRead !== undefined ? { cacheRead: m.cacheRead } : {}),
+    ...(m.cacheWrite5m !== undefined ? { cacheWrite5m: m.cacheWrite5m } : {}),
+    ...(m.cacheWrite1h !== undefined ? { cacheWrite1h: m.cacheWrite1h } : {}),
+  }
+}
+
+/**
+ * Find the dataset model a catalog row stands for: the row's slug, then its
+ * aliases, case-insensitively, and ONLY under the row's own vendor. models.dev
+ * lists a model under every gateway that re-serves it, at the gateway's rate;
+ * a vendor row's price must never come from one of those. A row whose
+ * provider maps to no dataset vendor is matched against the allowlisted
+ * vendors only.
+ */
+export function datasetModelFor(
+  dataset: readonly DatasetModel[],
+  row: Pick<Doc<'models'>, 'slug' | 'aliases' | 'provider'>
+): DatasetModel | null {
+  const keys = [row.slug, ...(row.aliases ?? [])].map((k) => k.toLowerCase())
+  const own = datasetProviderOf(row.provider)
+  return (
+    dataset.find(
+      (m) =>
+        keys.includes(m.id.toLowerCase()) &&
+        (own ? m.providerId === own : m.providerId in VENDOR_ALLOWLIST)
+    ) ?? null
+  )
+}
+
+/**
+ * The writes one run makes. `measuredIds` are the ids with tokens > 0 on the
+ * days (never inventory, ADR-0012 decision 8). `source` is the dataset
+ * citation the new periods carry, e.g. `models.dev@2026-08-29`.
+ */
+export function planImport(args: {
+  catalog: ModelCatalog
+  models: readonly Doc<'models'>[]
+  prices: readonly Doc<'modelPrices'>[]
+  dataset: readonly DatasetModel[]
+  measuredIds: readonly string[]
+  source: string
+  now: number
+}): ImportPlan {
+  const { catalog, models, prices, dataset, measuredIds, source, now } = args
+  const periods: PeriodInsert[] = []
+  const modelInserts: ModelInsert[] = []
+  const claimed = new Set<string>()
+  let skipped = 0
+
+  const claim = (slug: string) => {
+    if (claimed.has(slug) || catalog.bySlug.has(slug) || catalog.byAlias.has(slug)) return false
+    claimed.add(slug)
+    return true
+  }
+
+  // 1. Rate changes on rows the catalog holds.
+  for (const row of models) {
+    if (row.reviewStatus === 'rejected') continue
+    const m = datasetModelFor(dataset, row)
+    if (!m) continue
+    const current = periodInEffect(prices, row.slug, now)
+    const rates = ratesOf(m)
+    if (current && !ratesDiffer(current, rates)) continue
+    periods.push({
+      modelSlug: row.slug,
+      from: now,
+      rates: mergedRates(current, rates),
+      source,
+      before: current
+        ? {
+            input: current.input,
+            output: current.output,
+            ...(current.cacheRead !== undefined ? { cacheRead: current.cacheRead } : {}),
+            ...(current.cacheWrite5m !== undefined ? { cacheWrite5m: current.cacheWrite5m } : {}),
+            ...(current.cacheWrite1h !== undefined ? { cacheWrite1h: current.cacheWrite1h } : {}),
+          }
+        : null,
+    })
+  }
+
+  // 2. Dataset models with no row: allowlisted vendor, text-only, recent,
+  // not a variant, and not resolvable to an existing row by the alias rules.
+  for (const m of dataset) {
+    const vendor = VENDOR_ALLOWLIST[m.providerId]
+    if (!vendor) continue
+    if (isVariantId(m.id) || !m.textOnly || !withinWindow(m.releaseDate, now)) {
+      skipped++
+      continue
+    }
+    if (resolveModelId(catalog, m.id).catalogSlug !== null) continue
+    const slug = m.id.toLowerCase()
+    if (!claim(slug)) continue
+    modelInserts.push({
+      name: m.name,
+      slug,
+      provider: vendor,
+      aliases: slug === m.id ? [] : [m.id],
+      ...(m.iconUrl ? { iconUrl: m.iconUrl } : {}),
+      ...(m.contextWindow !== undefined ? { contextWindow: m.contextWindow } : {}),
+      reason: 'dataset',
+      rates: ratesOf(m),
+    })
+  }
+
+  // 3. Measured ids with tokens that reach no row.
+  for (const id of measuredIds) {
+    if (id.includes('#')) continue
+    const bare = vendorModelId(id)
+    if (!bare || PRICED_LANES.has(bare)) continue
+    if (resolveModelId(catalog, id).catalogSlug !== null) continue
+    const meta =
+      dataset.find((m) => m.id.toLowerCase() === bare.toLowerCase() && VENDOR_ALLOWLIST[m.providerId]) ??
+      dataset.find((m) => m.id.toLowerCase() === bare.toLowerCase()) ??
+      null
+    const slug = meta ? meta.id.toLowerCase() : bare
+    if (!claim(slug)) continue
+    modelInserts.push({
+      name: meta?.name ?? bare,
+      slug,
+      provider: meta ? (VENDOR_ALLOWLIST[meta.providerId] ?? meta.providerId) : 'unknown',
+      aliases: [...new Set([bare, meta?.id ?? bare].filter((a) => a !== slug))],
+      ...(meta?.iconUrl && VENDOR_ALLOWLIST[meta.providerId] ? { iconUrl: meta.iconUrl } : {}),
+      ...(meta?.contextWindow !== undefined ? { contextWindow: meta.contextWindow } : {}),
+      reason: 'measured',
+      rates: meta ? ratesOf(meta) : null,
+    })
+  }
+
+  return { periods, models: modelInserts, skipped }
+}
+
+/** `$5/$25 in/out` style, for the log. */
+export function formatRates(r: Rates): string {
+  const parts = [`$${r.input}/$${r.output}`]
+  if (r.cacheRead !== undefined) parts.push(`read $${r.cacheRead}`)
+  if (r.cacheWrite5m !== undefined) parts.push(`write5m $${r.cacheWrite5m}`)
+  if (r.cacheWrite1h !== undefined) parts.push(`write1h $${r.cacheWrite1h}`)
+  return parts.join(', ')
+}

--- a/convex/modelImport.test.ts
+++ b/convex/modelImport.test.ts
@@ -1,0 +1,339 @@
+/// <reference types="vite/client" />
+import { convexTest } from 'convex-test'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { api, internal } from './_generated/api'
+import { ADMIN_EMAILS } from './lib/admin'
+import { LITELLM_URL, MODELS_DEV_URL } from './lib/modelImport'
+import { measuredIdsWithTokens } from './modelImport'
+import schema from './schema'
+
+const modules = import.meta.glob('./**/*.{js,ts}')
+
+function asAdmin(t: ReturnType<typeof convexTest>) {
+  return t.withIdentity({ tokenIdentifier: 'convex|admin', email: ADMIN_EMAILS[0] })
+}
+
+function stubFetch(pages: Record<string, unknown | { status: number }>) {
+  const calls: string[] = []
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string) => {
+      calls.push(url)
+      const page = pages[url]
+      if (page === undefined) return new Response('missing', { status: 404 })
+      if (typeof page === 'object' && page !== null && 'status' in page && Object.keys(page).length === 1) {
+        return new Response('refused', { status: (page as { status: number }).status })
+      }
+      return new Response(JSON.stringify(page), { status: 200 })
+    })
+  )
+  return calls
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+const MODELS_DEV = {
+  anthropic: {
+    id: 'anthropic',
+    models: {
+      'claude-opus-4-7': {
+        id: 'claude-opus-4-7',
+        name: 'Claude Opus 4.7',
+        release_date: '2026-04-14',
+        modalities: { input: ['text'], output: ['text'] },
+        limit: { context: 1000000 },
+        cost: { input: 5, output: 25, cache_read: 0.5, cache_write: 6.25 },
+      },
+    },
+  },
+  openai: {
+    id: 'openai',
+    models: {
+      'gpt-5.6-sol': {
+        id: 'gpt-5.6-sol',
+        name: 'GPT-5.6 Sol',
+        release_date: '2026-07-29',
+        modalities: { input: ['text'], output: ['text'] },
+        cost: { input: 4, output: 20, cache_read: 0.4 },
+      },
+    },
+  },
+}
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  await t.run(async (ctx) => {
+    const now = 1
+    for (const [slug, provider] of [
+      ['claude-opus-4-7', 'Anthropic'],
+      ['gpt-5.6-sol', 'OpenAI'],
+    ] as const) {
+      await ctx.db.insert('models', {
+        name: slug,
+        slug,
+        shortId: slug.slice(0, 6),
+        provider,
+        category: 'coding',
+        reviewStatus: 'approved',
+        createdAt: now,
+        updatedAt: now,
+      })
+    }
+    await ctx.db.insert('modelPrices', {
+      modelSlug: 'claude-opus-4-7',
+      from: 0,
+      input: 5,
+      output: 25,
+      cacheRead: 0.5,
+      cacheWrite5m: 6.25,
+      cacheWrite1h: 10,
+      source: 'anthropic-list-2026-07-25',
+      createdAt: now,
+    })
+    await ctx.db.insert('modelPrices', {
+      modelSlug: 'gpt-5.6-sol',
+      from: 0,
+      input: 5,
+      output: 30,
+      source: 'openai-list-2026-08-02',
+      createdAt: now,
+    })
+  })
+}
+
+describe('modelImport (#337)', () => {
+  test('an unchanged rate writes nothing but the run line', async () => {
+    const t = convexTest(schema, modules)
+    await seed(t)
+    await t.run(async (ctx) => {
+      // Make Sol match the dataset so the whole run is a no-op.
+      const sol = await ctx.db
+        .query('modelPrices')
+        .withIndex('by_model', (q) => q.eq('modelSlug', 'gpt-5.6-sol'))
+        .first()
+      await ctx.db.patch(sol!._id, { input: 4, output: 20, cacheRead: 0.4 })
+    })
+    stubFetch({ [MODELS_DEV_URL]: MODELS_DEV })
+
+    const result = await t.action(internal.modelImport.run, {})
+    expect(result).toMatchObject({ periods: 0, models: 0 })
+    expect(result.source).toMatch(/^models\.dev@\d{4}-\d{2}-\d{2}$/)
+
+    await t.run(async (ctx) => {
+      expect(await ctx.db.query('modelPrices').collect()).toHaveLength(2)
+      expect(await ctx.db.query('models').collect()).toHaveLength(2)
+      const log = await ctx.db.query('importLog').collect()
+      expect(log.map((l) => l.kind)).toEqual(['run'])
+      expect(log[0].detail).toMatch(/0 price changes, 0 new pending rows/)
+    })
+  })
+
+  test('a changed rate appends a period dated to the run and logs it', async () => {
+    const t = convexTest(schema, modules)
+    await seed(t)
+    stubFetch({ [MODELS_DEV_URL]: MODELS_DEV })
+    const before = Date.now()
+
+    const result = await t.action(internal.modelImport.run, {})
+    expect(result).toMatchObject({ periods: 1, models: 0 })
+
+    await t.run(async (ctx) => {
+      const sol = await ctx.db
+        .query('modelPrices')
+        .withIndex('by_model', (q) => q.eq('modelSlug', 'gpt-5.6-sol'))
+        .collect()
+      expect(sol).toHaveLength(2)
+      const added = sol.find((p) => p.from !== 0)!
+      expect(added.from).toBeGreaterThanOrEqual(before)
+      expect(added).toMatchObject({ input: 4, output: 20, cacheRead: 0.4, source: result.source })
+      expect(added.provider).toBeUndefined()
+      const log = await ctx.db.query('importLog').collect()
+      expect(log.map((l) => l.kind).sort()).toEqual(['price', 'run'])
+      const line = log.find((l) => l.kind === 'price')!
+      expect(line.modelSlug).toBe('gpt-5.6-sol')
+      expect(line.detail).toBe(`$5/$30 -> $4/$20, read $0.4 (${result.source})`)
+    })
+
+    // The same dataset again: nothing more.
+    const again = await t.action(internal.modelImport.run, {})
+    expect(again).toMatchObject({ periods: 0, models: 0 })
+  })
+
+  test('creates pending rows for a new dataset model and for a measured id, never for the review lane', async () => {
+    const t = convexTest(schema, modules)
+    await seed(t)
+    await t.run(async (ctx) => {
+      const creatorId = await ctx.db.insert('creators', {
+        name: 'Owner',
+        slug: 'owner',
+        userId: 'user_1',
+        verified: false,
+        personalPages: [],
+        projectPages: [],
+        createdAt: 1,
+      })
+      const stackId = await ctx.db.insert('stacks', {
+        name: 'S',
+        slug: 's',
+        shortId: 'ssssss',
+        creatorId,
+        oneLiner: 'A stack',
+        toolSubscriptions: [],
+        hasUsageComponent: false,
+        published: true,
+        createdAt: 1,
+        updatedAt: 1,
+      } as never)
+      const usage = (models: Array<[string, number]>) => ({
+        harnesses: [
+          {
+            harness: 'codex',
+            sessions: 1,
+            projectKeys: [],
+            models: models.map(([model, input]) => ({
+              model,
+              tokens: { input, output: 0, cacheWrite: 0, cacheRead: 0 },
+            })),
+            subagentTokens: 0,
+            excludedTokens: { unpriced: 0, synthetic: 0 },
+          },
+        ],
+      })
+      await ctx.db.insert('measuredDays', {
+        stackId,
+        machine: 'laptop',
+        date: '2026-08-28',
+        capturedAt: 1,
+        receivedAt: 1,
+        aggregateVersion: 'measured-days/v1',
+        fingerprint: 'a',
+        usage: usage([
+          ['codex-auto-review', 100],
+          ['openai-codex:gpt-daybreak-blue', 7],
+          ['opencode-go:glm-5.2', 0],
+          ['claude-opus-4-7', 50],
+        ]),
+      })
+    })
+    stubFetch({
+      [MODELS_DEV_URL]: {
+        ...MODELS_DEV,
+        minimax: {
+          id: 'minimax',
+          models: {
+            'MiniMax-M2.7': {
+              id: 'MiniMax-M2.7',
+              name: 'MiniMax M2.7',
+              release_date: '2026-08-01',
+              modalities: { input: ['text'], output: ['text'] },
+              limit: { context: 204800 },
+              cost: { input: 0.3, output: 1.2, cache_read: 0.06, cache_write: 0.375 },
+            },
+          },
+        },
+      },
+    })
+
+    const result = await t.action(internal.modelImport.run, {})
+    expect(result).toMatchObject({ periods: 1, models: 2 })
+
+    await t.run(async (ctx) => {
+      const pending = await ctx.db
+        .query('models')
+        .withIndex('by_reviewStatus', (q) => q.eq('reviewStatus', 'pending'))
+        .collect()
+      expect(pending.map((m) => m.slug).sort()).toEqual(['gpt-daybreak-blue', 'minimax-m2.7'])
+      const mm = pending.find((m) => m.slug === 'minimax-m2.7')!
+      expect(mm).toMatchObject({
+        name: 'MiniMax M2.7',
+        provider: 'MiniMax',
+        aliases: ['MiniMax-M2.7'],
+        iconUrl: 'https://models.dev/logos/minimax.svg',
+        contextWindow: 204800,
+        createdBy: 'import',
+      })
+      expect(mm.shortId).toHaveLength(6)
+      const bare = pending.find((m) => m.slug === 'gpt-daybreak-blue')!
+      expect(bare.provider).toBe('unknown')
+      expect(bare.iconUrl).toBeUndefined()
+      const mmPrices = await ctx.db
+        .query('modelPrices')
+        .withIndex('by_model', (q) => q.eq('modelSlug', 'minimax-m2.7'))
+        .collect()
+      expect(mmPrices).toHaveLength(1)
+      expect(mmPrices[0]).toMatchObject({ input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite5m: 0.375 })
+      const all = await ctx.db.query('models').collect()
+      expect(all.some((m) => m.slug === 'codex-auto-review')).toBe(false)
+      expect(all.some((m) => m.slug === 'glm-5.2')).toBe(false)
+      const log = await ctx.db.query('importLog').collect()
+      expect(log.filter((l) => l.kind === 'model').map((l) => l.modelSlug).sort()).toEqual([
+        'gpt-daybreak-blue',
+        'minimax-m2.7',
+      ])
+    })
+
+    // A second run creates nothing more.
+    const again = await t.action(internal.modelImport.run, {})
+    expect(again).toMatchObject({ periods: 0, models: 0 })
+  })
+
+  test('falls back to LiteLLM when models.dev does not answer, and cites it', async () => {
+    const t = convexTest(schema, modules)
+    await seed(t)
+    const calls = stubFetch({
+      [MODELS_DEV_URL]: { status: 503 },
+      [LITELLM_URL]: {
+        'gpt-5.6-sol': {
+          litellm_provider: 'openai',
+          mode: 'chat',
+          input_cost_per_token: 0.000004,
+          output_cost_per_token: 0.00002,
+        },
+      },
+    })
+    const result = await t.action(internal.modelImport.run, {})
+    expect(calls).toEqual([MODELS_DEV_URL, LITELLM_URL])
+    expect(result.source).toMatch(/^litellm@/)
+    expect(result).toMatchObject({ periods: 1, models: 0 })
+  })
+
+  test('a run whose datasets both fail writes an error line and throws', async () => {
+    const t = convexTest(schema, modules)
+    stubFetch({})
+    await expect(t.action(internal.modelImport.run, {})).rejects.toThrow(/HTTP 404/)
+    await t.run(async (ctx) => {
+      const log = await ctx.db.query('importLog').collect()
+      expect(log.map((l) => l.kind)).toEqual(['error'])
+    })
+  })
+
+  test('runNow and readLog are admin-only', async () => {
+    const t = convexTest(schema, modules)
+    stubFetch({ [MODELS_DEV_URL]: MODELS_DEV })
+    await expect(t.action(api.modelImport.runNow, {})).rejects.toThrow(/Unauthorized/)
+    expect(await t.query(api.modelImport.readLog, {})).toBeNull()
+
+    const admin = asAdmin(t)
+    const result = await admin.action(api.modelImport.runNow, {})
+    expect(result.source).toMatch(/^models\.dev@/)
+    const log = await admin.query(api.modelImport.readLog, {})
+    expect(log?.map((l) => l.kind)).toContain('run')
+  })
+})
+
+describe('measuredIdsWithTokens', () => {
+  test('keeps an id only when a day holds tokens for it', () => {
+    const day = (models: Array<[string, number]>) => ({
+      usage: {
+        harnesses: [
+          {
+            models: models.map(([model, n]) => ({
+              model,
+              tokens: { input: 0, output: 0, cacheWrite: 0, cacheRead: n },
+            })),
+          },
+        ],
+      },
+    })
+    expect(measuredIdsWithTokens([day([['a', 0], ['b', 1]]), day([['a', 2]]), {}])).toEqual(['a', 'b'])
+  })
+})

--- a/convex/modelImport.ts
+++ b/convex/modelImport.ts
@@ -1,0 +1,290 @@
+import { v } from 'convex/values'
+import { internal } from './_generated/api'
+import {
+  action,
+  internalAction,
+  internalMutation,
+  internalQuery,
+  query,
+} from './_generated/server'
+import { isAdmin } from './lib/admin'
+import { generateUniqueShortId } from './lib/ids'
+import { catalogFrom } from './lib/modelCatalog'
+import {
+  type DatasetModel,
+  LITELLM_URL,
+  MODELS_DEV_URL,
+  formatRates,
+  parseLiteLlm,
+  parseModelsDev,
+  planImport,
+} from './lib/modelImport'
+
+/**
+ * The price and model import (#337). Daily by cron, or by hand from the admin
+ * page. The rules are in `convex/lib/modelImport.ts`; this file is the IO
+ * around them: one query reads the state, one action fetches the dataset and
+ * plans, one mutation applies the plan and writes the log.
+ *
+ * A run that finds nothing changed writes nothing to `modelPrices` and
+ * `models`, and one `run` line to the log. That is the contract the tests pin.
+ */
+
+const RatesV = v.object({
+  input: v.number(),
+  output: v.number(),
+  cacheRead: v.optional(v.number()),
+  cacheWrite5m: v.optional(v.number()),
+  cacheWrite1h: v.optional(v.number()),
+})
+
+const PeriodInsertV = v.object({
+  modelSlug: v.string(),
+  from: v.number(),
+  rates: RatesV,
+  source: v.string(),
+  before: v.union(RatesV, v.null()),
+})
+
+const ModelInsertV = v.object({
+  name: v.string(),
+  slug: v.string(),
+  provider: v.string(),
+  aliases: v.array(v.string()),
+  iconUrl: v.optional(v.string()),
+  contextWindow: v.optional(v.number()),
+  reason: v.union(v.literal('dataset'), v.literal('measured')),
+  rates: v.union(RatesV, v.null()),
+})
+
+const LOG_KEEP = 500
+
+type RunResult = { periods: number; models: number; source: string }
+
+/** Every measured id with tokens > 0 on a day (never inventory). */
+export function measuredIdsWithTokens(
+  days: ReadonlyArray<{
+    usage?: { harnesses: Array<{ models: Array<{ model: string; tokens: Record<string, unknown> }> }> }
+  }>
+): string[] {
+  const ids = new Set<string>()
+  for (const day of days) {
+    for (const h of day.usage?.harnesses ?? []) {
+      for (const m of h.models) {
+        const t = m.tokens as { input: number; output: number; cacheWrite: number; cacheRead: number }
+        if (t.input + t.output + t.cacheWrite + t.cacheRead > 0) ids.add(m.model)
+      }
+    }
+  }
+  return [...ids].sort()
+}
+
+/**
+ * The catalog, the periods and the measured ids, in one read. The days are
+ * collected whole: the table is a few hundred rows a day of one machine, and
+ * the ids are the only thing wanted from them.
+ */
+export const readState = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const [models, prices, days] = await Promise.all([
+      ctx.db.query('models').collect(),
+      ctx.db.query('modelPrices').collect(),
+      ctx.db.query('measuredDays').collect(),
+    ])
+    return { models, prices, measuredIds: measuredIdsWithTokens(days) }
+  },
+})
+
+/**
+ * Apply a plan. Re-checks the slug against the table before inserting a row
+ * (the plan was made from a snapshot) and skips a period that already exists
+ * at the same `from`. Writes one log line per write and the run line last.
+ */
+export const apply = internalMutation({
+  args: {
+    periods: v.array(PeriodInsertV),
+    models: v.array(ModelInsertV),
+    source: v.string(),
+    skipped: v.number(),
+    now: v.number(),
+  },
+  returns: v.object({ periods: v.number(), models: v.number() }),
+  handler: async (ctx, args) => {
+    const { now, source } = args
+    let periodsWritten = 0
+    let modelsWritten = 0
+    for (const p of args.periods) {
+      const existing = await ctx.db
+        .query('modelPrices')
+        .withIndex('by_model', (q) =>
+          q.eq('modelSlug', p.modelSlug).eq('provider', undefined).eq('from', p.from)
+        )
+        .first()
+      if (existing) continue
+      await ctx.db.insert('modelPrices', {
+        modelSlug: p.modelSlug,
+        from: p.from,
+        ...p.rates,
+        source,
+        createdAt: now,
+      })
+      periodsWritten++
+      await ctx.db.insert('importLog', {
+        at: now,
+        kind: 'price',
+        modelSlug: p.modelSlug,
+        detail: p.before
+          ? `${formatRates(p.before)} -> ${formatRates(p.rates)} (${source})`
+          : `first period ${formatRates(p.rates)} (${source})`,
+      })
+    }
+    for (const m of args.models) {
+      const taken = await ctx.db
+        .query('models')
+        .withIndex('by_slug', (q) => q.eq('slug', m.slug))
+        .first()
+      if (taken) continue
+      const shortId = await generateUniqueShortId(ctx, 'models')
+      await ctx.db.insert('models', {
+        name: m.name,
+        slug: m.slug,
+        shortId,
+        ...(m.aliases.length > 0 ? { aliases: m.aliases } : {}),
+        provider: m.provider,
+        category: 'coding',
+        ...(m.iconUrl ? { iconUrl: m.iconUrl } : {}),
+        ...(m.contextWindow !== undefined ? { contextWindow: m.contextWindow } : {}),
+        reviewStatus: 'pending',
+        createdBy: 'import',
+        createdAt: now,
+        updatedAt: now,
+      })
+      modelsWritten++
+      if (m.rates) {
+        await ctx.db.insert('modelPrices', {
+          modelSlug: m.slug,
+          from: now,
+          ...m.rates,
+          source,
+          createdAt: now,
+        })
+      }
+      await ctx.db.insert('importLog', {
+        at: now,
+        kind: 'model',
+        modelSlug: m.slug,
+        detail:
+          m.reason === 'measured'
+            ? `pending row for a measured id (${m.provider})${m.rates ? `, ${formatRates(m.rates)}` : ', unpriced'}`
+            : `pending row from ${source} (${m.provider}), ${m.rates ? formatRates(m.rates) : 'unpriced'}`,
+      })
+    }
+    await ctx.db.insert('importLog', {
+      at: now,
+      kind: 'run',
+      detail: `${source}: ${periodsWritten} price ${periodsWritten === 1 ? 'change' : 'changes'}, ${modelsWritten} new pending ${modelsWritten === 1 ? 'row' : 'rows'}, ${args.skipped} dataset models outside the rule`,
+    })
+    // Keep the log bounded.
+    const all = await ctx.db.query('importLog').withIndex('by_at').order('desc').collect()
+    for (const old of all.slice(LOG_KEEP)) await ctx.db.delete(old._id)
+    return { periods: periodsWritten, models: modelsWritten }
+  },
+})
+
+export const logError = internalMutation({
+  args: { detail: v.string(), now: v.number() },
+  handler: async (ctx, args) => {
+    await ctx.db.insert('importLog', { at: args.now, kind: 'error', detail: args.detail })
+  },
+})
+
+async function fetchJson(url: string): Promise<unknown> {
+  const res = await fetch(url, { headers: { Accept: 'application/json' } })
+  if (!res.ok) throw new Error(`${url}: HTTP ${res.status}`)
+  return res.json()
+}
+
+/** models.dev first; LiteLLM when it does not answer. */
+export async function fetchDataset(): Promise<{ dataset: DatasetModel[]; source: string }> {
+  const date = new Date().toISOString().slice(0, 10)
+  try {
+    const dataset = parseModelsDev(await fetchJson(MODELS_DEV_URL))
+    if (dataset.length === 0) throw new Error('models.dev: empty dataset')
+    return { dataset, source: `models.dev@${date}` }
+  } catch (primary) {
+    const dataset = parseLiteLlm(await fetchJson(LITELLM_URL))
+    if (dataset.length === 0) {
+      throw new Error(
+        `both datasets failed: ${primary instanceof Error ? primary.message : String(primary)}; litellm: empty`
+      )
+    }
+    return { dataset, source: `litellm@${date}` }
+  }
+}
+
+/** The whole run. Errors land in the log, never in the cron's stderr only. */
+export const run = internalAction({
+  args: {},
+  returns: v.object({ periods: v.number(), models: v.number(), source: v.string() }),
+  handler: async (ctx): Promise<RunResult> => {
+    const now = Date.now()
+    try {
+      const { dataset, source } = await fetchDataset()
+      const state = await ctx.runQuery(internal.modelImport.readState, {})
+      const plan = planImport({
+        catalog: catalogFrom(state.models, state.prices),
+        models: state.models,
+        prices: state.prices,
+        dataset,
+        measuredIds: state.measuredIds,
+        source,
+        now,
+      })
+      const written: { periods: number; models: number } = await ctx.runMutation(internal.modelImport.apply, {
+        periods: plan.periods,
+        models: plan.models,
+        source,
+        skipped: plan.skipped,
+        now,
+      })
+      return { ...written, source }
+    } catch (e) {
+      await ctx.runMutation(internal.modelImport.logError, {
+        detail: e instanceof Error ? e.message : String(e),
+        now,
+      })
+      throw e
+    }
+  },
+})
+
+/** The admin's "Run import now". Guarded server-side; the route gate is not protection. */
+export const runNow = action({
+  args: {},
+  returns: v.object({ periods: v.number(), models: v.number(), source: v.string() }),
+  handler: async (ctx): Promise<RunResult> => {
+    if (!(await isAdmin(ctx))) throw new Error('Unauthorized')
+    return await ctx.runAction(internal.modelImport.run, {})
+  },
+})
+
+/** The log, newest first. Null for anyone but an admin. */
+export const readLog = query({
+  args: { limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    if (!(await isAdmin(ctx))) return null
+    const rows = await ctx.db
+      .query('importLog')
+      .withIndex('by_at')
+      .order('desc')
+      .take(Math.min(args.limit ?? 100, LOG_KEEP))
+    return rows.map((r) => ({
+      _id: r._id,
+      at: r.at,
+      kind: r.kind,
+      modelSlug: r.modelSlug ?? null,
+      detail: r.detail,
+    }))
+  },
+})

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1019,6 +1019,20 @@ export default defineSchema({
     .index('by_model', ['modelSlug', 'provider', 'from'])
     .index('by_from', ['from']),
 
+  // The import's admin log (#337): one line per thing the price and model
+  // import did. A run that changes nothing writes only its `run` line.
+  importLog: defineTable({
+    at: v.number(),
+    kind: v.union(
+      v.literal('run'),
+      v.literal('price'),
+      v.literal('model'),
+      v.literal('error')
+    ),
+    modelSlug: v.optional(v.string()),
+    detail: v.string(),
+  }).index('by_at', ['at']),
+
   cliSessions: defineTable({
     userCode: v.string(),
     secretId: v.string(),

--- a/src/components/admin/AdminImportTab.tsx
+++ b/src/components/admin/AdminImportTab.tsx
@@ -1,0 +1,203 @@
+import { useAction, useMutation, useQuery } from "convex/react";
+import { Brain, Check, Download, X } from "lucide-react";
+import { useState } from "react";
+import { api } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
+import { ItemIcon } from "../ItemIcon";
+
+/**
+ * The price and model import (#337): run it by hand, approve the pending rows
+ * it created, and read what it did. The cron does the same run daily.
+ */
+export function AdminImportTab() {
+	const log = useQuery(api.modelImport.readLog, { limit: 200 });
+	const pendingModels = useQuery(api.admin.getPendingModels);
+	const runNow = useAction(api.modelImport.runNow);
+	const approveModel = useMutation(api.admin.approveModel);
+	const rejectModel = useMutation(api.admin.rejectModel);
+	const [running, setRunning] = useState(false);
+	const [result, setResult] = useState<string | null>(null);
+
+	const handleRun = async () => {
+		setRunning(true);
+		setResult(null);
+		try {
+			const r = await runNow({});
+			setResult(
+				`${r.source}: ${r.periods} price ${r.periods === 1 ? "change" : "changes"}, ${r.models} new pending ${r.models === 1 ? "row" : "rows"}`,
+			);
+		} catch (error) {
+			setResult(
+				`Failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		} finally {
+			setRunning(false);
+		}
+	};
+
+	const handleApprove = async (modelId: Id<"models">) => {
+		try {
+			await approveModel({ modelId });
+		} catch (error) {
+			console.error("Failed to approve model:", error);
+		}
+	};
+
+	const handleReject = async (modelId: Id<"models">) => {
+		try {
+			await rejectModel({ modelId });
+		} catch (error) {
+			console.error("Failed to reject model:", error);
+		}
+	};
+
+	return (
+		<div className="py-12 sm:py-16">
+			<div className="mx-auto max-w-6xl px-4 sm:px-6">
+				<div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+					<div>
+						<h2 className="font-mono text-xl font-bold uppercase tracking-wide text-fg-primary">
+							Price and model import
+						</h2>
+						<p className="mt-1 font-mono text-xs text-fg-muted">
+							models.dev daily at 05:00 UTC, LiteLLM as fallback. A rate change
+							is a new dated period; an unknown model is a pending row.
+						</p>
+					</div>
+					<div className="flex items-center gap-3">
+						{result && (
+							<span className="font-mono text-xs text-fg-secondary">
+								{result}
+							</span>
+						)}
+						<button
+							type="button"
+							onClick={handleRun}
+							disabled={running}
+							className="inline-flex items-center gap-2 border-2 border-accent-lime bg-accent-lime px-3 py-1.5 font-mono text-xs font-semibold uppercase tracking-wide text-accent-lime-contrast transition-colors hover:bg-accent-lime/90 disabled:opacity-50"
+						>
+							<Download className="size-3.5" />
+							{running ? "Running..." : "Run import now"}
+						</button>
+					</div>
+				</div>
+
+				<section className="mb-12">
+					<h3 className="mb-4 font-mono text-sm font-semibold uppercase tracking-wide text-fg-secondary">
+						Pending models
+						{pendingModels && pendingModels.length > 0 ? (
+							<span className="ml-2 inline-flex h-5 min-w-5 items-center justify-center bg-accent-lime px-1 font-mono text-xs font-bold text-bg-canvas">
+								{pendingModels.length}
+							</span>
+						) : null}
+					</h3>
+					{!pendingModels || pendingModels.length === 0 ? (
+						<div className="border-2 border-dashed border-stroke-subtle px-4 py-8 text-center">
+							<p className="font-mono text-sm text-fg-muted">
+								No pending models
+							</p>
+						</div>
+					) : (
+						<div className="border-2 border-stroke-strong bg-bg-panel">
+							{pendingModels.map((model) => (
+								<div
+									key={model._id}
+									className="flex flex-wrap items-center justify-between gap-4 border-b border-stroke-subtle px-4 py-3 last:border-b-0"
+								>
+									<div className="flex items-center gap-3">
+										<ItemIcon
+											src={model.iconUrl}
+											alt={model.name}
+											size="sm"
+											fallbackIcon={Brain}
+										/>
+										<div>
+											<div className="font-mono text-sm font-semibold text-fg-primary">
+												{model.name}
+											</div>
+											<div className="font-mono text-xs text-fg-muted">
+												{model.slug} · {model.provider}
+												{model.aliases && model.aliases.length > 0
+													? ` · aliases: ${model.aliases.join(", ")}`
+													: ""}
+												{model.createdBy === "import" ? " · import" : ""}
+											</div>
+										</div>
+									</div>
+									<div className="flex gap-2">
+										<button
+											type="button"
+											onClick={() => handleApprove(model._id)}
+											className="inline-flex items-center gap-1.5 border-2 border-accent-lime bg-accent-lime px-3 py-1.5 font-mono text-xs font-semibold uppercase tracking-wide text-accent-lime-contrast transition-colors hover:bg-accent-lime/90"
+										>
+											<Check className="size-3.5" />
+											Approve
+										</button>
+										<button
+											type="button"
+											onClick={() => handleReject(model._id)}
+											className="inline-flex items-center gap-1.5 border border-stroke-subtle px-3 py-1.5 font-mono text-xs font-semibold uppercase tracking-wide text-fg-secondary transition-colors hover:border-destructive hover:text-destructive"
+										>
+											<X className="size-3.5" />
+											Reject
+										</button>
+									</div>
+								</div>
+							))}
+						</div>
+					)}
+				</section>
+
+				<section>
+					<h3 className="mb-4 font-mono text-sm font-semibold uppercase tracking-wide text-fg-secondary">
+						Import log
+					</h3>
+					{!log || log.length === 0 ? (
+						<div className="border-2 border-dashed border-stroke-subtle px-4 py-8 text-center">
+							<p className="font-mono text-sm text-fg-muted">No runs yet</p>
+						</div>
+					) : (
+						<div className="overflow-x-auto border-2 border-stroke-strong bg-bg-panel">
+							<table className="w-full font-mono text-xs">
+								<tbody>
+									{log.map((line) => (
+										<tr
+											key={line._id}
+											className="border-b border-stroke-subtle last:border-b-0"
+										>
+											<td className="whitespace-nowrap px-4 py-2 text-fg-muted">
+												{new Date(line.at)
+													.toISOString()
+													.replace("T", " ")
+													.slice(0, 16)}
+											</td>
+											<td className="px-2 py-2">
+												<span
+													className={`inline-block px-1.5 py-0.5 font-semibold uppercase ${
+														line.kind === "error"
+															? "bg-destructive-fill text-white"
+															: line.kind === "run"
+																? "bg-bg-canvas text-fg-muted"
+																: "bg-accent-lime text-bg-canvas"
+													}`}
+												>
+													{line.kind}
+												</span>
+											</td>
+											<td className="whitespace-nowrap px-2 py-2 text-fg-primary">
+												{line.modelSlug ?? ""}
+											</td>
+											<td className="px-4 py-2 text-fg-secondary">
+												{line.detail}
+											</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					)}
+				</section>
+			</div>
+		</div>
+	);
+}

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -9,6 +9,7 @@ import { useQuery } from "convex/react";
 import {
 	ChartNoAxesColumn,
 	ClipboardCheck,
+	Download,
 	Flag,
 	Mail,
 	Newspaper,
@@ -18,6 +19,7 @@ import {
 	AdminEmailTab,
 	type EmailSubTab,
 } from "@/components/admin/AdminEmailTab";
+import { AdminImportTab } from "@/components/admin/AdminImportTab";
 import { AdminNewsTab, type NewsSubTab } from "@/components/admin/AdminNewsTab";
 import { AdminQualityTab } from "@/components/admin/AdminQualityTab";
 import { AdminReviewTab } from "@/components/admin/AdminReviewTab";
@@ -26,7 +28,7 @@ import { coerceEnum } from "@/lib/searchParams";
 import { seoMeta } from "@/lib/seo";
 import { api } from "../../convex/_generated/api";
 
-type AdminTab = "review" | "quality" | "email" | "views" | "news";
+type AdminTab = "review" | "quality" | "email" | "views" | "news" | "import";
 
 export const ADMIN_SEARCH_DEFAULTS = {
 	tab: "review" as AdminTab,
@@ -42,7 +44,7 @@ export const Route = createFileRoute("/admin")({
 	): { tab?: AdminTab; view?: EmailSubTab; news?: NewsSubTab } => ({
 		tab: coerceEnum(
 			search.tab,
-			["review", "quality", "email", "views", "news"] as const,
+			["review", "quality", "email", "views", "news", "import"] as const,
 			"review",
 		),
 		view: coerceEnum(
@@ -204,6 +206,18 @@ function AdminPage() {
 								</span>
 							) : null}
 						</button>
+						<button
+							type="button"
+							onClick={() => setSearch({ tab: "import" })}
+							className={`inline-flex items-center gap-2 border-b-2 px-6 py-4 font-mono text-sm font-semibold uppercase tracking-wide transition-colors -mb-[2px] ${
+								tab === "import"
+									? "border-accent-lime text-accent-lime"
+									: "border-transparent text-fg-muted hover:text-fg-primary"
+							}`}
+						>
+							<Download className="size-4" />
+							Import
+						</button>
 						<LivingStacks />
 					</div>
 				</div>
@@ -219,6 +233,7 @@ function AdminPage() {
 				/>
 			)}
 			{tab === "views" && <AdminViewsTab />}
+			{tab === "import" && <AdminImportTab />}
 			{tab === "news" && (
 				<AdminNewsTab
 					view={news}


### PR DESCRIPTION
Closes #337. Builds on #341 (#336): the import writes only `modelPrices` periods and `models` rows, and everything still reads prices through `loadModelCatalog` / `priceAt`.

## What changed

**Import** (`convex/modelImport.ts`, rules in `convex/lib/modelImport.ts`). An `internalAction` `run` fetches models.dev `https://models.dev/api.json` (fallback: LiteLLM `model_prices_and_context_window.json` from raw GitHub, cited `litellm@<date>`), reads the state in one internal query, plans with a pure function, and applies through one internal mutation.

- **Rate changes.** For each catalog row (not rejected) that maps to a dataset model by slug, then aliases, case-insensitively, and ONLY under the row's own vendor, the dataset's `input`, `output`, `cache_read`, `cache_write` (and the 1h tier from LiteLLM) are compared to the period in effect now. A difference appends one period with `from = now`, `source = models.dev@<date>`, carrying forward any tier the dataset is silent on (models.dev has no 1h rate), and writes a `price` log line. Unchanged writes nothing: `an unchanged rate writes nothing but the run line` pins it, and a second run of the same dataset appends nothing.
- **Gateway guard.** models.dev lists a model under every gateway that re-serves it at that gateway's rate (`jiekou` lists `gemini-3-pro-preview` at $1.8/$10.8). A vendor row only ever matches its own provider, so that never becomes Google's rate. Pinned by a test.
- **Pending rows from the dataset.** The rule, stated in `VENDOR_ALLOWLIST` and `CREATE_WINDOW_DAYS`: vendor in {anthropic, openai, google, xai, moonshotai, deepseek, zai, minimax}; `release_date` within the last 180 days; reads text and writes text only (no image, TTS, live, audio); not a `#fast`, dated `-YYYYMMDD`, `-latest`, embedding or robotics id; not a priced lane; not resolvable to an existing row by the decision 6 alias rules. The row gets name, provider (catalog spelling), the original id as alias when the slug lowercases it (`MiniMax-M2.7` -> `minimax-m2.7`), `contextWindow`, `iconUrl = https://models.dev/logos/<provider>.svg`, `reviewStatus: pending`, `createdBy: 'import'`, plus its first period. An offline dry run against the current models.dev and the bundled table would create 31 rows on a catalog holding only the bundled slugs; prod already holds several of them (kimi-k3, glm-5.2, grok-4.5 ...), so the first prod run creates fewer.
- **Pending rows from the days.** Every id with tokens > 0 on a `measuredDays` row (never `measuredInventory.modelsSeen`) that resolves to no row becomes a pending row: from dataset metadata when the bare id is in the dataset (any allowlisted vendor first), else a bare row with the id as slug and name and provider `unknown`. `codex-auto-review` and `#fast` ids never become rows. Pinned by tests.
- **Log.** New `importLog` table `{at, kind: run|price|model|error, modelSlug?, detail}`, index `by_at`, capped at 500 rows. A failed run writes an `error` line and rethrows so the cron shows it too.
- **Cron.** `model-price-import` daily at 05:00 UTC in `convex/crons.ts`.

**Admin.** New `Import` tab on `/admin` (`src/components/admin/AdminImportTab.tsx`): "Run import now" (calls `api.modelImport.runNow`, an action guarded by `isAdmin` server-side), the pending models with Approve / Reject (the existing `approveModel` / `rejectModel`, so the Review tab shows the same rows), and the log table. `readLog` returns null for a non-admin. Sharp corners, monospace labels, lime accent.

**AGENTS.md.** One bullet under Pricing describing the import and its rule.

## Prod steps

Schema adds one table (`importLog`), so the deploy workflow is the whole migration; no migration function to run. The cron starts on its own. To see the first result early: open `/admin?tab=import` and press "Run import now" after the deploy.

## Decisions the ticket did not settle

- Created rows get `category: 'coding'`.
- The icon is the models.dev provider SVG as `iconUrl` (https, valid for `assertValidIconUrl`); nothing is uploaded to storage. `scripts/migrate-icons.ts` moves it into storage later like any other http icon.
- A period that lacks a cache tier is not opened just to add the tier the dataset states; only a stated rate that differs from a stated rate opens a period.
- `CREATE_WINDOW_DAYS = 180` and the id exclusions above are the flood control. Older models still get rate updates when the catalog already holds them.

## Verification

- `pnpm test`: 182 files, 2517 passed, 6 skipped.
- `pnpm tsc --noEmit`: 0 errors under `convex/`, `packages/`, and the touched `src` files; 44 pre-existing errors remain, all under `src/**/__tests__` and `packages/cli/prototypes`.
- Biome scoped to the changed files. No em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UX3EwpV7eYAW4MNQsnzZ5
