### PR TITLE
Fill stack models from measured usage and cut off the old way (alp82/aistack#338)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,24 @@ free is a zero-rate period cited `local-no-charge`.
   a day that resolves to no row. Never for a priced lane, a `#fast` or dated
   variant, or an inventory-only id. Every write is a line in `importLog`.
 
+## Stack models
+
+The model list on a stack page is DERIVED (#338, map #332), in
+`convex/lib/stackModels.ts`: the measured models of the stack's 30-day fold with
+tokens, sorted by token share, then the manual picks (`stacks.modelSubscriptions`)
+in stored order. `getBySlug` and `getPublicSummary` hand the page that list; the
+page renders it as handed and ranks nothing. There are no roles.
+
+* **The picker adds only what no adapter sees.** A pick a later sync measures sorts
+  into the measured group, once. A pick that names no catalog row is dropped.
+* **Hide is display only.** `stacks.hiddenModelSlugs` drops a model from the public
+  list and from nothing else: tokens, spend and the leaderboard keep counting it.
+  The owner hides and unhides in the editor (`listMeasuredModels`, `setModelHidden`).
+* **Consent is the CLI approve gate plus that hide.** There is no separate flag, and
+  nothing asks to add a measured model: `addMeasuredModel` and the
+  `missing_from_authored` suggestion are gone.
+* On the tile print the share and nothing else ("Anthropic · 62%").
+
 ## Charts
 
 All charts come from `src/features/charts`. It is the only place that imports

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -194,8 +194,8 @@ rule change that bumps the aggregate version changes every fingerprint on purpos
 **Machine inventory**:
 The window-free sets one machine reports per harness: installed tools, MCP servers,
 skills, models seen, and the harness kit, plus when that machine last synced. One row per
-(stack, machine, harness), replaced on every sync. Freshness, the living count and the
-reconcile suggestions read it; nothing sums it.
+(stack, machine, harness), replaced on every sync. Freshness and the living count read
+it; nothing sums it, and nothing fills a stack from it.
 _Avoid_: snapshot, payload (the old whole-window row this replaces, ADR-0011)
 
 **Legacy figure**:
@@ -276,3 +276,19 @@ A measured id that carries a rate but names no model a person can choose, such a
 **Pending model**:
 A catalog row the import or a measured id created that an admin has not approved. It
 prices and fills stacks; pending only means not public.
+
+**Stack model list**:
+The models a stack page shows, derived at read time: the measured models of the last
+30 days sorted by token share, then the manual picks in stored order. Nothing stores
+the list and nothing ranks a pick against a measured model. There are no roles.
+_Avoid_: model subscriptions (that names only the picks), primary/secondary model
+
+**Manual pick**:
+A model the owner added through the picker because no adapter sees it, such as a chat
+app. It sorts after the measured models and leaves the pick group the moment a sync
+measures it.
+_Avoid_: authored model, suggestion
+
+**Hidden model**:
+A catalog slug the owner hid from the stack model list. Display only: the model still
+counts in tokens, spend and the leaderboard, and the owner can unhide it in the editor.

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -55,6 +55,7 @@ import type * as lib_reprice from "../lib/reprice.js";
 import type * as lib_resourceLinks from "../lib/resourceLinks.js";
 import type * as lib_scrapers from "../lib/scrapers.js";
 import type * as lib_sources from "../lib/sources.js";
+import type * as lib_stackModels from "../lib/stackModels.js";
 import type * as lib_tiers from "../lib/tiers.js";
 import type * as lib_webCrypto from "../lib/webCrypto.js";
 import type * as lib_workflow from "../lib/workflow.js";
@@ -71,6 +72,7 @@ import type * as migrations_20260823_knowledge_base_publication from "../migrati
 import type * as migrations_20260823_news_hn_lane from "../migrations/20260823_news_hn_lane.js";
 import type * as migrations_20260823_news_phase1_sources from "../migrations/20260823_news_phase1_sources.js";
 import type * as migrations_20260827_merge_duplicate_models from "../migrations/20260827_merge_duplicate_models.js";
+import type * as migrations_20260829_merge_model_picks from "../migrations/20260829_merge_model_picks.js";
 import type * as migrations_20260829_seed_model_prices from "../migrations/20260829_seed_model_prices.js";
 import type * as migrations_20260829_vendor_model_ids from "../migrations/20260829_vendor_model_ids.js";
 import type * as migrations__archived_migrateBlockToReference from "../migrations/_archived/migrateBlockToReference.js";
@@ -157,6 +159,7 @@ declare const fullApi: ApiFromModules<{
   "lib/resourceLinks": typeof lib_resourceLinks;
   "lib/scrapers": typeof lib_scrapers;
   "lib/sources": typeof lib_sources;
+  "lib/stackModels": typeof lib_stackModels;
   "lib/tiers": typeof lib_tiers;
   "lib/webCrypto": typeof lib_webCrypto;
   "lib/workflow": typeof lib_workflow;
@@ -173,6 +176,7 @@ declare const fullApi: ApiFromModules<{
   "migrations/20260823_news_hn_lane": typeof migrations_20260823_news_hn_lane;
   "migrations/20260823_news_phase1_sources": typeof migrations_20260823_news_phase1_sources;
   "migrations/20260827_merge_duplicate_models": typeof migrations_20260827_merge_duplicate_models;
+  "migrations/20260829_merge_model_picks": typeof migrations_20260829_merge_model_picks;
   "migrations/20260829_seed_model_prices": typeof migrations_20260829_seed_model_prices;
   "migrations/20260829_vendor_model_ids": typeof migrations_20260829_vendor_model_ids;
   "migrations/_archived/migrateBlockToReference": typeof migrations__archived_migrateBlockToReference;

--- a/convex/activity.test.ts
+++ b/convex/activity.test.ts
@@ -280,7 +280,7 @@ test('a model or bundle change is a composition change too', async () => {
 
   await asCreator.mutation(api.stacks.update, {
     stackId: created._id,
-    modelSubscriptions: [{ modelSlug: 'opus-5', role: 'primary' }],
+    modelSubscriptions: [{ modelSlug: 'opus-5' }],
   })
 
   const rows = await events(t)

--- a/convex/lib/stackModels.test.ts
+++ b/convex/lib/stackModels.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'vitest'
+import { mergeStackModels } from './stackModels'
+
+const canonical = (slug: string) =>
+  ({ 'claude-opus-5': 'claude-opus-5', 'fable-5': 'claude-fable-5', 'gpt-5.4': 'gpt-5.4' })[
+    slug
+  ] ?? null
+
+describe('mergeStackModels', () => {
+  test('measured models sort by share, then picks in stored order, no duplicates', () => {
+    const out = mergeStackModels({
+      measured: [
+        { catalogSlug: 'claude-fable-5', tokenShare: 0.3, totalTokens: 30 },
+        { catalogSlug: 'claude-opus-5', tokenShare: 0.7, totalTokens: 70 },
+      ],
+      picks: [{ modelSlug: 'gpt-5.4' }, { modelSlug: 'fable-5', description: 'reviews' }],
+      hidden: [],
+      canonical,
+    })
+    expect(out.map((m) => m.slug)).toEqual(['claude-opus-5', 'claude-fable-5', 'gpt-5.4'])
+    expect(out[1]).toMatchObject({ measured: true, tokenShare: 0.3, description: 'reviews' })
+    expect(out[2]).toMatchObject({ measured: false, tokenShare: null })
+  })
+
+  test('two measured ids on one catalog row add up; zero-token and unresolved ids drop', () => {
+    const out = mergeStackModels({
+      measured: [
+        { catalogSlug: 'claude-opus-5', tokenShare: 0.2, totalTokens: 2 },
+        { catalogSlug: 'claude-opus-5', tokenShare: 0.3, totalTokens: 3 },
+        { catalogSlug: 'gpt-5.4', tokenShare: 0, totalTokens: 0 },
+        { catalogSlug: null, tokenShare: 0.5, totalTokens: 5 },
+      ],
+      picks: [],
+      hidden: [],
+      canonical,
+    })
+    expect(out).toEqual([{ slug: 'claude-opus-5', tokenShare: 0.5, measured: true, hidden: false }])
+  })
+
+  test('a pick naming no catalog row is dropped and a hidden slug is flagged, not removed', () => {
+    const out = mergeStackModels({
+      measured: [{ catalogSlug: 'claude-opus-5', tokenShare: 1, totalTokens: 1 }],
+      picks: [{ modelSlug: 'nope' }, { modelSlug: 'gpt-5.4' }],
+      hidden: ['claude-opus-5'],
+      canonical,
+    })
+    expect(out.map((m) => [m.slug, m.hidden])).toEqual([
+      ['claude-opus-5', true],
+      ['gpt-5.4', false],
+    ])
+  })
+})

--- a/convex/lib/stackModels.ts
+++ b/convex/lib/stackModels.ts
@@ -1,0 +1,118 @@
+import { inDateRange, rangeDates, type UsageDay } from '@aistack/workflow-rules'
+import type { Doc } from '../_generated/dataModel'
+import type { MutationCtx, QueryCtx } from '../_generated/server'
+import { readUsageWindow, type UsageRow } from '../measured'
+import { measuredDaysForStack } from './measuredDays'
+import { type ModelCatalog, findInCatalog, loadModelCatalog } from './modelCatalog'
+
+/**
+ * The stack's model list, derived (#338, map #332).
+ *
+ * Measured models come first: every catalog row the stack's 30-day fold holds
+ * tokens for, sorted by token share descending. Manual picks follow in their
+ * stored order, minus any pick the fold already covers. Nothing ranks a pick
+ * against a measured model, and there are no roles.
+ *
+ * Hide is DISPLAY ONLY. A hidden slug drops out of the public list and stays
+ * in every token, spend and leaderboard figure; the owner's read keeps it with
+ * the flag set so the editor can unhide it.
+ */
+export type StackModelEntry = {
+  slug: string
+  /** Share of the 30-day fold's tokens; null for a manual pick. */
+  tokenShare: number | null
+  measured: boolean
+  hidden: boolean
+  description?: string
+}
+
+export type MeasuredModelInput = {
+  catalogSlug: string | null
+  tokenShare: number
+  totalTokens: number
+}
+
+export type PickInput = { modelSlug: string; description?: string }
+
+export function mergeStackModels(input: {
+  measured: readonly MeasuredModelInput[]
+  picks: readonly PickInput[]
+  hidden: readonly string[]
+  /** The catalog slug a pick names, or null when it names no row. */
+  canonical: (slug: string) => string | null
+}): StackModelEntry[] {
+  const hiddenSet = new Set(input.hidden)
+  const share = new Map<string, number>()
+  for (const m of input.measured) {
+    if (m.catalogSlug === null || m.totalTokens <= 0) continue
+    share.set(m.catalogSlug, (share.get(m.catalogSlug) ?? 0) + m.tokenShare)
+  }
+  const descriptions = new Map<string, string>()
+  for (const p of input.picks) {
+    const slug = input.canonical(p.modelSlug)
+    if (slug && p.description && !descriptions.has(slug)) descriptions.set(slug, p.description)
+  }
+  const out: StackModelEntry[] = [...share.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([slug, tokenShare]) => ({
+      slug,
+      tokenShare,
+      measured: true,
+      hidden: hiddenSet.has(slug),
+      ...(descriptions.has(slug) ? { description: descriptions.get(slug) } : {}),
+    }))
+  const seen = new Set(share.keys())
+  for (const p of input.picks) {
+    const slug = input.canonical(p.modelSlug)
+    if (slug === null || seen.has(slug)) continue
+    seen.add(slug)
+    out.push({
+      slug,
+      tokenShare: null,
+      measured: false,
+      hidden: hiddenSet.has(slug),
+      ...(p.description ? { description: p.description } : {}),
+    })
+  }
+  return out
+}
+
+/** The merged list with its catalog rows, read once per stack. */
+export async function stackModelList(
+  ctx: QueryCtx | MutationCtx,
+  stack: Doc<'stacks'>,
+  now = Date.now()
+): Promise<Array<StackModelEntry & { model: Doc<'models'> }>> {
+  const catalog = await loadModelCatalog(ctx)
+  const entries = mergeStackModels({
+    measured: await measuredModelsOf(ctx, stack, catalog, now),
+    picks: stack.modelSubscriptions ?? [],
+    hidden: stack.hiddenModelSlugs ?? [],
+    canonical: (slug) => findInCatalog(catalog, slug)?.slug ?? null,
+  })
+  const out: Array<StackModelEntry & { model: Doc<'models'> }> = []
+  for (const entry of entries) {
+    const model = catalog.bySlug.get(entry.slug)
+    if (model) out.push({ ...entry, model })
+  }
+  return out
+}
+
+async function measuredModelsOf(
+  ctx: QueryCtx | MutationCtx,
+  stack: Doc<'stacks'>,
+  catalog: ModelCatalog,
+  now: number
+): Promise<MeasuredModelInput[]> {
+  const window = rangeDates('30d', now)
+  const rows: UsageRow[] = (await measuredDaysForStack(ctx, stack._id))
+    .filter((row) => row.usage !== undefined && inDateRange(row.date, window))
+    .map((row) => ({ date: row.date, usage: row.usage as UsageDay }))
+  // Shares do not depend on cost, so the fold skips the pricing pass.
+  const folded = readUsageWindow(rows, catalog, false)
+  return (folded?.models ?? []).map((m) => ({
+    catalogSlug: m.catalogSlug,
+    tokenShare: m.tokenShare,
+    totalTokens: m.totalTokens,
+  }))
+}

--- a/convex/measured.test.ts
+++ b/convex/measured.test.ts
@@ -948,7 +948,7 @@ describe('reconcile', () => {
     expect(result.suggestions).toEqual([])
   })
 
-  test('suggests a measured model missing from the authored list', async () => {
+  test('never asks to add a measured model: the model list derives it (#338)', async () => {
     const t = convexTest(schema, modules)
     const { stackId } = await seedStack(t)
     await t.run(async (ctx) => {
@@ -973,18 +973,7 @@ describe('reconcile', () => {
     const result = await asOwner.query(api.measured.getReconcileSuggestions, { stackId })
     expect(result.hasSnapshot).toBe(true)
     expect(result.isFresh).toBe(true)
-    expect(result.receivedAt).toBeGreaterThan(0)
-    expect(result.suggestions).toEqual([
-      {
-        atomKind: 'model',
-        atomKey: 'claude-opus-5',
-        label: 'Claude Opus 5',
-        kind: 'missing_from_authored',
-        tokenShare: 1,
-        // The price line the card shows; absent when the client withheld cost.
-        apiEquivalentUSD: 12.34,
-      },
-    ])
+    expect(result.suggestions).toEqual([])
   })
 
   test('reports an old snapshot as present but not fresh', async () => {
@@ -1126,70 +1115,7 @@ describe('reconcile', () => {
     ).rejects.toThrow(/not on this stack/i)
   })
 
-  test('addMeasuredModel appends once, primary first, and clears the suggestion', async () => {
-    const t = convexTest(schema, modules)
-    const { stackId } = await seedStack(t)
-    await t.run(async (ctx) => {
-      await ctx.db.insert('models', {
-        name: 'Claude Opus 5',
-        slug: 'claude-opus-5',
-        shortId: 'mopus5',
-        provider: 'anthropic',
-        category: 'language',
-        reviewStatus: 'approved',
-        createdAt: Date.now(),
-        updatedAt: Date.now(),
-      })
-      await ctx.db.insert('models', {
-        name: 'Claude Haiku 4.5',
-        slug: 'claude-haiku-4-5',
-        shortId: 'mhaiku',
-        provider: 'anthropic',
-        category: 'language',
-        reviewStatus: 'approved',
-        createdAt: Date.now(),
-        updatedAt: Date.now(),
-      })
-    })
-    await t.mutation(internal.measured.publishSnapshot, { stackId, payload: payload() })
-    const asOwner = t.withIdentity(IDENTITY)
-
-    await asOwner.mutation(api.measured.addMeasuredModel, {
-      stackId,
-      modelSlug: 'claude-opus-5',
-    })
-    // Idempotent: the same answer twice is one row.
-    await asOwner.mutation(api.measured.addMeasuredModel, {
-      stackId,
-      modelSlug: 'claude-opus-5',
-    })
-    await asOwner.mutation(api.measured.addMeasuredModel, {
-      stackId,
-      modelSlug: 'claude-haiku-4-5',
-    })
-
-    const stack = await t.run((ctx) => ctx.db.get(stackId))
-    expect(stack!.modelSubscriptions).toEqual([
-      { modelSlug: 'claude-opus-5', role: 'primary' },
-      { modelSlug: 'claude-haiku-4-5', role: 'secondary' },
-    ])
-
-    const result = await asOwner.query(api.measured.getReconcileSuggestions, { stackId })
-    expect(result.suggestions).toEqual([])
-  })
-
-  test('addMeasuredModel refuses a model the catalog does not carry', async () => {
-    const t = convexTest(schema, modules)
-    const { stackId } = await seedStack(t)
-    await expect(
-      t.withIdentity(IDENTITY).mutation(api.measured.addMeasuredModel, {
-        stackId,
-        modelSlug: 'gpt-9',
-      }),
-    ).rejects.toThrow(/not in the catalog/i)
-  })
-
-  test('the two writes into the authored layer are owner-only', async () => {
+  test('the what-for write into the authored layer is owner-only', async () => {
     const t = convexTest(schema, modules)
     const { stackId } = await seedStackWithTool(t, '')
     const asStranger = t.withIdentity(OTHER_IDENTITY)
@@ -1199,12 +1125,6 @@ describe('reconcile', () => {
         stackId,
         toolSlug: 'cursor',
         whatFor: 'mine now',
-      }),
-    ).rejects.toThrow(/not authorized/i)
-    await expect(
-      asStranger.mutation(api.measured.addMeasuredModel, {
-        stackId,
-        modelSlug: 'claude-opus-5',
       }),
     ).rejects.toThrow(/not authorized/i)
   })

--- a/convex/measured.ts
+++ b/convex/measured.ts
@@ -49,7 +49,6 @@ import {
 import { estimateModelUSD, round2 } from './lib/reprice'
 import {
   type ModelCatalog,
-  findInCatalog,
   loadModelCatalog,
   resolveModelId,
 } from './lib/modelCatalog'
@@ -696,20 +695,10 @@ const ReconcileSuggestion = v.object({
   atomKey: v.string(),
   /** Display name resolved from the catalog, falling back to the key. */
   label: v.string(),
-  kind: v.union(
-    // Measured shows a catalog tool the authored list doesn't carry.
-    v.literal('missing_from_authored'),
-    // Authored carries the tool but its what-for is still blank.
-    v.literal('missing_what_for')
-  ),
-  tokenShare: v.optional(v.number()),
-  /**
-   * API-equivalent dollars for a measured model over the last 30 days, from
-   * the day fold. Absent when the owner withheld cost (`publishCost: false`,
-   * #33 decision 11) or the model was only ever seen by the inventory - the
-   * surface renders the price line only when it is present.
-   */
-  apiEquivalentUSD: v.optional(v.number()),
+  // Authored carries the tool but its what-for is still blank. The measured
+  // model kind (`missing_from_authored`) is gone: measured models fill the
+  // stack's list by themselves (#338).
+  kind: v.literal('missing_what_for'),
 })
 
 /**
@@ -765,9 +754,7 @@ export const getReconcileSuggestions = query({
       atomKind: 'model' | 'tool' | 'mcpServer' | 'skill'
       atomKey: string
       label: string
-      kind: 'missing_from_authored' | 'missing_what_for'
-      tokenShare?: number
-      apiEquivalentUSD?: number
+      kind: 'missing_what_for'
     }> = []
 
     // Authored-side: a subscribed tool with no what-for. Independent of whether
@@ -788,65 +775,7 @@ export const getReconcileSuggestions = query({
       })
     }
 
-    // Measured-side: a model that resolves to the catalog but is absent from
-    // the authored model list. Across harnesses the first (freshest-ordered)
-    // sighting wins - the suggestion is "you ran this", not a share ranking.
-    // Authored slugs go through the same alias resolution as measured ids, so
-    // a stack that stored an older spelling is not asked to add it again (#294).
-    const catalog = await loadModelCatalog(ctx)
-    const authoredModels = new Set(
-      (stack.modelSubscriptions ?? []).map(
-        (m) => findInCatalog(catalog, m.modelSlug)?.slug ?? m.modelSlug
-      )
-    )
-    // The last 30 days of usage carry a share and a price per model. A model
-    // the inventory saw but the fold does not hold (older than the window, or
-    // a stack with a legacy figure only) is still a candidate, with neither.
-    const window = rangeDates('30d', Date.now())
-    const usageRows = (await measuredDaysForStack(ctx, args.stackId))
-      .filter((row) => row.usage !== undefined && inDateRange(row.date, window))
-      .map((row) => ({ date: row.date, usage: row.usage as UsageDay }))
-    const folded = readUsageWindow(usageRows, catalog, stack.publishCost !== false)
-    const candidates: Array<{
-      id: string
-      catalogSlug: string | null
-      catalogName: string | null
-      tokenShare?: number
-      apiEquivalentUSD?: number
-    }> = [
-      ...(folded?.models ?? []).map((m) => ({
-        id: m.id,
-        catalogSlug: m.catalogSlug,
-        catalogName: m.catalogName,
-        tokenShare: m.tokenShare,
-        ...(m.usd === null ? {} : { apiEquivalentUSD: m.usd }),
-      })),
-      ...inventory.flatMap((row) =>
-        row.modelsSeen.map((id) => ({ id, ...resolveModelId(catalog, id) }))
-      ),
-    ]
-    const suggestedSlugs = new Set<string>()
-    for (const m of candidates) {
-      if (m.catalogSlug === null) continue
-      if (authoredModels.has(m.catalogSlug)) continue
-      if (dismissed.has(`model:${m.catalogSlug}`)) continue
-      if (suggestedSlugs.has(m.catalogSlug)) continue
-      suggestedSlugs.add(m.catalogSlug)
-      suggestions.push({
-        atomKind: 'model',
-        atomKey: m.catalogSlug,
-        label: m.catalogName ?? m.id,
-        kind: 'missing_from_authored',
-        ...(m.tokenShare === undefined ? {} : { tokenShare: m.tokenShare }),
-        ...(m.apiEquivalentUSD === undefined
-          ? {}
-          : { apiEquivalentUSD: m.apiEquivalentUSD }),
-      })
-    }
-
-    suggestions.sort(
-      (a, b) => (b.tokenShare ?? 0) - (a.tokenShare ?? 0) || a.label.localeCompare(b.label)
-    )
+    suggestions.sort((a, b) => a.label.localeCompare(b.label))
 
     const newestReceivedAt =
       inventory.length > 0
@@ -1011,47 +940,6 @@ export const applyWhatFor = mutation({
       toolSubscriptions: subs.map((s) =>
         s.toolSlug === args.toolSlug ? { ...s, description: whatFor } : s
       ),
-      updatedAt: Date.now(),
-    })
-    return null
-  },
-})
-
-/**
- * Add a measured model to the authored model list.
- *
- * Idempotent, so answering the same suggestion twice (two tabs, a double click)
- * adds one row. The role is not asked for at the gate - the surface answers a
- * yes/no question - so the first model added becomes `primary` and every later
- * one `secondary`. The owner can change the role in the editor.
- */
-export const addMeasuredModel = mutation({
-  args: {
-    stackId: v.id('stacks'),
-    modelSlug: v.string(),
-  },
-  returns: v.null(),
-  handler: async (ctx, args) => {
-    const stack = await requireStackOwner(ctx, args.stackId)
-    const model = await ctx.db
-      .query('models')
-      .withIndex('by_slug', (q) => q.eq('slug', args.modelSlug))
-      .first()
-    if (!model) throw new Error('Model is not in the catalog')
-
-    const existing = stack.modelSubscriptions ?? []
-    if (existing.some((m) => m.modelSlug === args.modelSlug)) return null
-
-    await ctx.db.patch(args.stackId, {
-      modelSubscriptions: [
-        ...existing,
-        {
-          modelSlug: args.modelSlug,
-          role: existing.some((m) => m.role === 'primary')
-            ? ('secondary' as const)
-            : ('primary' as const),
-        },
-      ],
       updatedAt: Date.now(),
     })
     return null

--- a/convex/migrations/20260829_merge_model_picks.test.ts
+++ b/convex/migrations/20260829_merge_model_picks.test.ts
@@ -1,0 +1,111 @@
+/// <reference types="vite/client" />
+import { convexTest } from 'convex-test'
+import { describe, expect, test } from 'vitest'
+import { internal } from '../_generated/api'
+import schema from '../schema'
+
+const modules = Object.fromEntries(
+  Object.entries(import.meta.glob('../**/*.{js,ts}')).map(([key, loader]) => [
+    key.replace(/^\.\//, '../migrations/'),
+    loader,
+  ])
+)
+
+const MIGRATION = internal.migrations['20260829_merge_model_picks']
+
+function modelRow(slug: string, name: string, aliases?: string[]) {
+  return {
+    name,
+    slug,
+    shortId: `sid-${slug}`.slice(0, 12),
+    aliases,
+    provider: 'Anthropic',
+    category: 'coding' as const,
+    reviewStatus: 'approved' as const,
+    createdAt: 1,
+    updatedAt: 1,
+  }
+}
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  return await t.run(async (ctx) => {
+    await ctx.db.insert('models', modelRow('claude-fable-5', 'Fable 5'))
+    await ctx.db.insert('models', modelRow('claude-opus-5', 'Opus 5', ['claude-opus-50']))
+    await ctx.db.insert('models', modelRow('gpt-5.4', 'GPT-5.4'))
+    const creatorId = await ctx.db.insert('creators', {
+      name: 'Owner',
+      slug: 'owner',
+      userId: 'user_owner',
+      verified: false,
+      personalPages: [],
+      projectPages: [],
+      createdAt: 1,
+    })
+    const stackId = await ctx.db.insert('stacks', {
+      name: 'S',
+      slug: 's',
+      shortId: 'sid-s',
+      creatorId,
+      oneLiner: 'A stack',
+      toolSubscriptions: [],
+      modelSubscriptions: [
+        // Still on the #334 rename map: the vendor-id migration did not run.
+        { modelSlug: 'fable-5', role: 'primary', description: 'daily driver' },
+        // An alias of a row becomes the row's slug.
+        { modelSlug: 'claude-opus-50', role: 'secondary' },
+        // A duplicate of the first after the rename.
+        { modelSlug: 'claude-fable-5', role: 'secondary' },
+        // Names no row anywhere.
+        { modelSlug: 'nope-1', role: 'specialized' },
+        { modelSlug: 'gpt-5.4', role: 'secondary' },
+      ],
+      hasUsageComponent: false,
+      published: true,
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    const untouchedId = await ctx.db.insert('stacks', {
+      name: 'U',
+      slug: 'u',
+      shortId: 'sid-u',
+      creatorId,
+      oneLiner: 'Already merged',
+      toolSubscriptions: [],
+      modelSubscriptions: [{ modelSlug: 'gpt-5.4' }],
+      hasUsageComponent: false,
+      published: true,
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    return { stackId, untouchedId }
+  })
+}
+
+describe('20260829_merge_model_picks', () => {
+  test('drops role, renames, dedupes and drops picks with no row', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, untouchedId } = await seed(t)
+
+    const result = await t.mutation(MIGRATION.run, {})
+
+    expect(result.stacksRewritten).toBe(1)
+    expect(result.picksDropped).toEqual(['s: nope-1'])
+    expect(result.picksRenamed).toEqual(['s: fable-5 -> claude-fable-5', 's: claude-opus-50 -> claude-opus-5'])
+    const stack = await t.run((ctx) => ctx.db.get(stackId))
+    expect(stack?.modelSubscriptions).toEqual([
+      { modelSlug: 'claude-fable-5', description: 'daily driver' },
+      { modelSlug: 'claude-opus-5' },
+      { modelSlug: 'gpt-5.4' },
+    ])
+    const untouched = await t.run((ctx) => ctx.db.get(untouchedId))
+    expect(untouched?.modelSubscriptions).toEqual([{ modelSlug: 'gpt-5.4' }])
+  })
+
+  test('a second run changes nothing', async () => {
+    const t = convexTest(schema, modules)
+    await seed(t)
+    await t.mutation(MIGRATION.run, {})
+    const again = await t.mutation(MIGRATION.run, {})
+    expect(again).toEqual({ stacksRewritten: 0, picksDropped: [], picksRenamed: [] })
+  })
+})

--- a/convex/migrations/20260829_merge_model_picks.ts
+++ b/convex/migrations/20260829_merge_model_picks.ts
@@ -1,0 +1,74 @@
+import { v } from 'convex/values'
+import { internalMutation } from '../_generated/server'
+import { RENAMES } from './20260829_vendor_model_ids'
+
+/**
+ * Merge the manual model picks into the derived model list (#338, map #332).
+ *
+ * The list a stack shows is now measured models by token share, then the
+ * picks. Roles are gone, so every pick loses its `role`. Along the way each
+ * pick is brought onto the catalog's current spelling: a slug still on the
+ * #334 rename map is rewritten (a no-op after `20260829_vendor_model_ids`
+ * ran), an alias becomes the row's slug, duplicates collapse to the first,
+ * and a pick that names no catalog row is dropped. Descriptions survive.
+ *
+ * IDEMPOTENT. A stack whose picks already match is left untouched. Run it
+ * after the deploy that made `role` optional; the follow-up revision removes
+ * the field from the schema once this has run on prod.
+ */
+export const run = internalMutation({
+  args: {},
+  returns: v.object({
+    stacksRewritten: v.number(),
+    picksDropped: v.array(v.string()),
+    picksRenamed: v.array(v.string()),
+  }),
+  handler: async (ctx) => {
+    const renames = new Map(RENAMES.map(({ from, to }) => [from, to]))
+    const bySlug = new Map<string, string>()
+    const byAlias = new Map<string, string>()
+    for (const row of await ctx.db.query('models').collect()) {
+      bySlug.set(row.slug, row.slug)
+      for (const alias of row.aliases ?? []) {
+        if (!byAlias.has(alias)) byAlias.set(alias, row.slug)
+      }
+    }
+    const canonical = (slug: string): string | null => {
+      const renamed = renames.get(slug) ?? slug
+      return bySlug.get(renamed) ?? byAlias.get(renamed) ?? bySlug.get(slug) ?? byAlias.get(slug) ?? null
+    }
+
+    let stacksRewritten = 0
+    const picksDropped: string[] = []
+    const picksRenamed: string[] = []
+    for (const stack of await ctx.db.query('stacks').collect()) {
+      const subs = stack.modelSubscriptions
+      if (subs === undefined) continue
+      const seen = new Set<string>()
+      const next: Array<{ modelSlug: string; description?: string }> = []
+      for (const s of subs) {
+        const slug = canonical(s.modelSlug)
+        if (slug === null) {
+          picksDropped.push(`${stack.slug}: ${s.modelSlug}`)
+          continue
+        }
+        if (slug !== s.modelSlug) picksRenamed.push(`${stack.slug}: ${s.modelSlug} -> ${slug}`)
+        if (seen.has(slug)) continue
+        seen.add(slug)
+        next.push(s.description ? { modelSlug: slug, description: s.description } : { modelSlug: slug })
+      }
+      const unchanged =
+        next.length === subs.length &&
+        next.every(
+          (n, i) =>
+            n.modelSlug === subs[i].modelSlug &&
+            n.description === subs[i].description &&
+            subs[i].role === undefined
+        )
+      if (unchanged) continue
+      await ctx.db.patch(stack._id, { modelSubscriptions: next })
+      stacksRewritten++
+    }
+    return { stacksRewritten, picksDropped, picksRenamed }
+  },
+})

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -847,15 +847,25 @@ export default defineSchema({
         }),
       ),
     ),
+    // Manual picks: the models no adapter sees (#338). The list the page shows
+    // is DERIVED: measured models from the 30-day fold first, sorted by token
+    // share, then these picks in stored order. `role` is retired; it stays
+    // optional here until `migrations/20260829_merge_model_picks` has run on
+    // prod, then a follow-up revision removes it.
     modelSubscriptions: v.optional(
       v.array(
         v.object({
           modelSlug: v.string(),
-          role: v.union(v.literal('primary'), v.literal('secondary'), v.literal('specialized')),
+          role: v.optional(
+            v.union(v.literal('primary'), v.literal('secondary'), v.literal('specialized'))
+          ),
           description: v.optional(v.string()),
         }),
       ),
     ),
+    // Catalog slugs the owner hid from the model list (#338). Display only:
+    // a hidden model still counts in tokens, spend and the leaderboard.
+    hiddenModelSlugs: v.optional(v.array(v.string())),
     fixedTotal: v.optional(Money),
     usageTotalNotes: v.optional(v.string()),
     hasUsageComponent: v.boolean(),

--- a/convex/stackModelsRead.test.ts
+++ b/convex/stackModelsRead.test.ts
@@ -1,0 +1,211 @@
+/// <reference types="vite/client" />
+import { convexTest } from 'convex-test'
+import { describe, expect, test } from 'vitest'
+import { api, internal } from './_generated/api'
+import type { Id } from './_generated/dataModel'
+import schema from './schema'
+
+const modules = import.meta.glob('./**/*.{js,ts}')
+const USER = 'user_models'
+const OTHER = 'user_other'
+
+function modelRow(slug: string, name: string, aliases?: string[]) {
+  return {
+    name,
+    slug,
+    shortId: `sid-${slug}`.slice(0, 12),
+    aliases,
+    provider: 'Anthropic',
+    category: 'coding' as const,
+    reviewStatus: 'approved' as const,
+    createdAt: 1,
+    updatedAt: 1,
+  }
+}
+
+function payload(models: Array<{ id: string; tokenShare: number; tokens: number }>) {
+  const today = new Date().toISOString().slice(0, 10)
+  return {
+    schemaVersion: 2 as const,
+    capturedAt: Date.now(),
+    window: { days: 1, from: today, to: today },
+    harness: { name: 'claude-code', version: '2.1.245' },
+    pricingTable: 'anthropic-list-2026-07-25',
+    activity: {
+      sessions: 1,
+      activeDayDates: [today],
+      projectKeys: ['AAAAAAAAAAAAAAAAAAAAAA'],
+      totalTokens: models.reduce((n, m) => n + m.tokens, 0),
+      cacheHitShare: 0,
+      subagentShare: 0,
+    },
+    models: models.map((m) => ({
+      id: m.id,
+      tokenShare: m.tokenShare,
+      tokens: { input: m.tokens, output: 0, cacheWrite: 0, cacheRead: 0 },
+    })),
+    inventory: {
+      builtinTools: [],
+      mcpServers: [],
+      skills: [],
+      subagents: [],
+      slashCommands: [],
+      withheld: { builtinTools: 0, mcpServers: 0, skills: 0, subagents: 0, slashCommands: 0 },
+      calls: { builtinTools: 0, mcpServers: 0, skills: 0, subagents: 0, slashCommands: 0 },
+    },
+    coverage: { filesScanned: 1, filesUnreadable: 0, linesParsed: 1, linesFailed: 0 },
+    excludedTokens: { unpriced: 0, synthetic: 0 },
+  }
+}
+
+/** The day wire the CLI ships beside the payload; the fold reads these rows. */
+function days(models: Array<{ id: string; tokens: number }>) {
+  const today = new Date().toISOString().slice(0, 10)
+  return {
+    aggregateVersion: 'measured-days/v1',
+    days: [
+      {
+        date: today,
+        usage: {
+          harnesses: [
+            {
+              harness: 'claude-code',
+              sessions: 1,
+              projectKeys: ['AAAAAAAAAAAAAAAAAAAAAA'],
+              models: models.map((m) => ({
+                model: m.id,
+                tokens: { input: m.tokens, output: 0, cacheWrite: 0, cacheRead: 0 },
+              })),
+              subagentTokens: 0,
+              excludedTokens: { unpriced: 0, synthetic: 0 },
+            },
+          ],
+        },
+      },
+    ],
+  }
+}
+
+const MEASURED = [
+  { id: 'claude-fable-5', tokenShare: 0.25, tokens: 25 },
+  { id: 'claude-opus-5', tokenShare: 0.75, tokens: 75 },
+]
+
+async function sync(t: ReturnType<typeof convexTest>, stackId: Id<'stacks'>) {
+  await t.mutation(internal.measured.publishSnapshot, {
+    stackId,
+    payload: payload(MEASURED),
+    measuredDays: days(MEASURED),
+  })
+}
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  return await t.run(async (ctx) => {
+    await ctx.db.insert('models', modelRow('claude-opus-5', 'Claude Opus 5'))
+    await ctx.db.insert('models', modelRow('claude-fable-5', 'Claude Fable 5', ['fable-5']))
+    await ctx.db.insert('models', modelRow('gpt-5.4', 'GPT-5.4'))
+    const creatorId = await ctx.db.insert('creators', {
+      name: 'Owner',
+      slug: 'owner-models',
+      userId: USER,
+      verified: false,
+      personalPages: [],
+      projectPages: [],
+      createdAt: Date.now(),
+    })
+    const stackId = await ctx.db.insert('stacks', {
+      name: 'My Stack',
+      slug: 'my-stack-sidmodels',
+      shortId: 'sidmodels',
+      creatorId,
+      oneLiner: 'A stack',
+      toolSubscriptions: [],
+      // Picks in stored order: one the fold also measures (older spelling),
+      // one no adapter sees, one that names no row.
+      modelSubscriptions: [
+        { modelSlug: 'gpt-5.4', description: 'chat app' },
+        { modelSlug: 'fable-5' },
+        { modelSlug: 'nope' },
+      ],
+      hasUsageComponent: false,
+      published: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    })
+    return { stackId }
+  })
+}
+
+const SLUG = 'my-stack-sidmodels'
+
+describe('the stack model list is derived from measured usage (#338)', () => {
+  test('measured models by share first, then picks, no duplicates, no roles', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seed(t)
+    await sync(t, stackId)
+
+    const stack = await t.query(api.stacks.getBySlug, { slug: SLUG })
+    expect(stack?.models.map((m) => [m.slug, m.measured, m.tokenShare])).toEqual([
+      ['claude-opus-5', true, 0.75],
+      ['claude-fable-5', true, 0.25],
+      ['gpt-5.4', false, null],
+    ])
+    expect(stack?.models[2].description).toBe('chat app')
+    expect(Object.keys(stack?.models[0] ?? {})).not.toContain('role')
+
+    const summary = await t.query(api.stacks.getPublicSummary, { slug: SLUG })
+    expect(summary?.models).toEqual(['Claude Opus 5', 'Claude Fable 5', 'GPT-5.4'])
+    expect(summary?.modelCount).toBe(3)
+  })
+
+  test('with nothing measured the list is the picks in stored order', async () => {
+    const t = convexTest(schema, modules)
+    await seed(t)
+    const stack = await t.query(api.stacks.getBySlug, { slug: SLUG })
+    expect(stack?.models.map((m) => m.slug)).toEqual(['gpt-5.4', 'claude-fable-5'])
+  })
+
+  test('hide is display only: the public list drops it, usage keeps counting it', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seed(t)
+    await sync(t, stackId)
+    const owner = t.withIdentity({ tokenIdentifier: `convex|${USER}`, subject: USER })
+    await owner.mutation(api.stacks.setModelHidden, {
+      stackId,
+      modelSlug: 'claude-opus-5',
+      hidden: true,
+    })
+
+    const stack = await t.query(api.stacks.getBySlug, { slug: SLUG })
+    expect(stack?.models.map((m) => m.slug)).toEqual(['claude-fable-5', 'gpt-5.4'])
+    const summary = await t.query(api.stacks.getPublicSummary, { slug: SLUG })
+    expect(summary?.models).toEqual(['Claude Fable 5', 'GPT-5.4'])
+
+    const usage = await t.query(api.measured.getUsageByStackSlug, { slug: SLUG })
+    expect(usage?.current?.models.map((m) => m.id)).toContain('claude-opus-5')
+
+    const mine = await owner.query(api.stacks.listMeasuredModels, { stackId })
+    expect(mine.map((m) => [m.slug, m.hidden])).toEqual([
+      ['claude-opus-5', true],
+      ['claude-fable-5', false],
+    ])
+
+    await owner.mutation(api.stacks.setModelHidden, {
+      stackId,
+      modelSlug: 'claude-opus-5',
+      hidden: false,
+    })
+    const back = await t.query(api.stacks.getBySlug, { slug: SLUG })
+    expect(back?.models[0].slug).toBe('claude-opus-5')
+  })
+
+  test('only the owner can hide', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId } = await seed(t)
+    await expect(
+      t
+        .withIdentity({ tokenIdentifier: `convex|${OTHER}`, subject: OTHER })
+        .mutation(api.stacks.setModelHidden, { stackId, modelSlug: 'gpt-5.4', hidden: true })
+    ).rejects.toThrow(/Not authorized/)
+  })
+})

--- a/convex/stacks.ts
+++ b/convex/stacks.ts
@@ -12,6 +12,9 @@ import { normalizeProjectUrl } from './projects'
 import { assertValidAccentPreset } from './lib/iconUrl'
 import { resolveCreatorAvatarUrl } from './lib/avatar'
 import { inventoryForStack } from './lib/measuredDays'
+import { stackModelList } from './lib/stackModels'
+import { findInCatalog, loadModelCatalog } from './lib/modelCatalog'
+import { requireStackOwner } from './measured'
 import { diffComposition, emitActivityEvent } from './activity'
 
 type ToolSubscriptionLike = {
@@ -126,7 +129,9 @@ const ModelValidator = v.object({
   provider: v.string(),
   category: v.string(),
   iconUrl: v.optional(v.string()),
-  role: v.union(v.literal('primary'), v.literal('secondary'), v.literal('specialized')),
+  /** Share of the stack's 30-day tokens; null for a manual pick (#338). */
+  tokenShare: v.union(v.number(), v.null()),
+  measured: v.boolean(),
   description: v.optional(v.string()),
 })
 
@@ -331,7 +336,6 @@ const BundleSubscriptionInput = v.object({
 
 const ModelSubscriptionInput = v.object({
   modelSlug: v.string(),
-  role: v.union(v.literal('primary'), v.literal('secondary'), v.literal('specialized')),
   description: v.optional(v.string()),
 })
 
@@ -627,7 +631,6 @@ export const getForEdit = query({
         modelProvider: v.string(),
         modelCategory: v.string(),
         modelIconUrl: v.optional(v.string()),
-        role: v.union(v.literal('primary'), v.literal('secondary'), v.literal('specialized')),
         description: v.optional(v.string()),
       })),
     }),
@@ -710,7 +713,6 @@ export const getForEdit = query({
           modelProvider: model.provider,
           modelCategory: model.category,
           modelIconUrl: resolvedModelUrl ?? model.iconUrl,
-          role: ms.role,
           description: ms.description,
         }
       })
@@ -1066,26 +1068,28 @@ export const getBySlug = query({
     )
     const bundles = bundleEntries.filter((b): b is NonNullable<typeof b> => b !== null)
 
-    const modelEntries = await Promise.all(
-      (stack.modelSubscriptions ?? []).map(async (ms) => {
-        const model = await findModelBySlugOrAlias(ctx, ms.modelSlug)
-        if (!model) return null
-        const resolvedModelUrl = model.iconStorageId
-          ? await ctx.storage.getUrl(model.iconStorageId)
-          : null
-        return {
-          _id: model._id,
-          name: model.name,
-          slug: model.slug,
-          provider: model.provider,
-          category: model.category,
-          iconUrl: resolvedModelUrl ?? model.iconUrl,
-          role: ms.role,
-          description: ms.description,
-        }
-      })
+    // Derived and already ordered (#338): measured by share, then picks. The
+    // page renders it as handed and ranks nothing. Hidden models stay out.
+    const models = await Promise.all(
+      (await stackModelList(ctx, stack))
+        .filter((entry) => !entry.hidden)
+        .map(async ({ model, ...entry }) => {
+          const resolvedModelUrl = model.iconStorageId
+            ? await ctx.storage.getUrl(model.iconStorageId)
+            : null
+          return {
+            _id: model._id,
+            name: model.name,
+            slug: model.slug,
+            provider: model.provider,
+            category: model.category,
+            iconUrl: resolvedModelUrl ?? model.iconUrl,
+            tokenShare: entry.tokenShare,
+            measured: entry.measured,
+            description: entry.description,
+          }
+        })
     )
-    const models = modelEntries.filter((m): m is NonNullable<typeof m> => m !== null)
 
     const pricing = await calculateStackPricing(ctx, stack.toolSubscriptions, stack.bundleSubscriptions ?? [])
     const resources = await resolveLinkedResources(ctx, 'stack', stack._id)
@@ -1180,10 +1184,9 @@ export const getPublicSummary = query({
       toolEntries.filter((t): t is NonNullable<typeof t> => t !== null),
     ).map((t) => t.name)
 
-    const models = await resolveNames(stack.modelSubscriptions ?? [], async (ms) => {
-      const model = await findModelBySlugOrAlias(ctx, ms.modelSlug)
-      return model?.name ?? null
-    })
+    const models = (await stackModelList(ctx, stack))
+      .filter((entry) => !entry.hidden)
+      .map((entry) => entry.model.name)
 
     const bundles = await resolveNames(stack.bundleSubscriptions ?? [], async (bs) => {
       const bundle = await ctx.db
@@ -1210,5 +1213,68 @@ export const getPublicSummary = query({
       models,
       bundles,
     }
+  },
+})
+
+/**
+ * The owner's view of the derived model list (#338): the measured models with
+ * their share and the hidden flag, so the editor can hide and unhide them.
+ * Manual picks are not here; the picker owns those.
+ */
+export const listMeasuredModels = query({
+  args: { stackId: v.id('stacks') },
+  returns: v.array(
+    v.object({
+      slug: v.string(),
+      name: v.string(),
+      provider: v.string(),
+      iconUrl: v.optional(v.string()),
+      tokenShare: v.number(),
+      hidden: v.boolean(),
+    })
+  ),
+  handler: async (ctx, args) => {
+    const stack = await requireStackOwner(ctx, args.stackId)
+    const entries = (await stackModelList(ctx, stack)).filter((e) => e.measured)
+    return await Promise.all(
+      entries.map(async ({ model, ...entry }) => {
+        const resolvedUrl = model.iconStorageId
+          ? await ctx.storage.getUrl(model.iconStorageId)
+          : null
+        return {
+          slug: model.slug,
+          name: model.name,
+          provider: model.provider,
+          iconUrl: resolvedUrl ?? model.iconUrl,
+          tokenShare: entry.tokenShare ?? 0,
+          hidden: entry.hidden,
+        }
+      })
+    )
+  },
+})
+
+/**
+ * Hide or unhide one model on the stack page (#338). Display only: the slug
+ * leaves the public list and nothing else. Tokens, spend and the leaderboard
+ * keep counting it. Idempotent.
+ */
+export const setModelHidden = mutation({
+  args: { stackId: v.id('stacks'), modelSlug: v.string(), hidden: v.boolean() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const stack = await requireStackOwner(ctx, args.stackId)
+    const catalog = await loadModelCatalog(ctx)
+    const slug = findInCatalog(catalog, args.modelSlug)?.slug
+    if (!slug) throw new Error('Model is not in the catalog')
+    const current = stack.hiddenModelSlugs ?? []
+    const next = args.hidden
+      ? current.includes(slug)
+        ? current
+        : [...current, slug]
+      : current.filter((s) => s !== slug)
+    if (next.length === current.length && next.every((s, i) => s === current[i])) return null
+    await ctx.db.patch(args.stackId, { hiddenModelSlugs: next, updatedAt: Date.now() })
+    return null
   },
 })

--- a/src/components/ModelItem.tsx
+++ b/src/components/ModelItem.tsx
@@ -8,7 +8,6 @@ export interface ModelItemData {
 	provider: string;
 	category: string;
 	iconUrl?: string;
-	role: "primary" | "secondary" | "specialized";
 }
 
 interface ModelItemProps {

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -1,12 +1,12 @@
 import { useQuery } from "convex/react";
 import { Brain, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
+import type { ModelSubscriptionEntry } from "@/features/stack-editor/types";
 import { api } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
-import type { ModelSubscriptionEntry } from "@/features/stack-editor/types";
-import { AddMissingItemButton } from "./AddMissingItemButton";
 import { AddItemModal } from "./AddItemModal";
-import { PickerEntryCard, PickerToggleButton, PickerBrowser } from "./picker";
+import { AddMissingItemButton } from "./AddMissingItemButton";
+import { PickerBrowser, PickerEntryCard, PickerToggleButton } from "./picker";
 
 export type ModelCategory =
 	| "language"
@@ -25,6 +25,8 @@ interface ModelPickerProps {
 	value: ModelSubscriptionEntry[];
 	onChange: (models: ModelSubscriptionEntry[]) => void;
 	onModelClick?: (model: ModelSubscriptionEntry) => void;
+	/** Slugs the stack's syncs already cover (#338); the browser leaves them out. */
+	excludeSlugs?: string[];
 }
 
 const categoryLabels: Record<ModelCategory, string> = {
@@ -43,6 +45,7 @@ export function ModelPicker({
 	value,
 	onChange,
 	onModelClick,
+	excludeSlugs = [],
 }: ModelPickerProps) {
 	const allModels = useQuery(api.models.listForEditor) ?? [];
 	const [search, setSearch] = useState("");
@@ -52,7 +55,10 @@ export function ModelPicker({
 	const [showAddModal, setShowAddModal] = useState(false);
 	const [customModelName, setCustomModelName] = useState("");
 
-	const selectedModelSlugs = new Set(value.map((m) => m.modelSlug));
+	const selectedModelSlugs = new Set([
+		...value.map((m) => m.modelSlug),
+		...excludeSlugs,
+	]);
 
 	const availableCategories = useMemo(() => {
 		const categories = new Set<ModelCategory>();
@@ -96,7 +102,6 @@ export function ModelPicker({
 			modelProvider: model.provider,
 			modelCategory: model.category,
 			modelIconUrl: model.iconUrl,
-			role: "primary",
 		};
 		onChange([...value, entry]);
 	};
@@ -112,7 +117,6 @@ export function ModelPicker({
 			modelName: customModelName.trim(),
 			modelProvider: "Custom",
 			modelCategory: "other",
-			role: "primary",
 		};
 		onChange([...value, entry]);
 		setCustomModelName("");

--- a/src/components/StackEditor.tsx
+++ b/src/components/StackEditor.tsx
@@ -249,7 +249,6 @@ export function StackEditor({
 				modelProvider: fullModel.provider,
 				modelCategory: fullModel.category,
 				modelIconUrl: fullModel.iconUrl,
-				role: "primary",
 			};
 
 			setModelSubscriptions([...currentState.modelSubscriptions, entry]);

--- a/src/features/reconcile/__tests__/changes-page.test.tsx
+++ b/src/features/reconcile/__tests__/changes-page.test.tsx
@@ -47,13 +47,13 @@ const STACK_ID = "stack_1" as never;
 const HOUR = 60 * 60 * 1000;
 const DAY = 24 * HOUR;
 
-const MODEL_ITEM = {
-	atomKind: "model" as const,
-	atomKey: "claude-opus-5",
-	label: "Claude Opus 5",
-	kind: "missing_from_authored" as const,
-	tokenShare: 0.62,
-	apiEquivalentUSD: 3402.4,
+// Two what-for items. The measured-model kind is gone (#338): measured
+// models fill the stack's list by themselves, so nothing here asks to add one.
+const LINEAR_ITEM = {
+	atomKind: "tool" as const,
+	atomKey: "linear",
+	label: "Linear",
+	kind: "missing_what_for" as const,
 };
 
 const TOOL_ITEM = {
@@ -67,7 +67,7 @@ type Suggestions = {
 	hasSnapshot: boolean;
 	receivedAt: number | null;
 	isFresh: boolean;
-	suggestions: Array<typeof MODEL_ITEM | typeof TOOL_ITEM>;
+	suggestions: Array<typeof LINEAR_ITEM | typeof TOOL_ITEM>;
 	dismissedCount: number;
 };
 
@@ -104,7 +104,6 @@ function setup(opts: {
 }) {
 	const spies = {
 		applyWhatFor: vi.fn().mockResolvedValue(null),
-		addMeasuredModel: vi.fn().mockResolvedValue(null),
 		dismissSuggestion: vi.fn().mockResolvedValue(null),
 		undismissSuggestion: vi.fn().mockResolvedValue(null),
 		addPublishedNameOptIns: vi.fn().mockResolvedValue({ added: 1 }),
@@ -123,7 +122,6 @@ function setup(opts: {
 	mutationMock.mockImplementation((ref: never) => {
 		const name = getFunctionName(ref);
 		if (name.endsWith("applyWhatFor")) return spies.applyWhatFor;
-		if (name.endsWith("addMeasuredModel")) return spies.addMeasuredModel;
 		if (name.endsWith("addPublishedNameOptIns"))
 			return spies.addPublishedNameOptIns;
 		if (name.endsWith("removePublishedNameOptIns"))
@@ -148,7 +146,7 @@ const FRESH: Suggestions = {
 	hasSnapshot: true,
 	receivedAt: Date.now() - 2 * HOUR,
 	isFresh: true,
-	suggestions: [MODEL_ITEM, TOOL_ITEM],
+	suggestions: [LINEAR_ITEM, TOOL_ITEM],
 	dismissedCount: 0,
 };
 
@@ -211,27 +209,13 @@ describe("freshness", () => {
 });
 
 describe("answering", () => {
-	it("adds a measured model, and shows its share and price", async () => {
+	it("leaves an item blank when the owner says so", () => {
 		const spies = setup({ data: FRESH });
-
-		expect(screen.getByText("62% of everything you ran")).toBeTruthy();
-		// The dollar figure is never a bill.
-		expect(screen.getByText("≈$3,402 at API prices")).toBeTruthy();
-
-		fireEvent.click(screen.getByRole("button", { name: /Add it/ }));
-		expect(spies.addMeasuredModel).toHaveBeenCalledWith({
-			stackId: STACK_ID,
-			modelSlug: "claude-opus-5",
-		});
-	});
-
-	it("hides an item the owner says is not theirs", () => {
-		const spies = setup({ data: FRESH });
-		fireEvent.click(screen.getByRole("button", { name: /Not mine, hide it/ }));
+		fireEvent.click(screen.getByRole("button", { name: /Leave it blank/ }));
 		expect(spies.dismissSuggestion).toHaveBeenCalledWith({
 			stackId: STACK_ID,
-			atomKind: "model",
-			atomKey: "claude-opus-5",
+			atomKind: "tool",
+			atomKey: "linear",
 		});
 	});
 
@@ -262,7 +246,10 @@ describe("one meter across both views", () => {
 		expect(screen.getByText("0 of 2 done")).toBeTruthy();
 
 		// Answer one on the card.
-		fireEvent.click(screen.getByRole("button", { name: /Add it/ }));
+		fireEvent.change(screen.getByLabelText("What you use Linear for"), {
+			target: { value: "tickets" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /Save it/ }));
 		expect(await screen.findByText("1 of 2 done")).toBeTruthy();
 		expect(screen.getByText("50%")).toBeTruthy();
 
@@ -320,8 +307,8 @@ describe("the vocabulary binds", () => {
 		]) {
 			expect(text.toLowerCase()).not.toContain(banned);
 		}
-		// The two kept on purpose, because replacing them would be a lie.
-		expect(text).toContain("API prices");
+		// "API prices" left with the measured-model card (#338); the page no
+		// longer prints a dollar figure.
 	});
 });
 

--- a/src/features/reconcile/copy.ts
+++ b/src/features/reconcile/copy.ts
@@ -9,7 +9,6 @@
  *   the measured layer ....... from your machine
  *   authored ................. what you've listed / your stack
  *   suggestion ............... thing to look at
- *   missing_from_authored .... "You use this, but it's not on your stack"
  *   missing_what_for ......... "You haven't said what you use this for"
  *   what-for note ............ note
  *   dismiss .................. hide
@@ -41,28 +40,16 @@ export type ReconcileItem = {
 	atomKind: "model" | "tool" | "mcpServer" | "skill";
 	atomKey: string;
 	label: string;
-	kind: "missing_from_authored" | "missing_what_for";
-	tokenShare?: number;
-	apiEquivalentUSD?: number;
+	/**
+	 * Only the what-for question is left. Measured models fill the stack's
+	 * model list by themselves (#338), so nothing asks to add one.
+	 */
+	kind: "missing_what_for";
 };
 
 /** What the item is asking the owner. */
-export function askLine(item: ReconcileItem): string {
-	return item.kind === "missing_from_authored"
-		? "You use this, but it's not on your stack"
-		: "You haven't said what you use this for";
-}
-
-/** "62% of everything you ran" - a share, never a raw token count. */
-export function usageLine(item: ReconcileItem): string | null {
-	if (item.tokenShare === undefined) return null;
-	return `${Math.round(item.tokenShare * 100)}% of everything you ran`;
-}
-
-/** "≈$3,402 at API prices" - absent when the sync withheld cost. */
-export function priceLine(item: ReconcileItem): string | null {
-	if (item.apiEquivalentUSD === undefined) return null;
-	return `≈$${Math.round(item.apiEquivalentUSD).toLocaleString("en-US")} at API prices`;
+export function askLine(_item: ReconcileItem): string {
+	return "You haven't said what you use this for";
 }
 
 /** The one line the sticky banner leads with. */

--- a/src/features/reconcile/parts.tsx
+++ b/src/features/reconcile/parts.tsx
@@ -1,12 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import {
-	ArrowRight,
-	Check,
-	EyeOff,
-	Plus,
-	RotateCcw,
-	Terminal,
-} from "lucide-react";
+import { ArrowRight, Check, EyeOff, RotateCcw, Terminal } from "lucide-react";
 import type { ReactNode } from "react";
 import { useCallback, useEffect } from "react";
 import { RelativeTime } from "@/components/RelativeTime";
@@ -16,9 +9,7 @@ import {
 	askLine,
 	KICKER_EMPTY,
 	lastCheckedLine,
-	priceLine,
 	type ReconcileItem,
-	usageLine,
 } from "./copy";
 import type { HiddenItem, ReconcileRun } from "./useReconcileRun";
 
@@ -27,21 +18,16 @@ export const MONO_LABEL =
 
 export function Monogram({
 	label,
-	tone,
 	size = "md",
 }: {
 	label: string;
-	tone: "measured" | "authored";
 	size?: "md" | "lg";
 }) {
 	return (
 		<span
 			className={cn(
-				"inline-flex shrink-0 items-center justify-center border font-mono font-bold uppercase",
+				"inline-flex shrink-0 items-center justify-center border border-stroke-subtle bg-bg-panel/60 font-mono font-bold uppercase text-fg-secondary",
 				size === "md" ? "size-9 text-sm" : "size-14 text-2xl",
-				tone === "measured"
-					? "border-accent-lime/40 bg-accent-lime/10 text-accent-lime"
-					: "border-stroke-subtle bg-bg-panel/60 text-fg-secondary",
 			)}
 		>
 			{label.charAt(0)}
@@ -238,129 +224,75 @@ export function OneItem({
 
 	if (!item) return <EmptyState run={run} />;
 
-	const isModel = item.kind === "missing_from_authored";
 	const note = run.notes[item.atomKey] ?? "";
 
 	return (
 		<div className="border border-stroke-subtle px-6 py-12 md:px-10 md:py-16">
 			<p className="mb-6 text-lg text-fg-secondary">{askLine(item)}</p>
 			<div className="flex items-center gap-5">
-				<Monogram
-					label={item.label}
-					tone={isModel ? "measured" : "authored"}
-					size="lg"
-				/>
+				<Monogram label={item.label} size="lg" />
 				<h2 className="text-4xl font-black tracking-tight text-fg-primary md:text-5xl">
 					{item.label}
 				</h2>
 			</div>
 
-			{isModel && (
-				<div className="mt-5 space-y-1">
-					{usageLine(item) && (
-						<p className="text-sm text-fg-secondary">{usageLine(item)}</p>
-					)}
-					{priceLine(item) && (
-						<p className="font-mono text-xs text-fg-muted">{priceLine(item)}</p>
-					)}
-				</div>
-			)}
-
-			{isModel ? (
-				<div className="mt-8 flex flex-wrap gap-3">
-					<PBtn
-						tone="primary"
-						onClick={() => answer("added")}
-						className="px-5 py-2.5"
-					>
-						<Plus className="size-3.5" /> Add it{" "}
-						<span className="opacity-60">↵</span>
-					</PBtn>
-					<PBtn
-						tone="danger"
-						onClick={() => answer("hidden")}
-						className="px-5 py-2.5"
-					>
-						<EyeOff className="size-3.5" /> Not mine, hide it{" "}
-						<span className="opacity-60">N</span>
-					</PBtn>
-				</div>
-			) : (
-				<>
-					<input
-						key={item.atomKey}
-						value={note}
-						onChange={(e) => run.setNote(item.atomKey, e.target.value)}
-						placeholder="e.g. writing and reviewing code"
-						aria-label={`What you use ${item.label} for`}
-						className="mt-6 w-full border-b-2 border-stroke-strong bg-transparent px-1 py-3 text-xl text-fg-primary placeholder:text-fg-muted focus:border-accent-lime focus:outline-none"
-					/>
-					<p className="mt-2 text-xs text-fg-muted">
-						One line. Anyone looking at your stack will see it.
-					</p>
-					<div className="mt-6 flex flex-wrap gap-3">
-						<PBtn
-							tone="primary"
-							onClick={() => answer("added")}
-							disabled={!note.trim()}
-							className="px-5 py-2.5"
-						>
-							Save it <span className="opacity-60">↵</span>
-						</PBtn>
-						<PBtn
-							tone="danger"
-							onClick={() => answer("hidden")}
-							className="px-5 py-2.5"
-						>
-							Leave it blank <span className="opacity-60">N</span>
-						</PBtn>
-					</div>
-				</>
-			)}
+			<input
+				key={item.atomKey}
+				value={note}
+				onChange={(e) => run.setNote(item.atomKey, e.target.value)}
+				placeholder="e.g. writing and reviewing code"
+				aria-label={`What you use ${item.label} for`}
+				className="mt-6 w-full border-b-2 border-stroke-strong bg-transparent px-1 py-3 text-xl text-fg-primary placeholder:text-fg-muted focus:border-accent-lime focus:outline-none"
+			/>
+			<p className="mt-2 text-xs text-fg-muted">
+				One line. Anyone looking at your stack will see it.
+			</p>
+			<div className="mt-6 flex flex-wrap gap-3">
+				<PBtn
+					tone="primary"
+					onClick={() => answer("added")}
+					disabled={!note.trim()}
+					className="px-5 py-2.5"
+				>
+					Save it <span className="opacity-60">↵</span>
+				</PBtn>
+				<PBtn
+					tone="danger"
+					onClick={() => answer("hidden")}
+					className="px-5 py-2.5"
+				>
+					Leave it blank <span className="opacity-60">N</span>
+				</PBtn>
+			</div>
 		</div>
 	);
 }
 
 function OpenRow({ run, item }: { run: ReconcileRun; item: ReconcileItem }) {
-	const isModel = item.kind === "missing_from_authored";
 	const note = run.notes[item.atomKey] ?? "";
 	return (
 		<div className="flex flex-col gap-3 px-4 py-4 sm:flex-row sm:items-center">
 			<div className="flex min-w-0 flex-1 items-center gap-4">
-				<Monogram label={item.label} tone={isModel ? "measured" : "authored"} />
+				<Monogram label={item.label} />
 				<div className="min-w-0 flex-1">
 					<p className="font-semibold text-fg-primary">{item.label}</p>
 					<p className="mt-0.5 text-sm text-fg-secondary">{askLine(item)}</p>
-					{isModel && (
-						<p className="mt-1 font-mono text-[11px] text-fg-muted">
-							{usageLine(item)}
-							{priceLine(item) ? ` · ${priceLine(item)}` : ""}
-						</p>
-					)}
-					{!isModel && (
-						<input
-							value={note}
-							onChange={(e) => run.setNote(item.atomKey, e.target.value)}
-							placeholder="e.g. writing and reviewing code"
-							aria-label={`What you use ${item.label} for`}
-							className="mt-2 w-full border border-stroke-subtle bg-bg-canvas px-2.5 py-1.5 text-sm text-fg-primary placeholder:text-fg-muted focus:border-accent-lime focus:outline-none"
-						/>
-					)}
+					<input
+						value={note}
+						onChange={(e) => run.setNote(item.atomKey, e.target.value)}
+						placeholder="e.g. writing and reviewing code"
+						aria-label={`What you use ${item.label} for`}
+						className="mt-2 w-full border border-stroke-subtle bg-bg-canvas px-2.5 py-1.5 text-sm text-fg-primary placeholder:text-fg-muted focus:border-accent-lime focus:outline-none"
+					/>
 				</div>
 			</div>
 			<div className="flex shrink-0 gap-2 sm:self-end">
 				<PBtn
 					tone="primary"
-					disabled={!isModel && !note.trim()}
+					disabled={!note.trim()}
 					onClick={() => void run.answer(item, "added")}
 				>
-					{isModel ? (
-						<>
-							<Plus className="size-3" /> Add it
-						</>
-					) : (
-						"Save it"
-					)}
+					Save it
 				</PBtn>
 				<PBtn tone="danger" onClick={() => void run.answer(item, "hidden")}>
 					<EyeOff className="size-3" /> Hide

--- a/src/features/reconcile/useReconcileRun.ts
+++ b/src/features/reconcile/useReconcileRun.ts
@@ -47,7 +47,6 @@ export function useReconcileRun(stackId: Id<"stacks"> | undefined) {
 	);
 
 	const applyWhatFor = useMutation(api.measured.applyWhatFor);
-	const addMeasuredModel = useMutation(api.measured.addMeasuredModel);
 	const dismiss = useMutation(api.measured.dismissSuggestion);
 	const undismiss = useMutation(api.measured.undismissSuggestion);
 
@@ -106,8 +105,6 @@ export function useReconcileRun(stackId: Id<"stacks"> | undefined) {
 						atomKind: item.atomKind,
 						atomKey: item.atomKey,
 					});
-				} else if (item.kind === "missing_from_authored") {
-					await addMeasuredModel({ stackId, modelSlug: item.atomKey });
 				} else {
 					await applyWhatFor({
 						stackId,
@@ -126,7 +123,7 @@ export function useReconcileRun(stackId: Id<"stacks"> | undefined) {
 				);
 			}
 		},
-		[stackId, notes, dismiss, addMeasuredModel, applyWhatFor],
+		[stackId, notes, dismiss, applyWhatFor],
 	);
 
 	const bringBack = useCallback(

--- a/src/features/stack-editor/components/MeasuredModels.tsx
+++ b/src/features/stack-editor/components/MeasuredModels.tsx
@@ -1,0 +1,101 @@
+import { useMutation } from "convex/react";
+import { Brain, Eye, EyeOff } from "lucide-react";
+import { useState } from "react";
+import { formatShare } from "@/features/stack-view/cards";
+import { cn } from "@/lib/utils";
+import { api } from "../../../../convex/_generated/api";
+import type { Id } from "../../../../convex/_generated/dataModel";
+
+export type MeasuredModelRow = {
+	slug: string;
+	name: string;
+	provider: string;
+	iconUrl?: string;
+	tokenShare: number;
+	hidden: boolean;
+};
+
+/**
+ * The measured half of the model list, in the editor (#338).
+ *
+ * These rows come from the stack's own syncs and the picker cannot add or
+ * remove them. The one control is hide: display only, so a hidden model
+ * leaves the public list and keeps counting in tokens, spend and the
+ * leaderboard. The rows arrive in server order (share descending) and are
+ * rendered as handed.
+ */
+export function MeasuredModels({
+	stackId,
+	models,
+}: {
+	stackId: Id<"stacks">;
+	models: MeasuredModelRow[];
+}) {
+	const setHidden = useMutation(api.stacks.setModelHidden);
+	const [pending, setPending] = useState<string | null>(null);
+
+	if (models.length === 0) return null;
+
+	const toggle = async (row: MeasuredModelRow) => {
+		setPending(row.slug);
+		try {
+			await setHidden({ stackId, modelSlug: row.slug, hidden: !row.hidden });
+		} finally {
+			setPending(null);
+		}
+	};
+
+	return (
+		<div className="mb-3 space-y-2">
+			<p className="font-mono text-[10px] uppercase tracking-wider text-fg-muted">
+				From your syncs
+			</p>
+			{models.map((row) => (
+				<div
+					key={row.slug}
+					className={cn(
+						"flex items-center gap-3 border border-stroke-subtle bg-bg-panel p-2",
+						row.hidden && "opacity-60",
+					)}
+				>
+					{row.iconUrl ? (
+						<img
+							src={row.iconUrl}
+							alt={row.name}
+							className="size-8 shrink-0 object-contain"
+						/>
+					) : (
+						<div className="flex size-8 shrink-0 items-center justify-center border border-stroke-subtle bg-bg-panel-muted">
+							<Brain className="size-4 text-fg-muted" />
+						</div>
+					)}
+					<div className="min-w-0 flex-1">
+						<p className="truncate font-mono text-sm font-semibold text-fg-primary">
+							{row.name}
+						</p>
+						<p className="truncate font-mono text-[10px] uppercase tracking-wider text-fg-muted">
+							{row.provider} · {formatShare(row.tokenShare)}
+						</p>
+					</div>
+					<button
+						type="button"
+						onClick={() => void toggle(row)}
+						disabled={pending === row.slug}
+						aria-label={`${row.hidden ? "Unhide" : "Hide"} ${row.name}`}
+						className="flex h-8 shrink-0 items-center gap-1 border border-stroke-subtle px-2 font-mono text-[10px] uppercase text-fg-muted transition-colors hover:border-accent-lime hover:text-accent-lime disabled:opacity-50"
+					>
+						{row.hidden ? (
+							<>
+								<Eye className="size-3" /> Unhide
+							</>
+						) : (
+							<>
+								<EyeOff className="size-3" /> Hide
+							</>
+						)}
+					</button>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/src/features/stack-editor/components/ToolsSidebar.tsx
+++ b/src/features/stack-editor/components/ToolsSidebar.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "convex/react";
 import { AnimatePresence, motion } from "framer-motion";
 import {
 	Brain,
@@ -25,10 +26,12 @@ import {
 	type ToolSubscriptionEntry,
 } from "@/components/ToolPicker";
 import { UnifiedResourceList } from "@/components/UnifiedResourceList";
+import { MeasuredModels } from "@/features/stack-editor/components/MeasuredModels";
 import { useEditorContext } from "@/features/stack-editor/context/EditorContext";
 import type { Resource } from "@/features/stack-editor/types";
 import { sumNormalizedMonthlyAmounts } from "@/lib/pricing";
 import { cn } from "@/lib/utils";
+import { api } from "../../../../convex/_generated/api";
 import type { Id } from "../../../../convex/_generated/dataModel";
 
 type SidebarSection = "tools" | "bundles" | "models" | "resources" | null;
@@ -65,6 +68,16 @@ function ToolsSidebar({
 	// Accordion state - only one section open at a time
 	// Tools section starts expanded by default (especially important when no tools exist yet)
 	const [activeSection, setActiveSection] = useState<SidebarSection>("tools");
+	// The measured half of the model list (#338): owner-only, none on a draft.
+	const measuredModels =
+		useQuery(
+			api.stacks.listMeasuredModels,
+			stackId && !guestSession ? { stackId } : "skip",
+		) ?? [];
+	const measuredSlugs = useMemo(
+		() => measuredModels.map((m) => m.slug),
+		[measuredModels],
+	);
 	const [editingResource, setEditingResource] = useState<
 		Resource | "new" | null
 	>(null);
@@ -444,7 +457,7 @@ function ToolsSidebar({
 					</div>
 					<div className="flex items-center gap-2">
 						<span className="font-mono text-[10px] text-fg-muted">
-							{models.length}
+							{models.length + measuredModels.length}
 						</span>
 						{activeSection === "models" ? (
 							<ChevronUp className="size-4 text-accent-lime" />
@@ -455,10 +468,14 @@ function ToolsSidebar({
 				</button>
 				{activeSection === "models" && (
 					<div className="mt-3">
+						{stackId && (
+							<MeasuredModels stackId={stackId} models={measuredModels} />
+						)}
 						<ModelPicker
 							value={models}
 							onChange={handleModelsChange}
 							onModelClick={handleModelClick}
+							excludeSlugs={measuredSlugs}
 						/>
 					</div>
 				)}

--- a/src/features/stack-editor/components/__tests__/measured-models.test.tsx
+++ b/src/features/stack-editor/components/__tests__/measured-models.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MeasuredModels } from "@/features/stack-editor/components/MeasuredModels";
+import { formatShare, ModelTile } from "@/features/stack-view/cards";
+
+const mutationMock = vi.fn();
+vi.mock("convex/react", () => ({
+	useMutation: () => mutationMock,
+}));
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+const STACK_ID = "stack_1" as never;
+
+describe("MeasuredModels (#338)", () => {
+	it("renders rows in server order with the share and a hide control", () => {
+		mutationMock.mockResolvedValue(null);
+		render(
+			<MeasuredModels
+				stackId={STACK_ID}
+				models={[
+					{
+						slug: "claude-opus-5",
+						name: "Claude Opus 5",
+						provider: "Anthropic",
+						tokenShare: 0.62,
+						hidden: false,
+					},
+					{
+						slug: "gpt-5.4",
+						name: "GPT-5.4",
+						provider: "OpenAI",
+						tokenShare: 0.004,
+						hidden: true,
+					},
+				]}
+			/>,
+		);
+		expect(screen.getByText("Anthropic · 62%")).toBeTruthy();
+		expect(screen.getByText("OpenAI · <1%")).toBeTruthy();
+
+		fireEvent.click(screen.getByRole("button", { name: "Hide Claude Opus 5" }));
+		expect(mutationMock).toHaveBeenCalledWith({
+			stackId: STACK_ID,
+			modelSlug: "claude-opus-5",
+			hidden: true,
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Unhide GPT-5.4" }));
+		expect(mutationMock).toHaveBeenCalledWith({
+			stackId: STACK_ID,
+			modelSlug: "gpt-5.4",
+			hidden: false,
+		});
+	});
+
+	it("renders nothing when no model is measured", () => {
+		const { container } = render(
+			<MeasuredModels stackId={STACK_ID} models={[]} />,
+		);
+		expect(container.innerHTML).toBe("");
+	});
+});
+
+describe("ModelTile prints the share and nothing else", () => {
+	it("shows the share for a measured model and only the provider for a pick", () => {
+		render(
+			<>
+				<ModelTile
+					model={{
+						_id: "m1",
+						name: "Claude Opus 5",
+						provider: "Anthropic",
+						tokenShare: 0.62,
+						measured: true,
+					}}
+				/>
+				<ModelTile
+					model={{
+						_id: "m2",
+						name: "GPT-5.4",
+						provider: "OpenAI",
+						tokenShare: null,
+						measured: false,
+					}}
+				/>
+			</>,
+		);
+		expect(screen.getByText("Anthropic · 62%")).toBeTruthy();
+		expect(screen.getByText("OpenAI")).toBeTruthy();
+		expect(screen.queryByText(/primary|secondary|specialized/i)).toBeNull();
+	});
+
+	it("formatShare rounds and floors tiny shares to <1%", () => {
+		expect(formatShare(0.62)).toBe("62%");
+		expect(formatShare(0.004)).toBe("<1%");
+		expect(formatShare(0)).toBe("0%");
+		expect(formatShare(1)).toBe("100%");
+	});
+});

--- a/src/features/stack-editor/state/editorSelectors.ts
+++ b/src/features/stack-editor/state/editorSelectors.ts
@@ -93,7 +93,6 @@ function selectSavePayload(state: EditorState, published: boolean) {
 		})),
 		modelSubscriptions: state.modelSubscriptions.map((model) => ({
 			modelSlug: model.modelSlug,
-			role: model.role,
 			description: model.description,
 		})),
 		accentPreset: state.accentPreset || undefined,

--- a/src/features/stack-editor/types.ts
+++ b/src/features/stack-editor/types.ts
@@ -79,7 +79,6 @@ type ModelSubscriptionEntry = {
 		| "embedding"
 		| "other";
 	modelIconUrl?: string;
-	role: "primary" | "secondary" | "specialized";
 	description?: string;
 };
 

--- a/src/features/stack-view/__tests__/stack-view-sections.test.tsx
+++ b/src/features/stack-view/__tests__/stack-view-sections.test.tsx
@@ -77,7 +77,8 @@ function makeModel(overrides: Partial<StackModel> = {}): StackModel {
 		_id: "model-1",
 		name: "GPT-4o",
 		provider: "OpenAI",
-		role: "primary",
+		tokenShare: null,
+		measured: false,
 		...overrides,
 	};
 }

--- a/src/features/stack-view/cards.tsx
+++ b/src/features/stack-view/cards.tsx
@@ -49,7 +49,9 @@ export type StackModel = {
 	provider: string;
 	category?: string;
 	iconUrl?: string;
-	role: "primary" | "secondary" | "specialized";
+	/** Share of the stack's 30-day tokens; null for a manual pick (#338). */
+	tokenShare: number | null;
+	measured: boolean;
 	description?: string;
 };
 
@@ -206,11 +208,11 @@ export function ToolCardMini({
 
 // --- Model tile -----------------------------------------------------------
 
-const ROLE_LABEL: Record<StackModel["role"], string> = {
-	primary: "Primary",
-	secondary: "Secondary",
-	specialized: "Specialized",
-};
+/** "62%" from a share; below half a percent prints "<1%". Numbers only. */
+export function formatShare(share: number): string {
+	const pct = Math.round(share * 100);
+	return pct === 0 && share > 0 ? "<1%" : `${pct}%`;
+}
 
 export function ModelTile({ model }: { model: StackModel }) {
 	return (
@@ -236,7 +238,8 @@ export function ModelTile({ model }: { model: StackModel }) {
 					{model.name}
 				</p>
 				<p className="truncate font-mono text-[10px] uppercase tracking-wider text-fg-muted">
-					{model.provider} · {ROLE_LABEL[model.role]}
+					{model.provider}
+					{model.tokenShare !== null && ` · ${formatShare(model.tokenShare)}`}
 				</p>
 			</div>
 		</div>

--- a/src/features/stack-view/sections.tsx
+++ b/src/features/stack-view/sections.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { ChevronRight, Pencil } from "lucide-react";
-import { type ReactNode, useId, useMemo, useState } from "react";
+import { type ReactNode, useId, useState } from "react";
 import { TableOfContents } from "@/components/TableOfContents";
 import { TiptapEditor } from "@/components/TiptapEditor";
 import { formatPriceDisplay, sortToolsByPrice } from "@/lib/pricing";
@@ -119,15 +119,6 @@ export function ToolsSection({
 
 	const price = formatPriceDisplay(fixedTotal?.amount ?? 0, "month", "floor");
 
-	const sortedModels = useMemo(
-		() =>
-			[...models].sort((a, b) => {
-				const p = a.provider.localeCompare(b.provider);
-				return p !== 0 ? p : b.name.localeCompare(a.name);
-			}),
-		[models],
-	);
-
 	if (tools.length === 0) return null;
 
 	return (
@@ -152,7 +143,8 @@ export function ToolsSection({
 						onOpenChange={onModelsOpenChange}
 					>
 						<div className={cn("grid grid-cols-1 sm:grid-cols-2", GAP)}>
-							{sortedModels.map((m) => (
+							{/* Server order (#338): measured by share, then picks. Nothing ranks here. */}
+							{models.map((m) => (
 								<ModelTile key={m._id} model={m} />
 							))}
 						</div>

--- a/src/routes/stacks.$slug_.edit.tsx
+++ b/src/routes/stacks.$slug_.edit.tsx
@@ -144,7 +144,6 @@ function EditStackPage() {
 					modelCategory:
 						m.modelCategory as ModelSubscriptionEntry["modelCategory"],
 					modelIconUrl: m.modelIconUrl,
-					role: m.role,
 				})),
 			}}
 		/>


### PR DESCRIPTION
Closes #338. Part of map #332.

## What changes

**Server**
- `convex/lib/stackModels.ts`: the stack's model list is derived at read time. Measured models from the 30-day fold (tokens > 0, resolved through `loadModelCatalog`) sorted by token share, then the manual picks (`modelSubscriptions`) in stored order, deduped. A pick a sync measures sorts into the measured group once; a pick naming no catalog row is dropped.
- `getBySlug` and `getPublicSummary` hand the page that list. Each entry carries `tokenShare` (null for a pick) and `measured`; `role` is gone from the read.
- Hide: `stacks.hiddenModelSlugs` plus owner-only `stacks.setModelHidden` and `stacks.listMeasuredModels`. Display only: a hidden model leaves the public list and keeps counting in tokens, spend and the leaderboard (asserted in `convex/stackModelsRead.test.ts`).
- Cut off: `addMeasuredModel` and the `missing_from_authored` suggestion path are deleted; `getReconcileSuggestions` keeps only the what-for question.
- Schema: `modelSubscriptions[].role` widened to optional (phase 1). `ModelSubscriptionInput` no longer accepts `role`.
- Migration `migrations/20260829_merge_model_picks`: drops `role`, rewrites any pick still on the #334 rename map (a no-op after `20260829_vendor_model_ids`), resolves aliases to slugs, dedupes, drops picks that resolve to no catalog row, keeps descriptions. Idempotent; reports what it rewrote.

**Web**
- Models disclosure renders the server order and prints `provider · share` on a measured tile, provider only on a pick. No roles, no client sort.
- Editor Models section: "From your syncs" rows with Hide/Unhide, then the picker for what no adapter sees (measured slugs excluded from the browser).
- Changes page: the measured-model card, its share and price lines are gone; only the what-for card remains.

**Docs**: `AGENTS.md` (Stack models section), `CONTEXT.md` (stack model list, manual pick, hidden model).

**CLI**: unchanged. The preview/approve gate already lists the models and is the consent. Wire untouched; old CLIs keep working.

## Prod steps (owner)

1. Merge; the workflow deploys the widened schema and the new functions.
2. `scripts/convex-prod.sh run migrations/20260829_merge_model_picks:run`
3. Verify a synced stack (for example `alpers-coding-stack`) lists its measured models by share with picks after them.

## Follow-up narrow revision (not in this PR)

After the migration has run on prod, a separate PR removes `role` from `stacks.modelSubscriptions` in `convex/schema.ts` (the object becomes `{ modelSlug, description? }`). Nothing else references the field.

## Verification

- `pnpm test`: 186 files, 2527 passed, 6 skipped.
- `pnpm tsc --noEmit`: 44 errors, all pre-existing under `src/**/__tests__` and `packages/cli/prototypes`; 0 outside the baseline.
- Biome scoped to touched files; remaining hits are pre-existing lines.

## Not settled by the ticket

- `creators.ts` `modelCount` still counts picks only (a per-stack fold on the creator page was out of scope).
- Model dismissals (`reconcileDismissals` with `atomKind: 'model'`) are now dead rows; left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UX3EwpV7eYAW4MNQsnzZ5
