### PR TITLE
Backfill missing model icons from the import

### DIFF
--- a/convex/lib/modelImport.test.ts
+++ b/convex/lib/modelImport.test.ts
@@ -328,11 +328,52 @@ describe('planImport', () => {
     expect(p.models.map((m) => m.slug)).toEqual(['deepseek-v4-pro'])
   })
 
+  test('backfills the vendor logo on an existing row that has no icon at all', () => {
+    const p = plan({
+      models: [
+        model({ slug: 'claude-opus-5' }),
+        model({ slug: 'claude-sonnet-5', iconUrl: 'https://example.com/own.svg' }),
+        model({ slug: 'claude-fable-5', iconStorageId: 'st_1' as Id<'_storage'> }),
+        model({ slug: 'gpt-5.6-sol', provider: 'OpenAI' }),
+      ],
+      dataset: [
+        dm({ id: 'claude-opus-5', providerId: 'anthropic' }),
+        dm({ id: 'claude-sonnet-5', providerId: 'anthropic' }),
+        dm({ id: 'claude-fable-5', providerId: 'anthropic' }),
+        // A gateway re-serving Sol must not decide the logo.
+        dm({ id: 'gpt-5.6-sol', providerId: 'openrouter' }),
+        dm({ id: 'gpt-5.6-sol', providerId: 'openai' }),
+      ],
+    })
+    expect(p.icons).toEqual([
+      { modelSlug: 'claude-opus-5', iconUrl: 'https://models.dev/logos/anthropic.svg' },
+      { modelSlug: 'gpt-5.6-sol', iconUrl: 'https://models.dev/logos/openai.svg' },
+    ])
+  })
+
+  test('derives the logo from the provider name when the dataset does not list the row', () => {
+    const p = plan({
+      models: [
+        model({ slug: 'gpt-5.6-luna', provider: 'OpenAI' }),
+        model({ slug: 'gemini-x', provider: 'Google DeepMind' }),
+        model({ slug: 'grok-x', provider: 'xAI' }),
+        model({ slug: 'mystery', provider: 'Acme' }),
+        model({ slug: 'nobody', provider: undefined }),
+      ],
+    })
+    expect(p.icons).toEqual([
+      { modelSlug: 'gpt-5.6-luna', iconUrl: 'https://models.dev/logos/openai.svg' },
+      { modelSlug: 'gemini-x', iconUrl: 'https://models.dev/logos/google.svg' },
+      { modelSlug: 'grok-x', iconUrl: 'https://models.dev/logos/xai.svg' },
+    ])
+  })
+
   test('a rejected row is left alone', () => {
     const p = plan({
       models: [model({ slug: 'claude-opus-4-7', reviewStatus: 'rejected' })],
       dataset: [dm({ id: 'claude-opus-4-7', providerId: 'anthropic', input: 1, output: 1 })],
     })
     expect(p.periods).toEqual([])
+    expect(p.icons).toEqual([])
   })
 })

--- a/convex/lib/modelImport.ts
+++ b/convex/lib/modelImport.ts
@@ -74,6 +74,11 @@ export function datasetProviderOf(provider: string | undefined): string | null {
   return null
 }
 
+/** The models.dev logo for a dataset provider id. */
+export function logoUrl(providerId: string): string {
+  return `https://models.dev/logos/${providerId}.svg`
+}
+
 function num(x: unknown): number | undefined {
   return typeof x === 'number' && Number.isFinite(x) ? x : undefined
 }
@@ -104,7 +109,7 @@ export function parseModelsDev(json: unknown): DatasetModel[] {
         ...(num(m?.limit?.context) !== undefined ? { contextWindow: m.limit.context } : {}),
         ...(typeof m?.release_date === 'string' ? { releaseDate: m.release_date } : {}),
         textOnly: inputs.includes('text') && outputs.length === 1 && outputs[0] === 'text',
-        iconUrl: `https://models.dev/logos/${providerId}.svg`,
+        iconUrl: logoUrl(providerId),
       })
     }
   }
@@ -227,9 +232,17 @@ export type ModelInsert = {
   rates: Rates | null
 }
 
+/** An existing row with no icon at all, and the vendor logo it gets. */
+export type IconBackfill = {
+  modelSlug: string
+  iconUrl: string
+}
+
 export type ImportPlan = {
   periods: PeriodInsert[]
   models: ModelInsert[]
+  /** Rows the run gives a logo to. */
+  icons: IconBackfill[]
   /** Dataset models the allowlist and the window kept out, for the run line. */
   skipped: number
 }
@@ -307,6 +320,7 @@ export function planImport(args: {
   const { catalog, models, prices, dataset, measuredIds, source, now } = args
   const periods: PeriodInsert[] = []
   const modelInserts: ModelInsert[] = []
+  const icons: IconBackfill[] = []
   const claimed = new Set<string>()
   let skipped = 0
 
@@ -316,10 +330,19 @@ export function planImport(args: {
     return true
   }
 
-  // 1. Rate changes on rows the catalog holds.
+  // 1. Rate changes on rows the catalog holds, and the vendor logo for a row
+  // that has no icon of any kind. The logo comes from the dataset match when
+  // there is one (already under the row's own vendor, never a gateway) and
+  // otherwise from the row's provider name, so a row the dataset skips still
+  // gets one. A row with any icon is left alone.
   for (const row of models) {
     if (row.reviewStatus === 'rejected') continue
     const m = datasetModelFor(dataset, row)
+    if (!row.iconStorageId && !row.iconUrl) {
+      const providerId = m ? m.providerId : datasetProviderOf(row.provider)
+      const iconUrl = m?.iconUrl ?? (providerId ? logoUrl(providerId) : undefined)
+      if (iconUrl) icons.push({ modelSlug: row.slug, iconUrl })
+    }
     if (!m) continue
     const current = periodInEffect(prices, row.slug, now)
     const rates = ratesOf(m)
@@ -389,7 +412,7 @@ export function planImport(args: {
     })
   }
 
-  return { periods, models: modelInserts, skipped }
+  return { periods, models: modelInserts, icons, skipped }
 }
 
 /** `$5/$25 in/out` style, for the log. */

--- a/convex/modelImport.test.ts
+++ b/convex/modelImport.test.ts
@@ -74,6 +74,7 @@ async function seed(t: ReturnType<typeof convexTest>) {
         provider,
         category: 'coding',
         reviewStatus: 'approved',
+        iconUrl: `https://models.dev/logos/${provider.toLowerCase()}.svg`,
         createdAt: now,
         updatedAt: now,
       })
@@ -274,6 +275,52 @@ describe('modelImport (#337)', () => {
     // A second run creates nothing more.
     const again = await t.action(internal.modelImport.run, {})
     expect(again).toMatchObject({ periods: 0, models: 0 })
+  })
+
+  test('backfills iconUrl on an icon-less row and logs one icon line', async () => {
+    const t = convexTest(schema, modules)
+    await seed(t)
+    await t.run(async (ctx) => {
+      const sol = await ctx.db.query('modelPrices').withIndex('by_model', (q) => q.eq('modelSlug', 'gpt-5.6-sol')).first()
+      await ctx.db.patch(sol!._id, { input: 4, output: 20, cacheRead: 0.4 })
+      const rows = await ctx.db.query('models').collect()
+      for (const r of rows) await ctx.db.patch(r._id, { iconUrl: undefined })
+      await ctx.db.insert('models', {
+        name: 'gpt-5.6-luna',
+        slug: 'gpt-5.6-luna',
+        shortId: 'luna01',
+        provider: 'OpenAI',
+        category: 'coding',
+        reviewStatus: 'approved',
+        createdAt: 1,
+        updatedAt: 1,
+      })
+    })
+    stubFetch({ [MODELS_DEV_URL]: MODELS_DEV })
+
+    const result = await t.action(internal.modelImport.run, {})
+    expect(result).toMatchObject({ periods: 0, models: 0 })
+
+    await t.run(async (ctx) => {
+      const rows = await ctx.db.query('models').collect()
+      expect(Object.fromEntries(rows.map((r) => [r.slug, r.iconUrl]))).toEqual({
+        'claude-opus-4-7': 'https://models.dev/logos/anthropic.svg',
+        'gpt-5.6-sol': 'https://models.dev/logos/openai.svg',
+        'gpt-5.6-luna': 'https://models.dev/logos/openai.svg',
+      })
+      const log = await ctx.db.query('importLog').collect()
+      expect(log.map((l) => l.kind).sort()).toEqual(['icon', 'icon', 'icon', 'run'])
+      expect(log.find((l) => l.modelSlug === 'gpt-5.6-luna')!.detail).toBe(
+        'icon https://models.dev/logos/openai.svg (provider OpenAI)'
+      )
+    })
+
+    const again = await t.action(internal.modelImport.run, {})
+    expect(again).toMatchObject({ periods: 0, models: 0 })
+    await t.run(async (ctx) => {
+      const log = await ctx.db.query('importLog').collect()
+      expect(log.filter((l) => l.kind === 'icon')).toHaveLength(3)
+    })
   })
 
   test('falls back to LiteLLM when models.dev does not answer, and cites it', async () => {

--- a/convex/modelImport.ts
+++ b/convex/modelImport.ts
@@ -57,6 +57,8 @@ const ModelInsertV = v.object({
   rates: v.union(RatesV, v.null()),
 })
 
+const IconBackfillV = v.object({ modelSlug: v.string(), iconUrl: v.string() })
+
 const LOG_KEEP = 500
 
 type RunResult = { periods: number; models: number; source: string }
@@ -105,6 +107,7 @@ export const apply = internalMutation({
   args: {
     periods: v.array(PeriodInsertV),
     models: v.array(ModelInsertV),
+    icons: v.optional(v.array(IconBackfillV)),
     source: v.string(),
     skipped: v.number(),
     now: v.number(),
@@ -180,6 +183,21 @@ export const apply = internalMutation({
             : `pending row from ${source} (${m.provider}), ${m.rates ? formatRates(m.rates) : 'unpriced'}`,
       })
     }
+    for (const i of args.icons ?? []) {
+      const row = await ctx.db
+        .query('models')
+        .withIndex('by_slug', (q) => q.eq('slug', i.modelSlug))
+        .first()
+      // Re-check against the table: the plan was made from a snapshot.
+      if (!row || row.iconStorageId || row.iconUrl) continue
+      await ctx.db.patch(row._id, { iconUrl: i.iconUrl, updatedAt: now })
+      await ctx.db.insert('importLog', {
+        at: now,
+        kind: 'icon',
+        modelSlug: i.modelSlug,
+        detail: `icon ${i.iconUrl} (provider ${row.provider ?? 'unknown'})`,
+      })
+    }
     await ctx.db.insert('importLog', {
       at: now,
       kind: 'run',
@@ -244,6 +262,7 @@ export const run = internalAction({
       const written: { periods: number; models: number } = await ctx.runMutation(internal.modelImport.apply, {
         periods: plan.periods,
         models: plan.models,
+        icons: plan.icons,
         source,
         skipped: plan.skipped,
         now,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1037,6 +1037,7 @@ export default defineSchema({
       v.literal('run'),
       v.literal('price'),
       v.literal('model'),
+      v.literal('icon'),
       v.literal('error')
     ),
     modelSlug: v.optional(v.string()),


### PR DESCRIPTION
On prod, existing `models` rows for newer models (`claude-opus-5`, `gpt-5.6-sol`, ...) have neither `iconStorageId` nor `iconUrl`, so the stack page shows letter fallbacks. The import set the models.dev logo only on rows it created.

- `planImport` emits `icons` for every icon-less row: from the dataset match (own vendor only, gateway guard kept), else derived from the provider name (`Anthropic`, `OpenAI`, `Google`, `xAI`, ...). Rows with any icon are untouched, pinned by test.
- `apply` patches `iconUrl` and writes one `icon` importLog line per row (schema union extended).
- Takes effect on the next cron run or "Run import now" on the Admin Import tab. `scripts/migrate-icons.ts` handles the svg URLs as-is (sharp rasterizes SVG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UX3EwpV7eYAW4MNQsnzZ5
