### PR TITLE
Invert monochrome models.dev logos in dark mode

### DIFF
--- a/scripts/migrate-icons.ts
+++ b/scripts/migrate-icons.ts
@@ -150,6 +150,9 @@ async function processRow(
 ): Promise<'ok' | 'skipped' | 'failed'> {
   if (row.iconStorageId) return 'skipped'
   if (!row.iconUrl) return 'skipped'
+  // models.dev logos are monochrome currentColor SVGs; the web inverts them
+  // per theme by URL, so they stay URLs (see src/lib/iconTheme.ts).
+  if (row.iconUrl.startsWith('https://models.dev/logos/')) return 'skipped'
 
   const isDataURI = row.iconUrl.startsWith('data:')
 

--- a/src/components/ItemIcon.tsx
+++ b/src/components/ItemIcon.tsx
@@ -1,5 +1,6 @@
-import { Box } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import { Box } from "lucide-react";
+import { monochromeLogoClass } from "@/lib/iconTheme";
 import { cn } from "@/lib/utils";
 
 type ItemIconSize = "xs" | "sm" | "md" | "lg";
@@ -36,6 +37,7 @@ export function ItemIcon({
 				className={cn(
 					container,
 					"shrink-0 rounded border border-stroke-subtle object-contain p-0.5",
+					monochromeLogoClass(src),
 					className,
 				)}
 			/>

--- a/src/features/stack-view/ui.tsx
+++ b/src/features/stack-view/ui.tsx
@@ -1,6 +1,7 @@
 import { ArrowUpRight } from "lucide-react";
 import type { ReactNode } from "react";
 import { categoryConfig } from "@/config/categoryConfig";
+import { monochromeLogoClass } from "@/lib/iconTheme";
 import { formatPriceDisplay } from "@/lib/pricing";
 import { useScrollHighlight } from "@/lib/useScrollHighlight";
 import { cn } from "@/lib/utils";
@@ -100,6 +101,7 @@ export function StackIcon({
 				className={cn(
 					ICON_SIZES[size].split(" ")[0],
 					"shrink-0 border border-stroke-subtle object-contain p-1",
+					monochromeLogoClass(src),
 					className,
 				)}
 			/>

--- a/src/lib/__tests__/iconTheme.test.ts
+++ b/src/lib/__tests__/iconTheme.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { isMonochromeLogo, monochromeLogoClass } from "../iconTheme";
+
+describe("monochromeLogoClass", () => {
+	it("inverts models.dev logos in dark mode and restores them under .light", () => {
+		expect(monochromeLogoClass("https://models.dev/logos/anthropic.svg")).toBe(
+			"invert [.light_&]:invert-0",
+		);
+	});
+	it("leaves every other icon source alone", () => {
+		expect(monochromeLogoClass("https://example.com/icon.png")).toBeUndefined();
+		expect(monochromeLogoClass(undefined)).toBeUndefined();
+		expect(isMonochromeLogo(null)).toBe(false);
+	});
+});

--- a/src/lib/iconTheme.ts
+++ b/src/lib/iconTheme.ts
@@ -1,0 +1,15 @@
+/**
+ * models.dev provider logos are single-color SVGs painted with `currentColor`,
+ * which renders black inside an <img>. The site defaults to dark, so those
+ * logos are inverted unless the root carries the `.light` class.
+ */
+export const MONOCHROME_LOGO_HOST = "https://models.dev/logos/";
+
+export function isMonochromeLogo(src?: string | null): boolean {
+	return typeof src === "string" && src.startsWith(MONOCHROME_LOGO_HOST);
+}
+
+/** Tailwind classes that flip a monochrome logo to the current theme. */
+export function monochromeLogoClass(src?: string | null): string | undefined {
+	return isMonochromeLogo(src) ? "invert [.light_&]:invert-0" : undefined;
+}


### PR DESCRIPTION
The provider logos the import stores (`https://models.dev/logos/<provider>.svg`) use `fill="currentColor"`, which renders black inside an `<img>`. On the dark default theme they showed as black marks on dark tiles.

- `src/lib/iconTheme.ts`: `monochromeLogoClass(src)` returns `invert [.light_&]:invert-0` for models.dev logo URLs, nothing otherwise. Tested.
- `ItemIcon` (admin tabs) and `StackIcon` (stack page) apply it.
- `scripts/migrate-icons.ts` skips models.dev logo URLs so the URL-based hint survives.

Tests: 295 passed in the touched areas; `tsc` at the 44-error baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UX3EwpV7eYAW4MNQsnzZ5