### PR TITLE
Polish the admin Import tab and keep a refresh on /admin

### DIFF
--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -765,3 +765,35 @@ export const updateToolEditSuggestion = mutation({
     await ctx.db.patch(args.suggestionId, patch)
   },
 })
+
+export const getImportTabCount = query({
+  args: {},
+  returns: v.union(v.number(), v.null()),
+  handler: async (ctx) => {
+    if (!(await isAdmin(ctx))) return null
+    const models = await ctx.db
+      .query('models')
+      .withIndex('by_reviewStatus', (q) => q.eq('reviewStatus', 'pending'))
+      .collect()
+    return models.length
+  },
+})
+
+export const approveAllPendingModels = mutation({
+  args: {},
+  returns: v.number(),
+  handler: async (ctx) => {
+    if (!(await isAdmin(ctx))) {
+      throw new Error('Unauthorized')
+    }
+    const models = await ctx.db
+      .query('models')
+      .withIndex('by_reviewStatus', (q) => q.eq('reviewStatus', 'pending'))
+      .collect()
+    const now = Date.now()
+    for (const model of models) {
+      await ctx.db.patch(model._id, { reviewStatus: 'approved', updatedAt: now })
+    }
+    return models.length
+  },
+})

--- a/convex/adminApproveAll.test.ts
+++ b/convex/adminApproveAll.test.ts
@@ -1,0 +1,56 @@
+import { convexTest } from 'convex-test'
+import { describe, expect, test } from 'vitest'
+import { api } from './_generated/api'
+import { ADMIN_EMAILS } from './lib/admin'
+import schema from './schema'
+
+const modules = import.meta.glob('./**/*.{js,ts}')
+
+function asAdmin(t: ReturnType<typeof convexTest>) {
+  return t.withIdentity({ tokenIdentifier: 'convex|admin', email: ADMIN_EMAILS[0] })
+}
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  const now = 1_700_000_000_000
+  await t.run(async (ctx) => {
+    for (const [slug, reviewStatus] of [
+      ['a-pending', 'pending'],
+      ['b-pending', 'pending'],
+      ['c-approved', 'approved'],
+    ] as const) {
+      await ctx.db.insert('models', {
+        name: slug,
+        slug,
+        shortId: slug.slice(0, 6),
+        provider: 'OpenAI',
+        category: 'coding',
+        reviewStatus,
+        createdAt: now,
+        updatedAt: now,
+      })
+    }
+  })
+}
+
+describe('approveAllPendingModels', () => {
+  test('approves every pending model and the import count drops to zero', async () => {
+    const t = convexTest(schema, modules)
+    await seed(t)
+    const admin = asAdmin(t)
+    expect(await admin.query(api.admin.getImportTabCount, {})).toBe(2)
+    expect(await admin.mutation(api.admin.approveAllPendingModels, {})).toBe(2)
+    expect(await admin.query(api.admin.getImportTabCount, {})).toBe(0)
+    const statuses = await t.run(async (ctx) =>
+      (await ctx.db.query('models').collect()).map((m) => m.reviewStatus)
+    )
+    expect(statuses).toEqual(['approved', 'approved', 'approved'])
+  })
+
+  test('refuses a non-admin and answers null for the count', async () => {
+    const t = convexTest(schema, modules)
+    await seed(t)
+    const user = t.withIdentity({ tokenIdentifier: 'convex|user', email: 'someone@example.com' })
+    expect(await user.query(api.admin.getImportTabCount, {})).toBeNull()
+    await expect(user.mutation(api.admin.approveAllPendingModels, {})).rejects.toThrow()
+  })
+})

--- a/src/components/admin/AdminImportTab.tsx
+++ b/src/components/admin/AdminImportTab.tsx
@@ -15,6 +15,7 @@ export function AdminImportTab() {
 	const runNow = useAction(api.modelImport.runNow);
 	const approveModel = useMutation(api.admin.approveModel);
 	const rejectModel = useMutation(api.admin.rejectModel);
+	const approveAll = useMutation(api.admin.approveAllPendingModels);
 	const [running, setRunning] = useState(false);
 	const [result, setResult] = useState<string | null>(null);
 
@@ -89,6 +90,16 @@ export function AdminImportTab() {
 							<span className="ml-2 inline-flex h-5 min-w-5 items-center justify-center bg-accent-lime px-1 font-mono text-xs font-bold text-bg-canvas">
 								{pendingModels.length}
 							</span>
+						) : null}
+						{pendingModels && pendingModels.length > 0 ? (
+							<button
+								type="button"
+								onClick={() => approveAll({}).catch(console.error)}
+								className="ml-4 inline-flex items-center gap-1.5 border-2 border-accent-lime px-2 py-0.5 font-mono text-xs font-semibold uppercase tracking-wide text-accent-lime transition-colors hover:bg-accent-lime hover:text-accent-lime-contrast"
+							>
+								<Check className="size-3.5" />
+								Approve all
+							</button>
 						) : null}
 					</h3>
 					{!pendingModels || pendingModels.length === 0 ? (

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -5,7 +5,8 @@ import {
 	useNavigate,
 	useSearch,
 } from "@tanstack/react-router";
-import { useQuery } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
+import type { LucideIcon } from "lucide-react";
 import {
 	ChartNoAxesColumn,
 	ClipboardCheck,
@@ -89,6 +90,8 @@ function AdminPage() {
 	const isAdmin = useQuery(api.admin.checkIsAdmin);
 	const reviewCount = useQuery(api.admin.getReviewTabCount);
 	const qualityCount = useQuery(api.admin.getQualityTabCount);
+	const importCount = useQuery(api.admin.getImportTabCount);
+	const { isLoading: authLoading } = useConvexAuth();
 	const newsCounts = useQuery(api.news.countItems);
 	const newsCount = newsCounts?.inbox ?? 0;
 	const navigate = useNavigate({ from: "/admin" });
@@ -109,7 +112,37 @@ function AdminPage() {
 		[navigate],
 	);
 
-	if (isAdmin === undefined) {
+	// Tab order is fixed: review, import, quality, views, email, news.
+	const tabs: Array<{
+		key: AdminTab;
+		label: string;
+		icon: LucideIcon;
+		count?: number | null;
+		patch?: Partial<typeof ADMIN_SEARCH_DEFAULTS>;
+	}> = [
+		{
+			key: "review",
+			label: "Review",
+			icon: ClipboardCheck,
+			count: reviewCount,
+			patch: { view: ADMIN_SEARCH_DEFAULTS.view },
+		},
+		{ key: "import", label: "Import", icon: Download, count: importCount },
+		{
+			key: "quality",
+			label: "Quality",
+			icon: Flag,
+			count: qualityCount,
+			patch: { view: ADMIN_SEARCH_DEFAULTS.view },
+		},
+		{ key: "views", label: "Views", icon: ChartNoAxesColumn },
+		{ key: "email", label: "Email", icon: Mail },
+		{ key: "news", label: "News", icon: Newspaper, count: newsCount },
+	];
+
+	// A refresh must stay on /admin: the admin check answers false while the
+	// auth token is still being fetched, so redirect only once auth has settled.
+	if (isAdmin === undefined || (authLoading && !isAdmin)) {
 		return (
 			<div className="flex min-h-screen items-center justify-center bg-bg-canvas">
 				<div className="font-mono text-sm text-fg-muted">Loading...</div>
@@ -127,97 +160,26 @@ function AdminPage() {
 			<div className="border-b-2 border-stroke-strong bg-bg-panel">
 				<div className="mx-auto max-w-6xl px-4 sm:px-6">
 					<div className="flex items-center gap-1">
-						<button
-							type="button"
-							onClick={() =>
-								setSearch({ tab: "review", view: ADMIN_SEARCH_DEFAULTS.view })
-							}
-							className={`inline-flex items-center gap-2 border-b-2 px-6 py-4 font-mono text-sm font-semibold uppercase tracking-wide transition-colors -mb-[2px] ${
-								tab === "review"
-									? "border-accent-lime text-accent-lime"
-									: "border-transparent text-fg-muted hover:text-fg-primary"
-							}`}
-						>
-							<ClipboardCheck className="size-4" />
-							Review
-							{reviewCount ? (
-								<span className="inline-flex h-5 min-w-5 items-center justify-center bg-accent-lime px-1 font-mono text-xs font-bold text-bg-canvas">
-									{reviewCount}
-								</span>
-							) : null}
-						</button>
-						<button
-							type="button"
-							onClick={() =>
-								setSearch({ tab: "quality", view: ADMIN_SEARCH_DEFAULTS.view })
-							}
-							className={`inline-flex items-center gap-2 border-b-2 px-6 py-4 font-mono text-sm font-semibold uppercase tracking-wide transition-colors -mb-[2px] ${
-								tab === "quality"
-									? "border-accent-lime text-accent-lime"
-									: "border-transparent text-fg-muted hover:text-fg-primary"
-							}`}
-						>
-							<Flag className="size-4" />
-							Quality
-							{qualityCount ? (
-								<span className="inline-flex h-5 min-w-5 items-center justify-center bg-accent-lime px-1 font-mono text-xs font-bold text-bg-canvas">
-									{qualityCount}
-								</span>
-							) : null}
-						</button>
-						<button
-							type="button"
-							onClick={() => setSearch({ tab: "email" })}
-							className={`inline-flex items-center gap-2 border-b-2 px-6 py-4 font-mono text-sm font-semibold uppercase tracking-wide transition-colors -mb-[2px] ${
-								tab === "email"
-									? "border-accent-lime text-accent-lime"
-									: "border-transparent text-fg-muted hover:text-fg-primary"
-							}`}
-						>
-							<Mail className="size-4" />
-							Email
-						</button>
-						<button
-							type="button"
-							onClick={() => setSearch({ tab: "views" })}
-							className={`inline-flex items-center gap-2 border-b-2 px-6 py-4 font-mono text-sm font-semibold uppercase tracking-wide transition-colors -mb-[2px] ${
-								tab === "views"
-									? "border-accent-lime text-accent-lime"
-									: "border-transparent text-fg-muted hover:text-fg-primary"
-							}`}
-						>
-							<ChartNoAxesColumn className="size-4" />
-							Views
-						</button>
-						<button
-							type="button"
-							onClick={() => setSearch({ tab: "news" })}
-							className={`inline-flex items-center gap-2 border-b-2 px-6 py-4 font-mono text-sm font-semibold uppercase tracking-wide transition-colors -mb-[2px] ${
-								tab === "news"
-									? "border-accent-lime text-accent-lime"
-									: "border-transparent text-fg-muted hover:text-fg-primary"
-							}`}
-						>
-							<Newspaper className="size-4" />
-							News
-							{newsCount ? (
-								<span className="inline-flex h-5 min-w-5 items-center justify-center bg-accent-lime px-1 font-mono text-xs font-bold text-bg-canvas">
-									{newsCount}
-								</span>
-							) : null}
-						</button>
-						<button
-							type="button"
-							onClick={() => setSearch({ tab: "import" })}
-							className={`inline-flex items-center gap-2 border-b-2 px-6 py-4 font-mono text-sm font-semibold uppercase tracking-wide transition-colors -mb-[2px] ${
-								tab === "import"
-									? "border-accent-lime text-accent-lime"
-									: "border-transparent text-fg-muted hover:text-fg-primary"
-							}`}
-						>
-							<Download className="size-4" />
-							Import
-						</button>
+						{tabs.map(({ key, label, icon: Icon, count, patch }) => (
+							<button
+								key={key}
+								type="button"
+								onClick={() => setSearch({ tab: key, ...patch })}
+								className={`inline-flex items-center gap-2 border-b-2 px-6 py-4 font-mono text-sm font-semibold uppercase tracking-wide transition-colors -mb-[2px] ${
+									tab === key
+										? "border-accent-lime text-accent-lime"
+										: "border-transparent text-fg-muted hover:text-fg-primary"
+								}`}
+							>
+								<Icon className="size-4" />
+								{label}
+								{count ? (
+									<span className="inline-flex h-5 min-w-5 items-center justify-center bg-accent-lime px-1 font-mono text-xs font-bold text-bg-canvas">
+										{count}
+									</span>
+								) : null}
+							</button>
+						))}
 						<LivingStacks />
 					</div>
 				</div>


### PR DESCRIPTION
- Import tab: **Approve all** button (`admin.approveAllPendingModels`, admin-guarded, tested) next to the pending count.
- Tab bar: the Import tab shows the pending-model count (`admin.getImportTabCount`); order is now review, import, quality, views, email, news. The buttons come from one list instead of six copies.
- Refresh: `checkIsAdmin` answers false while the auth token is still being fetched, which sent every refresh to `/`. The page now keeps its loading state until `useConvexAuth().isLoading` is false and only then redirects a non-admin.

Tests: new `convex/adminApproveAll.test.ts` (2), route tests pass, `tsc` clean outside the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UX3EwpV7eYAW4MNQsnzZ5