### PR TITLE
Point every known-provider model at its models.dev logo

### DIFF
--- a/convex/migrations/20260830_provider_logos.test.ts
+++ b/convex/migrations/20260830_provider_logos.test.ts
@@ -1,0 +1,43 @@
+import { convexTest } from 'convex-test'
+import { describe, expect, test } from 'vitest'
+import { internal } from '../_generated/api'
+import schema from '../schema'
+
+const modules = Object.fromEntries(
+  Object.entries(import.meta.glob('../**/*.{js,ts}')).map(([key, loader]) => [
+    key.replace(/^\.\//, '../migrations/'),
+    loader,
+  ]),
+)
+
+describe('20260830_provider_logos', () => {
+  test('points every known-provider model at its models.dev logo, once', async () => {
+    const t = convexTest(schema, modules)
+    const now = 1_700_000_000_000
+    await t.run(async (ctx) => {
+      const storageId = await ctx.storage.store(new Blob(['x']))
+      await ctx.db.insert('models', {
+        name: 'GPT-5.4', slug: 'gpt-5.4', shortId: 'gpt54', provider: 'OpenAI', category: 'coding',
+        reviewStatus: 'approved', iconStorageId: storageId, iconUrl: 'https://example.com/old.png',
+        createdAt: now, updatedAt: now,
+      })
+      await ctx.db.insert('models', {
+        name: 'GPT-5.6', slug: 'gpt-5.6', shortId: 'gpt56', provider: 'OpenAI', category: 'coding',
+        reviewStatus: 'pending', iconUrl: 'https://models.dev/logos/openai.svg', createdAt: now, updatedAt: now,
+      })
+      await ctx.db.insert('models', {
+        name: 'Mystery', slug: 'mystery', shortId: 'myst', provider: 'Nobody', category: 'other',
+        reviewStatus: 'approved', iconUrl: 'https://example.com/keep.png', createdAt: now, updatedAt: now,
+      })
+    })
+    const first = await t.mutation(internal.migrations['20260830_provider_logos'].run, {})
+    expect(first).toEqual({ patched: 1, skipped: 1, unknown: ['mystery'] })
+    const rows = await t.run(async (ctx) => ctx.db.query('models').collect())
+    const bySlug = Object.fromEntries(rows.map((r) => [r.slug, r]))
+    expect(bySlug['gpt-5.4'].iconUrl).toBe('https://models.dev/logos/openai.svg')
+    expect(bySlug['gpt-5.4'].iconStorageId).toBeUndefined()
+    expect(bySlug.mystery.iconUrl).toBe('https://example.com/keep.png')
+    const second = await t.mutation(internal.migrations['20260830_provider_logos'].run, {})
+    expect(second).toEqual({ patched: 0, skipped: 2, unknown: ['mystery'] })
+  })
+})

--- a/convex/migrations/20260830_provider_logos.ts
+++ b/convex/migrations/20260830_provider_logos.ts
@@ -1,0 +1,38 @@
+import { v } from 'convex/values'
+import { internalMutation } from '../_generated/server'
+import { datasetProviderOf, logoUrl } from '../lib/modelImport'
+
+/**
+ * One logo per provider. Rows created before the import carried hand-uploaded
+ * icons that differ from the models.dev logo the import stamps on new rows, so
+ * two models of one vendor rendered two different marks on a stack. Every
+ * model whose provider maps to a models.dev provider now points at that logo;
+ * a stored icon is detached (the storage file stays). Rows of an unknown
+ * provider keep whatever they had.
+ *
+ * IDEMPOTENT. A row already on the logo with no storage icon is skipped.
+ */
+export const run = internalMutation({
+  args: {},
+  returns: v.object({ patched: v.number(), skipped: v.number(), unknown: v.array(v.string()) }),
+  handler: async (ctx) => {
+    let patched = 0
+    let skipped = 0
+    const unknown: string[] = []
+    for (const row of await ctx.db.query('models').collect()) {
+      const providerId = datasetProviderOf(row.provider)
+      if (!providerId) {
+        unknown.push(row.slug)
+        continue
+      }
+      const iconUrl = logoUrl(providerId)
+      if (row.iconUrl === iconUrl && row.iconStorageId === undefined) {
+        skipped++
+        continue
+      }
+      await ctx.db.patch(row._id, { iconUrl, iconStorageId: undefined, updatedAt: Date.now() })
+      patched++
+    }
+    return { patched, skipped, unknown }
+  },
+})


### PR DESCRIPTION
Migration `20260830_provider_logos`: every model whose provider maps to a models.dev provider gets `iconUrl` set to that logo and its `iconStorageId` detached (storage files stay). Unknown providers keep their icon. Idempotent, tested.

Run after the deploy:

```sh
scripts/convex-prod.sh run migrations/20260830_provider_logos:run
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UX3EwpV7eYAW4MNQsnzZ5