### PR TITLE
Map Meta and correct three models filed under provider Other

### DIFF
--- a/convex/lib/modelImport.ts
+++ b/convex/lib/modelImport.ts
@@ -71,6 +71,7 @@ export function datasetProviderOf(provider: string | undefined): string | null {
   if (p === 'google deepmind') return 'google'
   if (p === 'moonshot' || p === 'moonshotai') return 'moonshotai'
   if (p === 'z.ai' || p === 'zhipu') return 'zai'
+  if (p === 'meta') return 'meta'
   return null
 }
 

--- a/convex/migrations/20260830_provider_logos.test.ts
+++ b/convex/migrations/20260830_provider_logos.test.ts
@@ -26,18 +26,24 @@ describe('20260830_provider_logos', () => {
         reviewStatus: 'pending', iconUrl: 'https://models.dev/logos/openai.svg', createdAt: now, updatedAt: now,
       })
       await ctx.db.insert('models', {
+        name: 'GLM-5.2', slug: 'glm-5.2', shortId: 'glm52', provider: 'Other', category: 'coding',
+        reviewStatus: 'approved', iconUrl: 'https://example.com/glm.png', createdAt: now, updatedAt: now,
+      })
+      await ctx.db.insert('models', {
         name: 'Mystery', slug: 'mystery', shortId: 'myst', provider: 'Nobody', category: 'other',
         reviewStatus: 'approved', iconUrl: 'https://example.com/keep.png', createdAt: now, updatedAt: now,
       })
     })
     const first = await t.mutation(internal.migrations['20260830_provider_logos'].run, {})
-    expect(first).toEqual({ patched: 1, skipped: 1, unknown: ['mystery'] })
+    expect(first).toEqual({ patched: 2, skipped: 1, unknown: ['mystery'] })
     const rows = await t.run(async (ctx) => ctx.db.query('models').collect())
     const bySlug = Object.fromEntries(rows.map((r) => [r.slug, r]))
     expect(bySlug['gpt-5.4'].iconUrl).toBe('https://models.dev/logos/openai.svg')
     expect(bySlug['gpt-5.4'].iconStorageId).toBeUndefined()
+    expect(bySlug['glm-5.2'].provider).toBe('Zhipu AI')
+    expect(bySlug['glm-5.2'].iconUrl).toBe('https://models.dev/logos/zai.svg')
     expect(bySlug.mystery.iconUrl).toBe('https://example.com/keep.png')
     const second = await t.mutation(internal.migrations['20260830_provider_logos'].run, {})
-    expect(second).toEqual({ patched: 0, skipped: 2, unknown: ['mystery'] })
+    expect(second).toEqual({ patched: 0, skipped: 3, unknown: ['mystery'] })
   })
 })

--- a/convex/migrations/20260830_provider_logos.ts
+++ b/convex/migrations/20260830_provider_logos.ts
@@ -10,8 +10,18 @@ import { datasetProviderOf, logoUrl } from '../lib/modelImport'
  * a stored icon is detached (the storage file stays). Rows of an unknown
  * provider keep whatever they had.
  *
+ * Three rows were filed under provider "Other" and are corrected first so
+ * they map. Meta has a logo too; the other vendors without one (ElevenLabs,
+ * Kuaishou, ByteDance, Black Forest Labs, Cognition) keep their stored icon.
+ *
  * IDEMPOTENT. A row already on the logo with no storage icon is skipped.
  */
+const PROVIDER_FIXES: Record<string, string> = {
+  'glm-5.2': 'Zhipu AI',
+  'kimi-k3': 'Moonshot AI',
+  'composer-2.5': 'Cursor',
+}
+
 export const run = internalMutation({
   args: {},
   returns: v.object({ patched: v.number(), skipped: v.number(), unknown: v.array(v.string()) }),
@@ -20,6 +30,11 @@ export const run = internalMutation({
     let skipped = 0
     const unknown: string[] = []
     for (const row of await ctx.db.query('models').collect()) {
+      const fixed = PROVIDER_FIXES[row.slug]
+      if (fixed && row.provider !== fixed) {
+        await ctx.db.patch(row._id, { provider: fixed, updatedAt: Date.now() })
+        row.provider = fixed
+      }
       const providerId = datasetProviderOf(row.provider)
       if (!providerId) {
         unknown.push(row.slug)


### PR DESCRIPTION
Follow-up to #347. Of the nine `unknown` rows, three were filed under provider "Other" (`glm-5.2` is Zhipu AI, `kimi-k3` is Moonshot AI, `composer-2.5` is Cursor); the migration now corrects the provider before mapping. `Meta` maps to its models.dev logo. The other five (ElevenLabs, Kuaishou, ByteDance, Black Forest Labs, Cognition) have no real models.dev logo (the host answers a generic fallback SVG for unknown ids), so they keep their stored icons.

Rerun after the deploy (idempotent):

```sh
scripts/convex-prod.sh run migrations/20260830_provider_logos:run
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UX3EwpV7eYAW4MNQsnzZ5