### PR TITLE
Add preset machine labels

### DIFF
--- a/convex/cliSessions.ts
+++ b/convex/cliSessions.ts
@@ -80,7 +80,13 @@ export const getBySecretId = internalQuery({
  */
 export const getPendingMachineName = query({
   args: { userCode: v.string() },
-  returns: v.union(v.object({ machineName: v.optional(v.string()) }), v.null()),
+  returns: v.union(
+    v.object({
+      machineName: v.optional(v.string()),
+      machineNameReadOnly: v.boolean(),
+    }),
+    v.null(),
+  ),
   handler: async (ctx, args) => {
     const user = await ctx.auth.getUserIdentity()
     if (!user) return null
@@ -92,7 +98,10 @@ export const getPendingMachineName = query({
     if (!session) return null
     if (session.status !== 'pending') return null
     if (session.expiresAt <= Date.now()) return null
-    return { machineName: session.machineName }
+    return {
+      machineName: session.machineName,
+      machineNameReadOnly: session.machineNameReadOnly === true,
+    }
   },
 })
 
@@ -140,10 +149,12 @@ export const approveSession = mutation({
       }
     }
 
-    // The name is the user's own string typed into a form, so it gets the same
-    // bound as every other client-supplied name (#45). A blank field clears the
-    // CLI's proposal rather than keeping it - the user deleted it on purpose.
-    const proposed = args.machineName?.trim() ?? ''
+    // An editable name is the user's own form value. A locked name is the
+    // explicit CLI parameter stored on the session, regardless of what a
+    // custom approval client submits. Both get the same display bound (#45).
+    const proposed = session.machineNameReadOnly
+      ? (session.machineName ?? '')
+      : (args.machineName?.trim() ?? '')
     if (proposed.length > 0 && !isDisplaySafeName(proposed)) {
       throw new Error('Machine name must be 64 characters or fewer and printable')
     }
@@ -164,6 +175,7 @@ export const createSession = internalMutation({
     secretId: v.string(),
     status: v.union(v.literal('pending'), v.literal('approved'), v.literal('expired')),
     machineName: v.optional(v.string()),
+    machineNameReadOnly: v.optional(v.boolean()),
     cliVersion: v.optional(v.string()),
     createdAt: v.number(),
     expiresAt: v.number(),
@@ -175,6 +187,7 @@ export const createSession = internalMutation({
       secretId: args.secretId,
       status: args.status,
       machineName: args.machineName,
+      machineNameReadOnly: args.machineNameReadOnly,
       cliVersion: args.cliVersion,
       createdAt: args.createdAt,
       expiresAt: args.expiresAt,

--- a/convex/httpCli.test.ts
+++ b/convex/httpCli.test.ts
@@ -185,6 +185,23 @@ describe('authStart machine name', () => {
     expect(stored).toBe('work laptop')
   })
 
+  test('stores the read-only marker only with a valid label', async () => {
+    const { t, json } = await start(
+      JSON.stringify({ machineName: 'build server', machineNameReadOnly: true }),
+    )
+    const stored = await t.run(async (ctx) => {
+      const row = await ctx.db
+        .query('cliSessions')
+        .withIndex('by_userCode', (q) => q.eq('userCode', json.userCode))
+        .first()
+      return {
+        name: row?.machineName,
+        readOnly: row?.machineNameReadOnly,
+      }
+    })
+    expect(stored).toEqual({ name: 'build server', readOnly: true })
+  })
+
   test('an older CLI that sends no body still authenticates', async () => {
     const { session } = await start()
     expect(session).not.toBeNull()
@@ -287,6 +304,39 @@ describe('the name reaches the machines list', () => {
 
     const rows = await t.withIdentity(IDENTITY).query(api.cliTokens.listByUser, {})
     expect(rows[0].name).toBeUndefined()
+  })
+
+  test('an explicit label cannot be changed during approval', async () => {
+    const t = convexTest(schema, modules)
+    await seedCreator(t)
+    const startResp = await t.fetch('/api/cli/auth/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        machineName: 'build server',
+        machineNameReadOnly: true,
+      }),
+    })
+    const { userCode, secretId } = await startResp.json()
+
+    const pending = await t
+      .withIdentity(IDENTITY)
+      .query(api.cliSessions.getPendingMachineName, { userCode })
+    expect(pending).toEqual({
+      machineName: 'build server',
+      machineNameReadOnly: true,
+    })
+
+    await t.withIdentity(IDENTITY).mutation(api.cliSessions.approveSession, {
+      userCode,
+      machineName: 'changed in a custom client',
+    })
+    await t.fetch(`/api/cli/auth/poll?secretId=${encodeURIComponent(secretId)}`, {
+      method: 'GET',
+    })
+
+    const rows = await t.withIdentity(IDENTITY).query(api.cliTokens.listByUser, {})
+    expect(rows[0].name).toBe('build server')
   })
 
   test('a name that cannot be rendered is refused at the approval form', async () => {

--- a/convex/httpCli.ts
+++ b/convex/httpCli.ts
@@ -218,10 +218,9 @@ async function authStartBudget(
 /**
  * POST /api/cli/auth/start - open a device-code session.
  *
- * The body is OPTIONAL and carries one field: `machineName`, the CLI's proposal
- * for what to call this machine (#49). It is a proposal, not a fact - the
- * approval page renders it in an editable field, so the string that reaches
- * `cliTokens.name` is always one the user saw and could overwrite.
+ * The body is OPTIONAL and carries `machineName`, the CLI's proposal for what
+ * to call this machine (#49). `machineNameReadOnly` marks an explicit
+ * `aistack login --label` value. Automatic hostname proposals stay editable.
  *
  * A name that fails the display bound is DROPPED, not rejected. Refusing the
  * whole login because a hostname carries a control character would break
@@ -258,15 +257,20 @@ export const authStart = httpAction(async (ctx, request) => {
   const now = Date.now()
 
   let machineName: string | undefined
+  let machineNameReadOnly: boolean | undefined
   let cliVersion: string | undefined
   try {
     const body = (await request.json()) as {
       machineName?: unknown
+      machineNameReadOnly?: unknown
       cliVersion?: unknown
     }
     if (typeof body?.machineName === 'string') {
       const trimmed = body.machineName.trim()
-      if (isDisplaySafeName(trimmed)) machineName = trimmed
+      if (isDisplaySafeName(trimmed)) {
+        machineName = trimmed
+        if (body.machineNameReadOnly === true) machineNameReadOnly = true
+      }
     }
     // Carried to the token exchange, where `cli_login_completed` reports it
     // (#77). Bounded and dropped when malformed, like the name above: a version
@@ -284,6 +288,7 @@ export const authStart = httpAction(async (ctx, request) => {
     secretId,
     status: 'pending',
     machineName,
+    machineNameReadOnly,
     cliVersion,
     createdAt: now,
     expiresAt: now + 15 * 60 * 1000,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1054,11 +1054,15 @@ export default defineSchema({
     // with no stack yet can still authenticate.
     stackId: v.optional(v.id('stacks')),
     // What this machine calls itself, so `/settings/machines` can tell three
-    // rows apart (#49). The CLI proposes `os.hostname()` at authStart and the
-    // approval page shows it in an editable field, so the stored string is
-    // always one the user saw and could overwrite. Optional permanently: an
-    // older CLI sends nothing, and the user may clear the field.
+    // rows apart (#49). The approval page always shows the stored string. An
+    // automatic hostname stays editable, while an explicit `--label` is fixed.
+    // Optional permanently: an older CLI sends nothing, and an editable field
+    // may be cleared.
     machineName: v.optional(v.string()),
+    // True only when the caller supplied `aistack login --label`. Unlike the
+    // automatically proposed hostname, that explicit label is fixed on the
+    // confirmation page and must survive approval unchanged.
+    machineNameReadOnly: v.optional(v.boolean()),
     // What the CLI calls itself, carried from `authStart` to the token exchange
     // so `cli_login_completed` can report it (#77). Optional permanently: an
     // older CLI sends nothing, and the login must still work.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,6 +40,7 @@ Link this machine to your AI Stack account via browser. Optional - `sync` runs t
 
 ```sh
 npx @use-aistack/cli login
+npx @use-aistack/cli login --label "build server" # preset and lock the label
 ```
 
 ### `npx @use-aistack/cli connect claude`

--- a/packages/cli/src/api.test.ts
+++ b/packages/cli/src/api.test.ts
@@ -61,6 +61,35 @@ describe("HTTP failures the user can act on", () => {
 	});
 });
 
+describe("authStart machine label", () => {
+	test("marks an explicit label as read-only", async () => {
+		const fetchMock = vi.fn(() =>
+			Promise.resolve(
+				new Response(
+					JSON.stringify({
+						secretId: "secret",
+						userCode: "ABC123",
+						authUrl: "/",
+					}),
+					{ status: 200 },
+				),
+			),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await authStart("build server", true);
+
+		const [, init] = fetchMock.mock.calls[0] as unknown as [
+			string,
+			RequestInit,
+		];
+		expect(JSON.parse(init.body as string)).toMatchObject({
+			machineName: "build server",
+			machineNameReadOnly: true,
+		});
+	});
+});
+
 /**
  * Setting the stack's auto-sync permission (#102's route, called by #103).
  *

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -47,12 +47,14 @@ function failure(what: string, res: Response): Error {
 /**
  * Open a device-code session.
  *
- * `machineName` is a PROPOSAL, not a fact: the approval page renders it in an
- * editable field, so the user sees the string before it is stored and can
- * overwrite or clear it. That is why the hostname may be sent automatically -
- * the consent happens in the browser, a moment later, with the string on screen.
+ * An automatic `machineName` is a proposal that stays editable. A label the
+ * user supplied as a command parameter sets `machineNameReadOnly`, so the
+ * confirmation page shows the chosen value without allowing another edit.
  */
-export async function authStart(machineName?: string): Promise<{
+export async function authStart(
+	machineName?: string,
+	machineNameReadOnly = false,
+): Promise<{
 	secretId: string;
 	userCode: string;
 	authUrl: string;
@@ -62,11 +64,11 @@ export async function authStart(machineName?: string): Promise<{
 		// `cliVersion` rides along so `cli_login_completed` can report which
 		// version linked the machine (#78). The server carries it on the pending
 		// session and reads it at the token exchange.
-		body: JSON.stringify(
-			machineName
-				? { machineName, cliVersion: CLI_VERSION }
-				: { cliVersion: CLI_VERSION },
-		),
+		body: JSON.stringify({
+			...(machineName ? { machineName } : {}),
+			...(machineNameReadOnly ? { machineNameReadOnly: true } : {}),
+			cliVersion: CLI_VERSION,
+		}),
 	});
 	if (!res.ok) throw failure("Auth start failed", res);
 	return res.json();

--- a/packages/cli/src/commands/login.test.ts
+++ b/packages/cli/src/commands/login.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { proposedMachineName } from "./login.js";
+import { proposedMachineName, requestedMachineLabel } from "./login.js";
 
 /**
  * The machine name the CLI proposes at login - wayfinder #49 (map #29).
@@ -33,5 +33,21 @@ describe("proposedMachineName", () => {
 				throw new Error("no hostname");
 			}),
 		).toBeUndefined();
+	});
+});
+
+describe("requestedMachineLabel", () => {
+	test("trims an explicit label", () => {
+		expect(requestedMachineLabel("  build server  ")).toBe("build server");
+	});
+
+	test("refuses a label the confirmation page cannot safely render", () => {
+		expect(() => requestedMachineLabel("   ")).toThrow(/Machine label/);
+		expect(() => requestedMachineLabel("x".repeat(65))).toThrow(
+			/Machine label/,
+		);
+		expect(() => requestedMachineLabel("bad\u202Ename")).toThrow(
+			/Machine label/,
+		);
 	});
 });

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -3,6 +3,7 @@ import * as p from "@clack/prompts";
 import open from "open";
 import { authPoll, authStart } from "../api.js";
 import { saveToken } from "../config.js";
+import { isDisplaySafeName } from "../harness/shared/aggregate.js";
 import { dim, intro, lime, limeBold, outro, outroError } from "../theme.js";
 
 /**
@@ -33,13 +34,34 @@ export function proposedMachineName(
  * the standalone command. Logs its own progress and errors; returns whether a
  * token was saved.
  */
-export async function performLogin(): Promise<boolean> {
+type LoginOptions = { label?: string };
+
+export function requestedMachineLabel(label: string): string {
+	const trimmed = label.trim();
+	if (!isDisplaySafeName(trimmed)) {
+		throw new Error(
+			"Machine label must be 64 characters or fewer and contain only printable characters.",
+		);
+	}
+	return trimmed;
+}
+
+export async function performLogin(
+	options: LoginOptions = {},
+): Promise<boolean> {
 	const s = p.spinner();
 	s.start("Starting authentication...");
 
 	let session: Awaited<ReturnType<typeof authStart>>;
 	try {
-		session = await authStart(proposedMachineName());
+		const requestedLabel =
+			options.label === undefined
+				? undefined
+				: requestedMachineLabel(options.label);
+		session = await authStart(
+			requestedLabel ?? proposedMachineName(),
+			requestedLabel !== undefined,
+		);
 		s.stop("Session created");
 	} catch (err) {
 		s.stop("Failed to start authentication");
@@ -90,10 +112,10 @@ export async function performLogin(): Promise<boolean> {
 	return false;
 }
 
-export async function loginCommand() {
+export async function loginCommand(options: LoginOptions = {}) {
 	intro("login");
 
-	if (!(await performLogin())) {
+	if (!(await performLogin(options))) {
 		outroError("error");
 		process.exit(1);
 	}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,7 +18,8 @@ program
 program
 	.command("login")
 	.description("Authenticate with AI Stack")
-	.action(loginCommand);
+	.option("--label <label>", "Set the machine label")
+	.action((options) => loginCommand(options));
 
 program
 	.command("collect")

--- a/src/__tests__/cli-auth-route.test.tsx
+++ b/src/__tests__/cli-auth-route.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ComponentType, ReactNode } from "react";
+import { afterEach, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	pending: {
+		machineName: "build server",
+		machineNameReadOnly: true,
+	},
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+	createFileRoute: () => (options: unknown) => ({ options }),
+	useNavigate: () => vi.fn(),
+	useSearch: () => ({ code: "ABC123" }),
+}));
+
+vi.mock("convex/react", () => ({
+	useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
+	useMutation: () => vi.fn(),
+	useQuery: (_query: unknown, args: Record<string, unknown>) =>
+		"userCode" in args ? mocks.pending : [],
+}));
+
+vi.mock("@/components/ui/Dialog", () => ({
+	Dialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+type TestRoute = {
+	options: { component: ComponentType };
+};
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+test("an explicitly supplied machine label is read-only on confirmation", async () => {
+	const routeModule = await import("@/routes/cli.auth");
+	const Page = (routeModule.Route as unknown as TestRoute).options.component;
+
+	render(<Page />);
+
+	expect(await screen.findByDisplayValue("build server")).toHaveAttribute(
+		"readonly",
+	);
+});

--- a/src/routes/cli.auth.tsx
+++ b/src/routes/cli.auth.tsx
@@ -57,7 +57,9 @@ function CliAuthPage() {
 	);
 	const [machineName, setMachineName] = useState<string | null>(null);
 	const machineNameId = useId();
+	const syncStackId = useId();
 	const proposedName = pending?.machineName;
+	const machineNameReadOnly = pending?.machineNameReadOnly === true;
 	useEffect(() => {
 		if (proposedName && machineName === null) setMachineName(proposedName);
 	}, [proposedName, machineName]);
@@ -82,7 +84,11 @@ function CliAuthPage() {
 	const hasStacks = stacks.length > 0;
 	// A profile with no stack can still authorize the CLI for its other commands;
 	// the token simply carries no sync target until it is re-linked.
-	const canApprove = !stacksLoading && (!hasStacks || selectedStackId !== null);
+	const pendingLoading = isAuthenticated && code && pending === undefined;
+	const canApprove =
+		!stacksLoading &&
+		!pendingLoading &&
+		(!hasStacks || selectedStackId !== null);
 
 	useEffect(() => {
 		if (!isLoading && !isAuthenticated) {
@@ -175,8 +181,9 @@ function CliAuthPage() {
 							maxLength={64}
 							value={machineName ?? ""}
 							onChange={(e) => setMachineName(e.target.value)}
+							readOnly={machineNameReadOnly}
 							placeholder="work laptop"
-							className="w-full border border-border-subtle bg-bg-subtle p-3 font-mono text-sm text-fg-primary placeholder:text-fg-muted"
+							className="w-full border border-border-subtle bg-bg-subtle p-3 font-mono text-sm text-fg-primary placeholder:text-fg-muted read-only:cursor-default read-only:text-fg-muted"
 						/>
 						<p className="mt-2 font-mono text-[0.7rem] leading-relaxed text-fg-muted">
 							Only you ever see this. It is how you tell your machines apart
@@ -193,7 +200,7 @@ function CliAuthPage() {
 					{!stacksLoading && hasStacks && (
 						<div className="mb-6">
 							<label
-								htmlFor="sync-stack"
+								htmlFor={syncStackId}
 								className="mb-2 block font-mono text-[0.7rem] font-bold uppercase tracking-wider text-fg-muted"
 							>
 								Sync usage data to
@@ -206,7 +213,7 @@ function CliAuthPage() {
 								</div>
 							) : (
 								<select
-									id="sync-stack"
+									id={syncStackId}
 									value={selectedStackId ?? ""}
 									onChange={(e) => setSelectedStackId(e.target.value || null)}
 									className="w-full border border-border-subtle bg-bg-subtle p-3 font-mono text-sm text-fg-primary"


### PR DESCRIPTION
## Summary

- add `aistack login --label <label>`
- render explicitly supplied labels as read-only during browser confirmation
- preserve locked labels through approval and token issuance
- keep automatic hostname proposals editable

## Verification

- `pnpm exec vitest run packages/cli/src/api.test.ts packages/cli/src/commands/login.test.ts src/__tests__/cli-auth-route.test.tsx convex/httpCli.test.ts`
- `pnpm --dir packages/cli build`
- `pnpm build`
- Biome checks on changed source and test files