### PR TITLE
fix(cli): restrict credential file permissions

### DIFF
--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -1,4 +1,11 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
@@ -23,6 +30,7 @@ const LOCAL = "http://localhost:3019";
 
 let dir: string;
 let file: string;
+const testOnPosix = test.skipIf(process.platform === "win32");
 
 beforeEach(() => {
 	dir = mkdtempSync(join(tmpdir(), "aistack-config-"));
@@ -34,6 +42,31 @@ afterEach(() => {
 });
 
 describe("saveToken / getToken", () => {
+	testOnPosix(
+		"creates credentials and its directory with restrictive permissions",
+		() => {
+			const configDir = join(dir, "config");
+			const credentialsFile = join(configDir, "credentials.json");
+
+			saveToken("tok-prod", "user-1", PROD, credentialsFile);
+
+			expect(statSync(configDir).mode & 0o777).toBe(0o700);
+			expect(statSync(credentialsFile).mode & 0o777).toBe(0o600);
+		},
+	);
+
+	testOnPosix(
+		"repairs an existing credentials file to restrictive permissions",
+		() => {
+			writeFileSync(file, JSON.stringify({ servers: {} }));
+			chmodSync(file, 0o644);
+
+			saveToken("tok-prod", "user-1", PROD, file);
+
+			expect(statSync(file).mode & 0o777).toBe(0o600);
+		},
+	);
+
 	test("round-trips a token for one server", () => {
 		saveToken("tok-prod", "user-1", PROD, file);
 		expect(getToken(PROD, file)).toBe("tok-prod");
@@ -72,10 +105,14 @@ describe("legacy flat-form migration", () => {
 
 	test("rewrites the flat form to the map on first read", () => {
 		writeFileSync(file, JSON.stringify({ token: "tok-flat", userId: "u1" }));
+		if (process.platform !== "win32") chmodSync(file, 0o644);
 		getToken(PROD, file);
 		const raw = JSON.parse(readFileSync(file, "utf-8"));
 		expect(raw.token).toBeUndefined();
 		expect(raw.servers[PROD]).toEqual({ token: "tok-flat", userId: "u1" });
+		if (process.platform !== "win32") {
+			expect(statSync(file).mode & 0o777).toBe(0o600);
+		}
 	});
 
 	test("a login on top of a legacy file keeps the migrated entry", () => {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,5 +1,11 @@
 import { randomBytes } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { BASE_URL } from "./api.js";
@@ -68,8 +74,9 @@ function readCredentials(file: string): {
 }
 
 function writeCredentials(file: string, data: CredentialsFile): void {
-	mkdirSync(dirname(file), { recursive: true });
-	writeFileSync(file, JSON.stringify(data, null, 2));
+	mkdirSync(dirname(file), { recursive: true, mode: 0o700 });
+	writeFileSync(file, JSON.stringify(data, null, 2), { mode: 0o600 });
+	if (process.platform !== "win32") chmodSync(file, 0o600);
 }
 
 export function getToken(


### PR DESCRIPTION
## Summary

- Create CLI credential directories with POSIX mode `0700`.
- Create and repair `credentials.json` as `0600`.
- Keep Windows behavior unchanged.
- Cover new files, existing files, and legacy migration with regression tests.

The credential file holds the only plaintext copy of each CLI bearer token. Explicit modes prevent a permissive process umask from making that file readable by other local users.

## Review finding

A Daybreak Blue CLI security review found that `writeFileSync` inherited the process umask, so `credentials.json` could be created with group or world read permission on shared POSIX hosts. This PR fixes that finding. No Fable pass has been run.

## Verification

- `CI=1 FORCE_COLOR=0 node_modules/.bin/vitest run packages/cli/src --reporter=dot` - 36 files, 548 tests passed.
- `node_modules/.bin/biome check packages/cli/src/config.ts packages/cli/src/config.test.ts` - passed.