### PR TITLE
Prototype: hero and subnav (alp82/aistack#352)

### DIFF
--- a/prototypes/stack-page-compact/NOTES.md
+++ b/prototypes/stack-page-compact/NOTES.md
@@ -182,3 +182,22 @@ on mobile.
 Rules carried from the real hero: no measured dollars in the hero (the only
 money is the authored price), nothing without a reading, the spy marks the
 section a third of the way down the viewport.
+
+## Round 2
+
+Operator verdict on round 1: v38 by far. Issues: the upvote, share and report
+chips are ugly, small, and ignore that the three actions differ in importance;
+the rule above the logo strip distracts (same grey as everything else);
+"built with" reads as "this page was built with"; "checked" should be
+"updated"; the subnav has too many lines.
+
+Four knobs on v38, cycling in the bottom bar (defaults first):
+
+- act: stacked (Upvote as a lime outline button and Share as a ghost button
+  under the one-liner, Report a dotted text link by the update stamp) /
+  tile (the two buttons head the tile column) / corner (top right of the hero)
+  / chips (round 1).
+- rule: dim (25% hairline) / none (spacing only) / line (round 1).
+- lbl: "runs on" / "11 tools" / none.
+- nav: quiet (one dim hairline, no tab borders) / bare (tint band, no lines,
+  shadow when stuck) / lines (round 1).

--- a/prototypes/stack-page-compact/NOTES.md
+++ b/prototypes/stack-page-compact/NOTES.md
@@ -252,3 +252,10 @@ sets `?win=`, which relabels the Stats meta and headline (the demo has 30-day
 data only, so the figures do not change). The visibility segments overlap
 their neighbor by 1px to close the seam. A tab is active while at least half
 of its section, or half of the viewport, shows it.
+
+## Round 9
+
+Micro animations: the identity row unfolds (grid-rows 0fr to 1fr plus a fade)
+when the bar sticks and folds back on the way up; tab clicks smooth-scroll to
+the section and update the hash; the visibility segments ease between scroll
+frames. A click anywhere on the identity row scrolls smoothly to the top.

--- a/prototypes/stack-page-compact/NOTES.md
+++ b/prototypes/stack-page-compact/NOTES.md
@@ -243,3 +243,12 @@ The stuck subnav is two lines: an identity row (avatar, name, author, price,
 tab row, so nothing shifts sideways. Tabs are 136px wide with no gap, so the
 visibility segments join into one line. Mobile keeps avatar and name only in
 the identity row.
+
+## Round 8
+
+Identity row: avatar, name, upvotes, price; sparkline and token total on the
+right. A "window" dropdown (30 days, 7 days, 24 hours) ends the tab row and
+sets `?win=`, which relabels the Stats meta and headline (the demo has 30-day
+data only, so the figures do not change). The visibility segments overlap
+their neighbor by 1px to close the seam. A tab is active while at least half
+of its section, or half of the viewport, shows it.

--- a/prototypes/stack-page-compact/NOTES.md
+++ b/prototypes/stack-page-compact/NOTES.md
@@ -209,3 +209,12 @@ chip lists the rest), nav quiet with no stats and every tab 180px wide. rule
 none gained more room; new rule dim2 draws the hairline above and below the
 logo strip for symmetry. The bottom bar collapses the 40 variants and the v37
 knobs behind a "…" button; only the #352 knobs show by default.
+
+## Round 4
+
+Title fitter: the name shrinks from 88px until it fits one line; below 44px it
+wraps to two lines and shrinks again to fit two. The title block reserves two
+lines of height so every stack's hero is the same height. `?name=...` swaps in
+any name to test it. Mobile keeps the buttons at their natural width and puts
+the two tiles side by side. The quiet subnav underlines only the label, not the
+180px tab. The "// sync" style kickers are gone from the section rails.

--- a/prototypes/stack-page-compact/NOTES.md
+++ b/prototypes/stack-page-compact/NOTES.md
@@ -218,3 +218,11 @@ lines of height so every stack's hero is the same height. `?name=...` swaps in
 any name to test it. Mobile keeps the buttons at their natural width and puts
 the two tiles side by side. The quiet subnav underlines only the label, not the
 180px tab. The "// sync" style kickers are gone from the section rails.
+
+## Round 5
+
+Name and one-liner sit right under the byline; the tool row follows at 36px
+logos, five tools with a +N chip, or all six when there are six. The update
+stamp and Report link sit under the tokens tile as part of the column. Quiet
+subnav tabs are 150px wide with a 20px gap and the underline spans the tab.
+The left column reserves a fixed height so a one-line name gets the space.

--- a/prototypes/stack-page-compact/NOTES.md
+++ b/prototypes/stack-page-compact/NOTES.md
@@ -267,3 +267,9 @@ natural top), so the Stats tab keeps the identity row and it folds only when
 scrolling further up. The identity row's click-to-top is a real listener.
 Sparkline narrower with more room before the token figure; 64px between the
 title column and the tiles; the one-liner spans the title column.
+
+## Round 11
+
+Bug: tab clicks could not scroll up. `offsetTop` of the sticky bar reports the
+stuck position while stuck, so the "never above the bar" floor equalled the
+current scroll. The floor now comes from the hero's bottom.

--- a/prototypes/stack-page-compact/NOTES.md
+++ b/prototypes/stack-page-compact/NOTES.md
@@ -226,3 +226,12 @@ logos, five tools with a +N chip, or all six when there are six. The update
 stamp and Report link sit under the tokens tile as part of the column. Quiet
 subnav tabs are 150px wide with a 20px gap and the underline spans the tab.
 The left column reserves a fixed height so a one-line name gets the space.
+
+## Round 6
+
+Quiet tabs are 100px wide with a 14px gap. The underline is now a visibility
+indicator: each tab's lime segment covers the part of its section that is on
+screen (left edge = share scrolled past the top, right edge = share still
+below the fold), so one continuous line across the tabs shows what is on
+screen. The stuck bar keeps the name on the left and moves the price to the
+far right.

--- a/prototypes/stack-page-compact/NOTES.md
+++ b/prototypes/stack-page-compact/NOTES.md
@@ -259,3 +259,11 @@ Micro animations: the identity row unfolds (grid-rows 0fr to 1fr plus a fade)
 when the bar sticks and folds back on the way up; tab clicks smooth-scroll to
 the section and update the hash; the visibility segments ease between scroll
 frames. A click anywhere on the identity row scrolls smoothly to the top.
+
+## Round 10
+
+Tab clicks scroll so the bar is stuck on landing (never above the bar's own
+natural top), so the Stats tab keeps the identity row and it folds only when
+scrolling further up. The identity row's click-to-top is a real listener.
+Sparkline narrower with more room before the token figure; 64px between the
+title column and the tiles; the one-liner spans the title column.

--- a/prototypes/stack-page-compact/NOTES.md
+++ b/prototypes/stack-page-compact/NOTES.md
@@ -273,3 +273,9 @@ title column and the tiles; the one-liner spans the title column.
 Bug: tab clicks could not scroll up. `offsetTop` of the sticky bar reports the
 stuck position while stuck, so the "never above the bar" floor equalled the
 current scroll. The floor now comes from the hero's bottom.
+
+## Round 12 - locked
+
+Operator locked v38 as it stands after round 11: /index.html?v=v38 with the
+default knobs (act tile, rule none, lbl none, nav quiet). Implementation is
+#356.

--- a/prototypes/stack-page-compact/NOTES.md
+++ b/prototypes/stack-page-compact/NOTES.md
@@ -143,3 +143,42 @@ what to replace, what to combine, like the previous tooltips) and depends on
 the hero prototype (#352). The accepted design is v37 with rail title,
 4 tints, "Stats", exclusive accordion, stack top block, feature expansion:
 /index.html?v=v37
+
+# Hero and subnav (alp82/aistack#352)
+
+Same demo, same data. The accepted v37 body stays untouched under each variant;
+only the top of the page and the section navigation change. Default variant is
+now v38. The bottom bar keeps the v37 knobs on v38-v40 and gains a "390" button
+that opens the current variant in a 390px window for the mobile read.
+
+## Round 1
+
+Three hero and subnav pairs, each answering the same three questions: what the
+hero promises, how the subnav guides and tracks scroll, and how both behave
+on mobile.
+
+- v38 Masthead + tabs. Hero promises identity plus two figures: the authored
+  price (lime tile, hover for the breakdown) and the measured tokens (outlined
+  tile with the 30-day sparkline, links to Stats), then a "built with" logo
+  strip. Subnav is a tab bar under the hero that sticks under the site header;
+  each tab carries the section's stat, the current tab gets a lime underline,
+  and the stack name and price appear in the bar once it is stuck. Mobile: tiles
+  side by side, tabs scroll horizontally with the stats dropped.
+- v39 Figures first. The four section figures are the hero: 6.18B tokens,
+  6 projects, 11 tools at $336/mo, 2 min guide, one tile each with a watermark
+  chart, every tile a link to its section. The name shrinks to a masthead line,
+  the one-liner follows in large type. Subnav is a vertical rail on the left on
+  screens wider than 1560px, with a lime progress line that fills as the page is
+  read; narrower screens get a sticky strip of the same four figures under the
+  header. Mobile: tiles in a 2x2 grid, figure strip stays pinned.
+- v40 Contents + scrubber. Hero is a two-column split: name, one-liner and
+  byline on the left, an "in this stack" ladder on the right with one sentence
+  per section (numbers only, no adjectives), each a link. Subnav is a reading
+  scrubber pinned under the header once the hero leaves: four segments sized by
+  section height, the current one underlined, a lime fill that shows how far
+  through each section the reader is. Mobile: the segments keep only their
+  numbers except the current one.
+
+Rules carried from the real hero: no measured dollars in the hero (the only
+money is the authored price), nothing without a reading, the spy marks the
+section a third of the way down the viewport.

--- a/prototypes/stack-page-compact/NOTES.md
+++ b/prototypes/stack-page-compact/NOTES.md
@@ -201,3 +201,11 @@ Four knobs on v38, cycling in the bottom bar (defaults first):
 - lbl: "runs on" / "11 tools" / none.
 - nav: quiet (one dim hairline, no tab borders) / bare (tint band, no lines,
   shadow when stuck) / lines (round 1).
+
+## Round 3
+
+Locked: act tile, lbl none (logos carry tooltips with name and price, the +N
+chip lists the rest), nav quiet with no stats and every tab 180px wide. rule
+none gained more room; new rule dim2 draws the hairline above and below the
+logo strip for symmetry. The bottom bar collapses the 40 variants and the v37
+knobs behind a "…" button; only the #352 knobs show by default.

--- a/prototypes/stack-page-compact/NOTES.md
+++ b/prototypes/stack-page-compact/NOTES.md
@@ -235,3 +235,11 @@ screen (left edge = share scrolled past the top, right edge = share still
 below the fold), so one continuous line across the tabs shows what is on
 screen. The stuck bar keeps the name on the left and moves the price to the
 far right.
+
+## Round 7
+
+The stuck subnav is two lines: an identity row (avatar, name, author, price,
+30-day sparkline with the token total, upvotes) appears above the unchanged
+tab row, so nothing shifts sideways. Tabs are 136px wide with no gap, so the
+visibility segments join into one line. Mobile keeps avatar and name only in
+the identity row.

--- a/prototypes/stack-page-compact/build.py
+++ b/prototypes/stack-page-compact/build.py
@@ -4,7 +4,7 @@ d=open('slim.json').read().replace('</','<\\/')
 h=open('template.html').read()
 assert '__DATA__' in h
 h=h.replace('__DATA__',d)
-for f in ('variants.js','variants2.js','variants3.js','variants4.js','variants5.js','variants6.js'):
+for f in ('variants.js','variants2.js','variants3.js','variants4.js','variants5.js','variants6.js','variants7.js'):
     v=open(f).read().replace('</','<\\/')
     h=h.replace(f'<script src="{f}"></script>','<script>\n'+v+'\n</script>')
 open('index.html','w').write(h)

--- a/prototypes/stack-page-compact/index.html
+++ b/prototypes/stack-page-compact/index.html
@@ -2306,11 +2306,11 @@ function heroA(){
   const reportSlot=act==="chips"?"":`<span style="margin-left:auto;display:flex;gap:16px;align-items:center" class="mono small muted"><span>updated ${readCheckedAgo}<\/span>${lnkReport}<\/span>`;
   return `<section style="background:${TINT4[0]};padding:56px 0 36px"><div style="max-width:1280px;margin:0 auto;padding:0 24px">
    ${act==="corner"?`<div style="display:flex;justify-content:flex-end;margin:-24px 0 8px">${actionsTopRight}<\/div>`:""}
-   <div style="display:grid;grid-template-columns:1fr auto;gap:40px;align-items:end" class="g2">
+   <div style="display:grid;grid-template-columns:1fr auto;gap:64px;align-items:end" class="g2">
     <div style="min-width:0" class="ha-left">
       <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">${avatar352(40)}${byline352()}<\/div>
       <div class="ha-h1w"><h1 class="ha-h1">${esc(S.name)}<\/h1><\/div>
-      <p style="margin-top:14px;font-size:18px;color:var(--fg-secondary);max-width:560px">${esc(S.oneLiner)}<\/p>
+      <p style="margin-top:14px;font-size:18px;color:var(--fg-secondary)">${esc(S.oneLiner)}<\/p>
       ${actionsUnderTitle}
       <div style="display:flex;align-items:center;gap:10px;margin-top:26px;${ruleCss?ruleCss+";padding-top:16px":""}">
         ${label?`<span class="kick muted" style="margin-right:8px">${label}<\/span>`:""}<a href="#s-tools" style="display:flex;gap:10px;align-items:center">${toolsSorted.slice(0,shown).map(t=>`<span title="${esc(t.name)}${t.amount>0?" · "+priceMo(t.amount):""}" style="display:inline-flex;cursor:help">${toolIcn(t,36)}<\/span>`).join("")}${S.tools.length>shown?`<span class="chip" title="${toolsSorted.slice(shown).map(t=>esc(t.name)).join(", ")}" style="border-color:oklch(0.55 0.01 256 / 0.35);cursor:help;height:36px">+${S.tools.length-shown}<\/span>`:""}<\/a>
@@ -2332,11 +2332,11 @@ function heroA(){
    <\/div>
   <\/div><\/section>
   <nav id="ha-tabs" class="ha-tabs ha-nav-${nav}" aria-label="Sections">
-   <div class="ha-idrow" title="back to top" onclick="scrollTo({top:0,behavior:'smooth'})"><div class="ha-idin"><div style="max-width:1280px;margin:0 auto;padding:8px 24px;display:flex;align-items:center;gap:22px;overflow:hidden">
+   <div class="ha-idrow" title="back to top"><div class="ha-idin"><div style="max-width:1280px;margin:0 auto;padding:8px 24px;display:flex;align-items:center;gap:22px;overflow:hidden">
      ${avatar352(22)}<b style="font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap">${esc(S.name)}<\/b>
      <span class="mono small sec2" style="white-space:nowrap">▲ ${UPVOTES}<\/span>
      <span class="mono small lime" style="white-space:nowrap;font-weight:700">${priceMo(S.price)}<\/span>
-     <span class="mono small" style="margin-left:auto;display:inline-flex;align-items:center;gap:8px;white-space:nowrap"><span style="width:90px;display:inline-block">${spark(U.series,400,18)}<\/span><b>${fmtT(U.totalTokens)}<\/b> <span class="muted">tokens<\/span><\/span>
+     <span class="mono small" style="margin-left:auto;display:inline-flex;align-items:center;gap:14px;white-space:nowrap"><span style="width:70px;display:inline-block">${spark(U.series,400,18)}<\/span><b>${fmtT(U.totalTokens)}<\/b> <span class="muted">tokens<\/span><\/span>
    <\/div><\/div><\/div>
    <div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:stretch;overflow-x:auto">
     ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="lab"><span class="n">${s.n}<\/span><span class="t">${s.title}<\/span><\/span><span class="s">${s.stat}<\/span><span class="vis"><\/span><\/a>`).join("")}
@@ -2519,7 +2519,9 @@ window.afterRender=function(){
     let s=MAX;h1.style.fontSize=s+"px";
     while(h1.offsetHeight>2*s*.88*1.05&&s>MIN){s-=2;h1.style.fontSize=s+"px";}
   };
-  document.querySelectorAll("#ha-tabs .ha-tab").forEach(a=>a.addEventListener("click",e=>{const t=document.getElementById(a.dataset.spy);if(!t)return;e.preventDefault();t.scrollIntoView({behavior:"smooth",block:"start"});history.replaceState(null,"","#"+t.id);}));
+  document.querySelectorAll("#ha-tabs .ha-tab").forEach(a=>a.addEventListener("click",e=>{const t=document.getElementById(a.dataset.spy);if(!t)return;e.preventDefault();const nav=document.getElementById("ha-tabs");const ptop=ptopOf();
+    const y=Math.max(nav.offsetTop-ptop,t.offsetTop-ptop-88);scrollTo({top:y,behavior:"smooth"});history.replaceState(null,"","#"+t.id);}));
+  const idrow=document.querySelector("#ha-tabs .ha-idrow");if(idrow)idrow.addEventListener("click",()=>scrollTo({top:0,behavior:"smooth"}));
   fitTitle();onScroll();
   const onResize=()=>{fitTitle();onScroll();};
   addEventListener("scroll",onScroll,{passive:true});addEventListener("resize",onResize);

--- a/prototypes/stack-page-compact/index.html
+++ b/prototypes/stack-page-compact/index.html
@@ -2333,8 +2333,9 @@ function heroA(){
   <\/div><\/section>
   <nav id="ha-tabs" class="ha-tabs ha-nav-${nav}" aria-label="Sections">
    <div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:stretch;overflow-x:auto">
-    <span class="ha-id"><b>${esc(S.name)}<\/b><span class="lime mono" style="font-size:11px">${priceMo(S.price)}<\/span><\/span>
-    ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="lab"><span class="n">${s.n}<\/span><span class="t">${s.title}<\/span><\/span><span class="s">${s.stat}<\/span><\/a>`).join("")}
+    <span class="ha-id"><b>${esc(S.name)}<\/b><\/span>
+    ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="lab"><span class="n">${s.n}<\/span><span class="t">${s.title}<\/span><\/span><span class="s">${s.stat}<\/span><span class="vis"><\/span><\/a>`).join("")}
+    <span class="ha-price lime mono" style="font-size:11px;font-weight:700">${priceMo(S.price)}<\/span>
    <\/div>
   <\/nav>
   <style>
@@ -2347,10 +2348,12 @@ function heroA(){
    .ha-ghost:hover{border-color:var(--fg-secondary)}
    .ha-quiet{font-family:var(--mono);font-size:11px;color:var(--fg-muted);text-decoration:underline dotted;text-underline-offset:3px}.ha-quiet:hover{color:oklch(0.75 0.15 60)}
    .ha-tabs{position:sticky;top:var(--ptop,0px);z-index:30;background:${TINT4[0]}}
-   .ha-tab{display:flex;align-items:baseline;gap:10px;padding:0 18px;white-space:nowrap;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--fg-muted);box-shadow:inset 0 -3px 0 transparent}
+   .ha-tab{position:relative;display:flex;align-items:baseline;gap:10px;padding:0 18px;white-space:nowrap;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--fg-muted);box-shadow:inset 0 -3px 0 transparent}
    .ha-tab .n{color:var(--stroke-strong)}.ha-tab .s{font-weight:400;letter-spacing:.04em;text-transform:none;font-size:11px}
    .ha-tab .lab{display:inline-flex;gap:10px;align-items:baseline;padding:14px 0 12px;box-shadow:inset 0 -3px 0 transparent}
-   .ha-tab.on{color:var(--lime)}.ha-nav-lines .ha-tab.on{box-shadow:inset 0 -3px 0 var(--lime)}.ha-nav-quiet .ha-tab.on,.ha-nav-bare .ha-tab.on{box-shadow:inset 0 -3px 0 var(--lime)}.ha-tab.on .n{color:var(--lime)}
+   .ha-tab.on{color:var(--lime)}.ha-nav-lines .ha-tab.on{box-shadow:inset 0 -3px 0 var(--lime)}
+   .ha-tab .vis{position:absolute;left:0;bottom:0;height:3px;width:0;background:var(--lime)}
+   .ha-price{display:none;align-items:center;margin-left:auto;padding-left:18px;white-space:nowrap}.ha-tabs.stuck .ha-price{display:flex}.ha-tab.on .n{color:var(--lime)}
    .ha-tab:hover{color:var(--fg-primary)}
    .ha-id{display:none;align-items:center;gap:10px;padding:0 18px 0 0;margin-right:6px;font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap}
    .ha-tabs.stuck .ha-id{display:flex}
@@ -2358,10 +2361,10 @@ function heroA(){
    .ha-nav-lines{border-top:1px solid var(--stroke);border-bottom:1px solid var(--stroke)}
    .ha-nav-lines .ha-tab{border-right:1px solid var(--stroke)}.ha-nav-lines .ha-tab:first-of-type{border-left:1px solid var(--stroke)}
    .ha-nav-quiet{border-bottom:1px solid oklch(0.55 0.01 256 / 0.25)}
-   .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:150px;margin-right:20px;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
+   .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:100px;margin-right:14px;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
    .ha-nav-bare{background:${TINT4[1]}}.ha-nav-bare .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
    .ha-nav-bare.stuck{box-shadow:0 8px 24px oklch(0 0 0 / .35)}
-   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id{display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{width:auto;margin-right:22px}}
+   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id,.ha-tabs .ha-price{display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{width:auto;margin-right:22px}}
    @media(max-width:820px){.ha-tiles{grid-template-columns:1fr 1fr;max-width:520px;min-width:0!important}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3;justify-content:flex-start}.ha-tiles .ha-up{flex:none!important}.ha-tiles>div:last-child{grid-column:1/3}.ha-left{min-height:0}.ha-tiles .kick{font-size:10px;letter-spacing:.15em}}
   <\/style>`;
 }
@@ -2483,7 +2486,11 @@ window.afterRender=function(){
     spyLinks.forEach(a=>a.classList.toggle("on",a.dataset.spy===cur));
     const heroGone=hero.getBoundingClientRect().bottom<ptop;
     const tabs=document.getElementById("ha-tabs");
-    if(tabs)tabs.classList.toggle("stuck",tabs.getBoundingClientRect().top<=ptop+1);
+    if(tabs){tabs.classList.toggle("stuck",tabs.getBoundingClientRect().top<=ptop+1);
+      const vpTop=scrollY+ptop+tabs.offsetHeight,vpBot=scrollY+innerHeight;
+      tabs.querySelectorAll(".ha-tab").forEach(a=>{const s=document.getElementById(a.dataset.spy);if(!s)return;
+        const st=Math.min(1,Math.max(0,(vpTop-s.offsetTop)/s.offsetHeight)),en=Math.min(1,Math.max(0,(vpBot-s.offsetTop)/s.offsetHeight));
+        const vis=a.querySelector(".vis");vis.style.left=(st*100).toFixed(1)+"%";vis.style.width=(Math.max(0,en-st)*100).toFixed(1)+"%";});}
     const rail=document.getElementById("hb-rail");
     if(rail){rail.classList.toggle("shown",heroGone);const p=scrollY/Math.max(1,document.documentElement.scrollHeight-innerHeight);document.getElementById("hb-fill").style.height=(p*100).toFixed(1)+"%";}
     const bar=document.getElementById("hc-bar");

--- a/prototypes/stack-page-compact/index.html
+++ b/prototypes/stack-page-compact/index.html
@@ -2520,7 +2520,8 @@ window.afterRender=function(){
     while(h1.offsetHeight>2*s*.88*1.05&&s>MIN){s-=2;h1.style.fontSize=s+"px";}
   };
   document.querySelectorAll("#ha-tabs .ha-tab").forEach(a=>a.addEventListener("click",e=>{const t=document.getElementById(a.dataset.spy);if(!t)return;e.preventDefault();const nav=document.getElementById("ha-tabs");const ptop=ptopOf();
-    const y=Math.max(nav.offsetTop-ptop,t.offsetTop-ptop-88);scrollTo({top:y,behavior:"smooth"});history.replaceState(null,"","#"+t.id);}));
+    const navTop=hero.offsetTop+hero.offsetHeight; /* nav.offsetTop reports the STUCK position while stuck */
+    const y=Math.max(navTop-ptop,t.offsetTop-ptop-88);scrollTo({top:y,behavior:"smooth"});history.replaceState(null,"","#"+t.id);}));
   const idrow=document.querySelector("#ha-tabs .ha-idrow");if(idrow)idrow.addEventListener("click",()=>scrollTo({top:0,behavior:"smooth"}));
   fitTitle();onScroll();
   const onResize=()=>{fitTitle();onScroll();};

--- a/prototypes/stack-page-compact/index.html
+++ b/prototypes/stack-page-compact/index.html
@@ -55,6 +55,7 @@ hr.rule{border:0;border-top:1px solid var(--stroke)}
 <script>
 "use strict";
 const DATA = JSON.parse(document.getElementById("data").textContent);
+const _nm=new URLSearchParams(location.search).get("name");if(_nm)DATA.stack.name=_nm;
 const S = DATA.stack, U = DATA.usage, W = DATA.wf, P = DATA.projects;
 
 /* ---------- formatters (mirroring measured/copy.ts) ---------- */
@@ -2078,8 +2079,8 @@ function sec37(i,n,kick,title,meta,body){
   return `<section style="background:${bg};padding:48px 0"><div style="max-width:1280px;margin:0 auto;padding:0 24px">
     <div style="display:grid;grid-template-columns:170px 1fr;gap:40px" class="rl2">
       <div><div class="mono" style="font-size:48px;font-weight:900;color:var(--lime);line-height:1">${n}<\/div>
-        <p class="kick lime" style="margin-top:8px">${kick}<\/p>
-        <h2 style="font-size:21px;font-weight:900;text-transform:uppercase;letter-spacing:-.01em;margin-top:2px">${title}<\/h2>
+        ${kick?`<p class="kick lime" style="margin-top:8px">${kick}<\/p>`:""}
+        <h2 style="font-size:21px;font-weight:900;text-transform:uppercase;letter-spacing:-.01em;margin-top:${kick?"2px":"10px"}">${title}<\/h2>
         <p class="mono small muted" style="margin-top:12px;line-height:1.7">${meta||""}<\/p><\/div>
       <div style="min-width:0">${body}<\/div>
     <\/div><\/div><\/section>`;
@@ -2271,10 +2272,10 @@ function body352(){
   const rows=OPT("rows")==="tabs"?`<div style="margin-top:36px">${cssTabs("t37")}<\/div>`:`<div style="margin-top:36px">${statsAccordion()}<\/div>`;
   const ids=["s-stats","s-projects","s-tools","s-guide"];
   let i=0;
-  const html=sec37(1,"01","// sync",name,`30d · all machines<br>updated ${readCheckedAgo}`,statsTop37()+rows)+
-    sec37(2,"02","// showcase","Projects",P.length+" projects",projGridV16())+
-    sec37(3,"03","// ai components","Tools",`${S.tools.length} tools · ${priceMo(S.price)}`,toolsBodyV16())+
-    sec37(0,"04","// writeup","Guide",guideMin+" min read",guideBodyV16());
+  const html=sec37(1,"01","",name,`30d · all machines<br>updated ${readCheckedAgo}`,statsTop37()+rows)+
+    sec37(2,"02","","Projects",P.length+" projects",projGridV16())+
+    sec37(3,"03","","Tools",`${S.tools.length} tools · ${priceMo(S.price)}`,toolsBodyV16())+
+    sec37(0,"04","","Guide",guideMin+" min read",guideBodyV16());
   return html.replace(/<section /g,()=>`<section id="${ids[i++]}" `)+ctaStrip()+MEDIA_G2+
     `<style>[id^="s-"]{scroll-margin-top:calc(var(--ptop,0px) + 48px)}<\/style>`;
 }
@@ -2308,7 +2309,7 @@ function heroA(){
    <div style="display:grid;grid-template-columns:1fr auto;gap:40px;align-items:end" class="g2">
     <div style="min-width:0">
       <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">${avatar352(40)}${byline352()}<\/div>
-      <h1 style="font-size:clamp(44px,7vw,88px);font-weight:900;line-height:.88;letter-spacing:-.03em;text-transform:uppercase;margin-top:20px">${esc(S.name)}<\/h1>
+      <div class="ha-h1w"><h1 class="ha-h1">${esc(S.name)}<\/h1><\/div>
       <p style="margin-top:16px;font-size:18px;color:var(--fg-secondary);max-width:560px">${esc(S.oneLiner)}<\/p>
       ${actionsUnderTitle}
     <\/div>
@@ -2333,19 +2334,22 @@ function heroA(){
   <nav id="ha-tabs" class="ha-tabs ha-nav-${nav}" aria-label="Sections">
    <div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:stretch;overflow-x:auto">
     <span class="ha-id"><b>${esc(S.name)}<\/b><span class="lime mono" style="font-size:11px">${priceMo(S.price)}<\/span><\/span>
-    ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="n">${s.n}<\/span><span class="t">${s.title}<\/span><span class="s">${s.stat}<\/span><\/a>`).join("")}
+    ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="lab"><span class="n">${s.n}<\/span><span class="t">${s.title}<\/span><\/span><span class="s">${s.stat}<\/span><\/a>`).join("")}
    <\/div>
   <\/nav>
   <style>
+   .ha-h1w{min-height:calc(2 * .88 * clamp(44px,7vw,88px));display:flex;align-items:flex-end;margin-top:20px}
+   .ha-h1{font-size:clamp(44px,7vw,88px);font-weight:900;line-height:.88;letter-spacing:-.03em;text-transform:uppercase;overflow-wrap:anywhere}
    .ha-up{display:inline-flex;align-items:center;gap:8px;background:none;border:1px solid var(--lime);color:var(--lime);font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;padding:10px 16px;cursor:pointer}
    .ha-up:hover{background:var(--lime);color:var(--lime-contrast)}.ha-up .tri{font-size:10px}.ha-up b{font-weight:900}
    .ha-ghost{display:inline-flex;align-items:center;background:none;border:1px solid var(--stroke);color:var(--fg-secondary);font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;padding:10px 16px;cursor:pointer}
    .ha-ghost:hover{border-color:var(--fg-secondary)}
    .ha-quiet{font-family:var(--mono);font-size:11px;color:var(--fg-muted);text-decoration:underline dotted;text-underline-offset:3px}.ha-quiet:hover{color:oklch(0.75 0.15 60)}
    .ha-tabs{position:sticky;top:var(--ptop,0px);z-index:30;background:${TINT4[0]}}
-   .ha-tab{display:flex;align-items:baseline;gap:10px;padding:14px 18px 12px;white-space:nowrap;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--fg-muted);box-shadow:inset 0 -3px 0 transparent}
+   .ha-tab{display:flex;align-items:baseline;gap:10px;padding:0 18px;white-space:nowrap;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--fg-muted);box-shadow:inset 0 -3px 0 transparent}
    .ha-tab .n{color:var(--stroke-strong)}.ha-tab .s{font-weight:400;letter-spacing:.04em;text-transform:none;font-size:11px}
-   .ha-tab.on{color:var(--lime);box-shadow:inset 0 -3px 0 var(--lime)}.ha-tab.on .n{color:var(--lime)}
+   .ha-tab .lab{display:inline-flex;gap:10px;align-items:baseline;padding:14px 0 12px;box-shadow:inset 0 -3px 0 transparent}
+   .ha-tab.on{color:var(--lime)}.ha-nav-lines .ha-tab.on{box-shadow:inset 0 -3px 0 var(--lime)}.ha-nav-quiet .ha-tab.on .lab,.ha-nav-bare .ha-tab.on .lab{box-shadow:inset 0 -3px 0 var(--lime)}.ha-tab.on .n{color:var(--lime)}
    .ha-tab:hover{color:var(--fg-primary)}
    .ha-id{display:none;align-items:center;gap:10px;padding:0 18px 0 0;margin-right:6px;font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap}
    .ha-tabs.stuck .ha-id{display:flex}
@@ -2356,7 +2360,8 @@ function heroA(){
    .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:180px;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
    .ha-nav-bare{background:${TINT4[1]}}.ha-nav-bare .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
    .ha-nav-bare.stuck{box-shadow:0 8px 24px oklch(0 0 0 / .35)}
-   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id{display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{margin-right:20px}.ha-tiles{grid-template-columns:1fr 1fr}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3}}
+   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id{display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{margin-right:20px}}
+   @media(max-width:820px){.ha-tiles{grid-template-columns:1fr 1fr;max-width:520px;min-width:0!important}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3;justify-content:flex-start}.ha-tiles .ha-up{flex:none!important}.ha-tiles .kick{font-size:10px;letter-spacing:.15em}}
   <\/style>`;
 }
 
@@ -2485,9 +2490,22 @@ window.afterRender=function(){
       secs.forEach(s=>{const seg=bar.querySelector(`[data-seg="${s.id}"]`);if(!seg)return;seg.style.flexGrow=Math.max(1,s.offsetHeight/100);
         const f=Math.min(1,Math.max(0,(line-s.offsetTop)/s.offsetHeight));seg.querySelector(".fill").style.width=(f*100).toFixed(1)+"%";});}
   };
-  onScroll();
-  addEventListener("scroll",onScroll,{passive:true});addEventListener("resize",onScroll);
-  window._nav352=()=>{removeEventListener("scroll",onScroll);removeEventListener("resize",onScroll);};
+  /* the title fitter: one line when the font stays above MIN, else two lines */
+  const fitTitle=()=>{
+    const h1=document.querySelector(".ha-h1");if(!h1)return;
+    const MAX=Math.min(88,Math.max(44,innerWidth*0.07)),MIN=44;
+    h1.style.whiteSpace="nowrap";h1.style.fontSize=MAX+"px";
+    const w=h1.parentElement.clientWidth,sw=h1.scrollWidth;
+    const one=Math.min(MAX,MAX*w/sw);
+    if(one>=MIN){h1.style.fontSize=one+"px";return;}
+    h1.style.whiteSpace="normal";
+    let s=MAX;h1.style.fontSize=s+"px";
+    while(h1.offsetHeight>2*s*.88*1.05&&s>MIN){s-=2;h1.style.fontSize=s+"px";}
+  };
+  fitTitle();onScroll();
+  const onResize=()=>{fitTitle();onScroll();};
+  addEventListener("scroll",onScroll,{passive:true});addEventListener("resize",onResize);
+  window._nav352=()=>{removeEventListener("scroll",onScroll);removeEventListener("resize",onResize);};
 };
 
 </script>

--- a/prototypes/stack-page-compact/index.html
+++ b/prototypes/stack-page-compact/index.html
@@ -2332,12 +2332,12 @@ function heroA(){
    <\/div>
   <\/div><\/section>
   <nav id="ha-tabs" class="ha-tabs ha-nav-${nav}" aria-label="Sections">
-   <div class="ha-idrow"><div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:22px;overflow:hidden">
+   <div class="ha-idrow" title="back to top" onclick="scrollTo({top:0,behavior:'smooth'})"><div class="ha-idin"><div style="max-width:1280px;margin:0 auto;padding:8px 24px;display:flex;align-items:center;gap:22px;overflow:hidden">
      ${avatar352(22)}<b style="font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap">${esc(S.name)}<\/b>
      <span class="mono small sec2" style="white-space:nowrap">▲ ${UPVOTES}<\/span>
      <span class="mono small lime" style="white-space:nowrap;font-weight:700">${priceMo(S.price)}<\/span>
      <span class="mono small" style="margin-left:auto;display:inline-flex;align-items:center;gap:8px;white-space:nowrap"><span style="width:90px;display:inline-block">${spark(U.series,400,18)}<\/span><b>${fmtT(U.totalTokens)}<\/b> <span class="muted">tokens<\/span><\/span>
-   <\/div><\/div>
+   <\/div><\/div><\/div>
    <div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:stretch;overflow-x:auto">
     ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="lab"><span class="n">${s.n}<\/span><span class="t">${s.title}<\/span><\/span><span class="s">${s.stat}<\/span><span class="vis"><\/span><\/a>`).join("")}
     <label class="ha-win"><span class="muted">window<\/span><select onchange="const y=scrollY;const u=new URL(location);u.searchParams.set('win',this.value);history.replaceState(null,'',u);show(current(),false);scrollTo(0,y)">${[["30d","last 30 days"],["7d","last 7 days"],["24h","last 24 hours"]].map(([k,l])=>`<option value="${k}"${OPT("win")===k?" selected":""}>${l}<\/option>`).join("")}<\/select><\/label>
@@ -2360,7 +2360,10 @@ function heroA(){
    .ha-tab .vis{position:absolute;left:0;bottom:0;height:3px;width:0;background:var(--lime)}
    .ha-win{margin-left:auto;display:flex;align-items:center;gap:8px;font-family:var(--mono);font-size:11px;white-space:nowrap}
    .ha-win select{background:var(--bg-shell);color:var(--fg-primary);border:1px solid oklch(0.55 0.01 256 / 0.35);font:inherit;padding:4px 6px;cursor:pointer}
-   .ha-idrow{display:none;border-bottom:1px solid oklch(0.55 0.01 256 / 0.18);padding:8px 0}.ha-tabs.stuck .ha-idrow{display:block}.ha-tab.on .n{color:var(--lime)}
+   .ha-idrow{display:grid;grid-template-rows:0fr;opacity:0;cursor:pointer;transition:grid-template-rows .28s cubic-bezier(.2,.7,.2,1),opacity .2s}.ha-idrow .ha-idin{min-height:0;overflow:hidden;border-bottom:1px solid oklch(0.55 0.01 256 / 0.18)}
+   .ha-tabs.stuck .ha-idrow{grid-template-rows:1fr;opacity:1}
+   .ha-tab .vis{transition:left .12s linear,width .12s linear}
+   .ha-tab .lab{transition:color .2s}.ha-tab.on .n{color:var(--lime)}
    .ha-tab:hover{color:var(--fg-primary)}
       /* nav: lines = round 1, quiet = one dim hairline, bare = tint only */
    .ha-nav-lines{border-top:1px solid var(--stroke);border-bottom:1px solid var(--stroke)}
@@ -2369,7 +2372,7 @@ function heroA(){
    .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:136px;margin:0;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
    .ha-nav-bare{background:${TINT4[1]}}.ha-nav-bare .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
    .ha-nav-bare.stuck{box-shadow:0 8px 24px oklch(0 0 0 / .35)}
-   @media(max-width:700px){.ha-tab .s{display:none}.ha-idrow>div>*:nth-child(n+5){display:none!important}.ha-win span{display:none}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{width:auto;padding-right:22px}}
+   @media(max-width:700px){.ha-tab .s{display:none}.ha-idrow .ha-idin>div>*:nth-child(n+5){display:none!important}.ha-win span{display:none}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{width:auto;padding-right:22px}}
    @media(max-width:820px){.ha-tiles{grid-template-columns:1fr 1fr;max-width:520px;min-width:0!important}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3;justify-content:flex-start}.ha-tiles .ha-up{flex:none!important}.ha-tiles>div:last-child{grid-column:1/3}.ha-left{min-height:0}.ha-tiles .kick{font-size:10px;letter-spacing:.15em}}
   <\/style>`;
 }
@@ -2516,6 +2519,7 @@ window.afterRender=function(){
     let s=MAX;h1.style.fontSize=s+"px";
     while(h1.offsetHeight>2*s*.88*1.05&&s>MIN){s-=2;h1.style.fontSize=s+"px";}
   };
+  document.querySelectorAll("#ha-tabs .ha-tab").forEach(a=>a.addEventListener("click",e=>{const t=document.getElementById(a.dataset.spy);if(!t)return;e.preventDefault();t.scrollIntoView({behavior:"smooth",block:"start"});history.replaceState(null,"","#"+t.id);}));
   fitTitle();onScroll();
   const onResize=()=>{fitTitle();onScroll();};
   addEventListener("scroll",onScroll,{passive:true});addEventListener("resize",onResize);

--- a/prototypes/stack-page-compact/index.html
+++ b/prototypes/stack-page-compact/index.html
@@ -2291,7 +2291,8 @@ function heroA(){
   const sec=sections352();
   const shown=8;
   const act=OPT("act"), rule=OPT("rule"), lbl=OPT("lbl"), nav=OPT("nav");
-  const ruleCss=rule==="line"?"border-top:1px solid var(--stroke)":rule==="dim"?"border-top:1px solid oklch(0.55 0.01 256 / 0.25)":"";
+  const hair="1px solid oklch(0.55 0.01 256 / 0.25)";
+  const ruleCss=rule==="line"?"border-top:1px solid var(--stroke)":rule==="dim"?`border-top:${hair}`:rule==="dim2"?`border-top:${hair};border-bottom:${hair};padding-bottom:20px`:"";
   const label=lbl==="runs on"?"runs on":lbl==="tools"?`${S.tools.length} tools`:"";
   /* the three actions, arranged by importance: upvote > share > report */
   const btnUp=`<button class="ha-up" type="button"><span class="tri">▲<\/span> Upvote <b>${UPVOTES}<\/b><\/button>`;
@@ -2324,8 +2325,8 @@ function heroA(){
       <\/a>
     <\/div>
    <\/div>
-   <div style="display:flex;align-items:center;gap:8px;margin-top:${rule==="none"?"36px":"32px"};padding-top:${rule==="none"?"0":"20px"};${ruleCss};flex-wrap:wrap">
-     ${label?`<span class="kick muted" style="margin-right:8px">${label}<\/span>`:""}<a href="#s-tools" style="display:flex;gap:8px;align-items:center">${toolsSorted.slice(0,shown).map(t=>toolIcn(t,28)).join("")}<span class="chip" style="border-color:oklch(0.55 0.01 256 / 0.35)">+${S.tools.length-shown}<\/span><\/a>
+   <div style="display:flex;align-items:center;gap:8px;margin-top:${rule==="none"?"44px":"32px"};padding-top:${rule==="none"?"0":"20px"};padding-bottom:${rule==="none"?"8px":"0"};${ruleCss};flex-wrap:wrap">
+     ${label?`<span class="kick muted" style="margin-right:8px">${label}<\/span>`:""}<a href="#s-tools" style="display:flex;gap:8px;align-items:center">${toolsSorted.slice(0,shown).map(t=>`<span title="${esc(t.name)}${t.amount>0?" · "+priceMo(t.amount):""}" style="display:inline-flex;cursor:help">${toolIcn(t,28)}<\/span>`).join("")}<span class="chip" title="${toolsSorted.slice(shown).map(t=>esc(t.name)).join(", ")}" style="border-color:oklch(0.55 0.01 256 / 0.35);cursor:help">+${S.tools.length-shown}<\/span><\/a>
      ${reportSlot||`<span class="mono small muted" style="margin-left:auto">updated ${readCheckedAgo}<\/span>`}
    <\/div>
   <\/div><\/section>
@@ -2352,7 +2353,7 @@ function heroA(){
    .ha-nav-lines{border-top:1px solid var(--stroke);border-bottom:1px solid var(--stroke)}
    .ha-nav-lines .ha-tab{border-right:1px solid var(--stroke)}.ha-nav-lines .ha-tab:first-of-type{border-left:1px solid var(--stroke)}
    .ha-nav-quiet{border-bottom:1px solid oklch(0.55 0.01 256 / 0.25)}
-   .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
+   .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:180px;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
    .ha-nav-bare{background:${TINT4[1]}}.ha-nav-bare .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
    .ha-nav-bare.stuck{box-shadow:0 8px 24px oklch(0 0 0 / .35)}
    @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id{display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{margin-right:20px}.ha-tiles{grid-template-columns:1fr 1fr}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3}}
@@ -2504,7 +2505,8 @@ function measureAll(){
   for(const [k] of VARIANTS){probe.innerHTML=RENDER[k]();heights[k]=probe.scrollHeight;}
   probe.remove();
 }
-const KNOBS=[["title",["rail","num"]],["bands",["4","2"]],["name",["stats","usage"]],["rows",["acc","tabs"]],["top",["stack","side","merged","hero"]],["exp",["feature","grid","rows"]],["act",["stacked","tile","corner","chips"]],["rule",["dim","none","line"]],["lbl",["runs on","tools","none"]],["nav",["quiet","bare","lines"]]];
+const KNOBS=[["title",["rail","num"]],["bands",["4","2"]],["name",["stats","usage"]],["rows",["acc","tabs"]],["top",["stack","side","merged","hero"]],["exp",["feature","grid","rows"]],["act",["tile","stacked","corner","chips"]],["rule",["none","dim2","dim","line"]],["lbl",["none","runs on","tools"]],["nav",["quiet","bare","lines"]]];
+const KNOBS_352=["act","rule","lbl","nav"];
 function readOpts(){const p=new URLSearchParams(location.search);window.OPTS={};for(const [k,vals]of KNOBS)window.OPTS[k]=vals.includes(p.get(k))?p.get(k):vals[0];}
 function current(){const v=new URLSearchParams(location.search).get("v");return RENDER[v]?v:"v38";}
 function show(k,push){
@@ -2513,9 +2515,15 @@ function show(k,push){
   if(window.afterRender)afterRender();
   if(push){const u=new URL(location);u.searchParams.set("v",k);history.replaceState(null,"",u);}
   const bar=document.getElementById("switcher");
-  bar.innerHTML=VARIANTS.map(([id,label])=>`<button class="${id===k?"on":""}" data-v="${id}" title="${label}">${label.split(" ")[0].replace("Baseline","Base")}</button>`).join("")+
-    (/^v(37|38|39|40)$/.test(k)?KNOBS.map(([key,vals])=>{const cur=window.OPTS[key];const next=vals[(vals.indexOf(cur)+1)%vals.length];return `<button class="knob" data-k="${key}" data-next="${next}" style="border-left:1px solid var(--stroke);color:var(--lime)">${key}: ${cur}</button>`;}).join(""):"")+
+  const more=sessionStorage.getItem("more352")==="1";
+  const vBtns=VARIANTS.map(([id,label])=>`<button class="${id===k?"on":""}" data-v="${id}" title="${label}">${label.split(" ")[0].replace("Baseline","Base")}</button>`).join("");
+  const knobBtn=([key,vals])=>{const cur=window.OPTS[key];const next=vals[(vals.indexOf(cur)+1)%vals.length];return `<button class="knob" data-k="${key}" data-next="${next}" style="border-left:1px solid var(--stroke);color:var(--lime)">${key}: ${cur}</button>`;};
+  const mine=KNOBS.filter(([key])=>KNOBS_352.includes(key)), old=KNOBS.filter(([key])=>!KNOBS_352.includes(key));
+  bar.innerHTML=`<button id="more352" title="show every variant and the v37 toggles">${more?"less":"…"}</button>`+
+    (more?vBtns+old.map(knobBtn).join(""):`<span class="h" style="border:0">${k}</span>`)+
+    (/^v(37|38|39|40)$/.test(k)?mine.map(knobBtn).join(""):"")+
     `<button class="knob" style="border-left:1px solid var(--stroke)" title="open this variant in a 390px window" onclick="open(location.href,'m352','width=390,height=780')">📱 390</button><span class="h" id="hread"></span>`;
+  document.getElementById("more352").onclick=()=>{sessionStorage.setItem("more352",more?"0":"1");show(k,false);};
   bar.querySelectorAll("button[data-v]").forEach(b=>b.onclick=()=>show(b.dataset.v,true));
   bar.querySelectorAll("button.knob").forEach(b=>b.onclick=()=>{const u=new URL(location);u.searchParams.set(b.dataset.k,b.dataset.next);history.replaceState(null,"",u);show(k,false);});
   const hn=document.getElementById("hnote");

--- a/prototypes/stack-page-compact/index.html
+++ b/prototypes/stack-page-compact/index.html
@@ -1907,7 +1907,7 @@ function metricBlock(){
     <div style="position:relative;padding:12px">
       <button type="button" onclick="this.querySelector('i').textContent=FACTS[(++this.dataset.i)%FACTS.length]" data-i="0" style="all:unset;cursor:pointer;display:block">
         <span class="mono" style="font-size:clamp(44px,5.4vw,60px);font-weight:900;line-height:1;display:block">${fmtT(U.totalTokens)}<\/span>
-        <span class="kick muted" style="display:block;margin-top:8px">tokens · last 30 days<\/span>
+        <span class="kick muted" style="display:block;margin-top:8px">tokens · ${window.WIN_TXT||"last 30 days"}<\/span>
         <i class="mono small lime" style="display:block;font-style:normal;margin-top:4px">≈ tap for a fun fact<\/i>
       <\/button>
       <p class="mono small muted" style="margin-top:6px">${fmtT(FRESH)} fresh · ${fmtT(CACHED)} cached<\/p>
@@ -2272,7 +2272,7 @@ function body352(){
   const rows=OPT("rows")==="tabs"?`<div style="margin-top:36px">${cssTabs("t37")}<\/div>`:`<div style="margin-top:36px">${statsAccordion()}<\/div>`;
   const ids=["s-stats","s-projects","s-tools","s-guide"];
   let i=0;
-  const html=sec37(1,"01","",name,`30d · all machines<br>updated ${readCheckedAgo}`,statsTop37()+rows)+
+  const html=sec37(1,"01","",name,`${OPT("win")} · all machines<br>updated ${readCheckedAgo}`,statsTop37()+rows)+
     sec37(2,"02","","Projects",P.length+" projects",projGridV16())+
     sec37(3,"03","","Tools",`${S.tools.length} tools · ${priceMo(S.price)}`,toolsBodyV16())+
     sec37(0,"04","","Guide",guideMin+" min read",guideBodyV16());
@@ -2334,13 +2334,13 @@ function heroA(){
   <nav id="ha-tabs" class="ha-tabs ha-nav-${nav}" aria-label="Sections">
    <div class="ha-idrow"><div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:22px;overflow:hidden">
      ${avatar352(22)}<b style="font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap">${esc(S.name)}<\/b>
-     <span class="mono small muted" style="white-space:nowrap">${esc(S.creator.name)}<\/span>
-     <span class="mono small" style="margin-left:auto;white-space:nowrap"><span class="lime" style="font-weight:700">${priceMo(S.price)}<\/span><\/span>
-     <span class="mono small" style="display:inline-flex;align-items:center;gap:8px;white-space:nowrap"><span style="width:90px;display:inline-block">${spark(U.series,400,18)}<\/span><b>${fmtT(U.totalTokens)}<\/b> <span class="muted">tokens · 30d<\/span><\/span>
-     <span class="mono small muted" style="white-space:nowrap">▲ ${UPVOTES}<\/span>
+     <span class="mono small sec2" style="white-space:nowrap">▲ ${UPVOTES}<\/span>
+     <span class="mono small lime" style="white-space:nowrap;font-weight:700">${priceMo(S.price)}<\/span>
+     <span class="mono small" style="margin-left:auto;display:inline-flex;align-items:center;gap:8px;white-space:nowrap"><span style="width:90px;display:inline-block">${spark(U.series,400,18)}<\/span><b>${fmtT(U.totalTokens)}<\/b> <span class="muted">tokens<\/span><\/span>
    <\/div><\/div>
    <div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:stretch;overflow-x:auto">
     ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="lab"><span class="n">${s.n}<\/span><span class="t">${s.title}<\/span><\/span><span class="s">${s.stat}<\/span><span class="vis"><\/span><\/a>`).join("")}
+    <label class="ha-win"><span class="muted">window<\/span><select onchange="const y=scrollY;const u=new URL(location);u.searchParams.set('win',this.value);history.replaceState(null,'',u);show(current(),false);scrollTo(0,y)">${[["30d","last 30 days"],["7d","last 7 days"],["24h","last 24 hours"]].map(([k,l])=>`<option value="${k}"${OPT("win")===k?" selected":""}>${l}<\/option>`).join("")}<\/select><\/label>
    <\/div>
   <\/nav>
   <style>
@@ -2358,6 +2358,8 @@ function heroA(){
    .ha-tab .lab{display:inline-flex;gap:10px;align-items:baseline;padding:14px 0 12px;box-shadow:inset 0 -3px 0 transparent}
    .ha-tab.on{color:var(--lime)}.ha-nav-lines .ha-tab.on{box-shadow:inset 0 -3px 0 var(--lime)}
    .ha-tab .vis{position:absolute;left:0;bottom:0;height:3px;width:0;background:var(--lime)}
+   .ha-win{margin-left:auto;display:flex;align-items:center;gap:8px;font-family:var(--mono);font-size:11px;white-space:nowrap}
+   .ha-win select{background:var(--bg-shell);color:var(--fg-primary);border:1px solid oklch(0.55 0.01 256 / 0.35);font:inherit;padding:4px 6px;cursor:pointer}
    .ha-idrow{display:none;border-bottom:1px solid oklch(0.55 0.01 256 / 0.18);padding:8px 0}.ha-tabs.stuck .ha-idrow{display:block}.ha-tab.on .n{color:var(--lime)}
    .ha-tab:hover{color:var(--fg-primary)}
       /* nav: lines = round 1, quiet = one dim hairline, bare = tint only */
@@ -2367,7 +2369,7 @@ function heroA(){
    .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:136px;margin:0;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
    .ha-nav-bare{background:${TINT4[1]}}.ha-nav-bare .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
    .ha-nav-bare.stuck{box-shadow:0 8px 24px oklch(0 0 0 / .35)}
-   @media(max-width:700px){.ha-tab .s{display:none}.ha-idrow>div>*:nth-child(n+3){display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{width:auto;padding-right:22px}}
+   @media(max-width:700px){.ha-tab .s{display:none}.ha-idrow>div>*:nth-child(n+5){display:none!important}.ha-win span{display:none}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{width:auto;padding-right:22px}}
    @media(max-width:820px){.ha-tiles{grid-template-columns:1fr 1fr;max-width:520px;min-width:0!important}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3;justify-content:flex-start}.ha-tiles .ha-up{flex:none!important}.ha-tiles>div:last-child{grid-column:1/3}.ha-left{min-height:0}.ha-tiles .kick{font-size:10px;letter-spacing:.15em}}
   <\/style>`;
 }
@@ -2486,14 +2488,15 @@ window.afterRender=function(){
     const line=scrollY+innerHeight*0.3;
     let cur=null;
     for(const s of secs){if(s.offsetTop<=line)cur=s.id;}
-    spyLinks.forEach(a=>a.classList.toggle("on",a.dataset.spy===cur));
+    spyLinks.forEach(a=>{if(!a.classList.contains("ha-tab"))a.classList.toggle("on",a.dataset.spy===cur);});
     const heroGone=hero.getBoundingClientRect().bottom<ptop;
     const tabs=document.getElementById("ha-tabs");
     if(tabs){tabs.classList.toggle("stuck",tabs.getBoundingClientRect().top<=ptop+1);
       const vpTop=scrollY+ptop+tabs.offsetHeight,vpBot=scrollY+innerHeight;
       tabs.querySelectorAll(".ha-tab").forEach(a=>{const s=document.getElementById(a.dataset.spy);if(!s)return;
         const st=Math.min(1,Math.max(0,(vpTop-s.offsetTop)/s.offsetHeight)),en=Math.min(1,Math.max(0,(vpBot-s.offsetTop)/s.offsetHeight));
-        const vis=a.querySelector(".vis");vis.style.left=(st*100).toFixed(1)+"%";vis.style.width=(Math.max(0,en-st)*100).toFixed(1)+"%";});}
+        const vis=a.querySelector(".vis");vis.style.left=(st*100).toFixed(1)+"%";vis.style.width=`calc(${(Math.max(0,en-st)*100).toFixed(1)}%${en>=1&&st<1?" + 1px":""})`;
+        const px=Math.max(0,en-st)*s.offsetHeight;a.classList.toggle("on",px/s.offsetHeight>=.5||px/(vpBot-vpTop)>=.5);});}
     const rail=document.getElementById("hb-rail");
     if(rail){rail.classList.toggle("shown",heroGone);const p=scrollY/Math.max(1,document.documentElement.scrollHeight-innerHeight);document.getElementById("hb-fill").style.height=(p*100).toFixed(1)+"%";}
     const bar=document.getElementById("hc-bar");
@@ -2534,9 +2537,9 @@ function measureAll(){
   for(const [k] of VARIANTS){probe.innerHTML=RENDER[k]();heights[k]=probe.scrollHeight;}
   probe.remove();
 }
-const KNOBS=[["title",["rail","num"]],["bands",["4","2"]],["name",["stats","usage"]],["rows",["acc","tabs"]],["top",["stack","side","merged","hero"]],["exp",["feature","grid","rows"]],["act",["tile","stacked","corner","chips"]],["rule",["none","dim2","dim","line"]],["lbl",["none","runs on","tools"]],["nav",["quiet","bare","lines"]]];
-const KNOBS_352=["act","rule","lbl","nav"];
-function readOpts(){const p=new URLSearchParams(location.search);window.OPTS={};for(const [k,vals]of KNOBS)window.OPTS[k]=vals.includes(p.get(k))?p.get(k):vals[0];}
+const KNOBS=[["title",["rail","num"]],["bands",["4","2"]],["name",["stats","usage"]],["rows",["acc","tabs"]],["top",["stack","side","merged","hero"]],["exp",["feature","grid","rows"]],["act",["tile","stacked","corner","chips"]],["rule",["none","dim2","dim","line"]],["lbl",["none","runs on","tools"]],["nav",["quiet","bare","lines"]],["win",["30d","7d","24h"]]];
+const KNOBS_352=["act","rule","lbl","nav"]; // win is set by the page's own dropdown
+function readOpts(){const p=new URLSearchParams(location.search);window.OPTS={};for(const [k,vals]of KNOBS)window.OPTS[k]=vals.includes(p.get(k))?p.get(k):vals[0];window.WIN_TXT={"30d":"last 30 days","7d":"last 7 days","24h":"last 24 hours"}[window.OPTS.win];}
 function current(){const v=new URLSearchParams(location.search).get("v");return RENDER[v]?v:"v38";}
 function show(k,push){
   readOpts();

--- a/prototypes/stack-page-compact/index.html
+++ b/prototypes/stack-page-compact/index.html
@@ -2271,7 +2271,7 @@ function body352(){
   const rows=OPT("rows")==="tabs"?`<div style="margin-top:36px">${cssTabs("t37")}<\/div>`:`<div style="margin-top:36px">${statsAccordion()}<\/div>`;
   const ids=["s-stats","s-projects","s-tools","s-guide"];
   let i=0;
-  const html=sec37(1,"01","// sync",name,`30d · all machines<br>checked ${readCheckedAgo}`,statsTop37()+rows)+
+  const html=sec37(1,"01","// sync",name,`30d · all machines<br>updated ${readCheckedAgo}`,statsTop37()+rows)+
     sec37(2,"02","// showcase","Projects",P.length+" projects",projGridV16())+
     sec37(3,"03","// ai components","Tools",`${S.tools.length} tools · ${priceMo(S.price)}`,toolsBodyV16())+
     sec37(0,"04","// writeup","Guide",guideMin+" min read",guideBodyV16());
@@ -2290,15 +2290,29 @@ const actions352=()=>`<span class="chip" style="cursor:pointer">▲ ${UPVOTES}<\
 function heroA(){
   const sec=sections352();
   const shown=8;
+  const act=OPT("act"), rule=OPT("rule"), lbl=OPT("lbl"), nav=OPT("nav");
+  const ruleCss=rule==="line"?"border-top:1px solid var(--stroke)":rule==="dim"?"border-top:1px solid oklch(0.55 0.01 256 / 0.25)":"";
+  const label=lbl==="runs on"?"runs on":lbl==="tools"?`${S.tools.length} tools`:"";
+  /* the three actions, arranged by importance: upvote > share > report */
+  const btnUp=`<button class="ha-up" type="button"><span class="tri">▲<\/span> Upvote <b>${UPVOTES}<\/b><\/button>`;
+  const btnShare=`<button class="ha-ghost" type="button">Share<\/button>`;
+  const lnkReport=`<a class="ha-quiet" href="#">Report<\/a>`;
+  const actionsUnderTitle=act==="stacked"?`<div style="display:flex;gap:10px;margin-top:22px;align-items:center">${btnUp}${btnShare}<\/div>`:
+    act==="chips"?`<div style="display:flex;gap:6px;margin-top:20px">${actions352()}<\/div>`:"";
+  const actionsInColumn=act==="tile"?`<div style="display:flex;gap:8px;align-items:stretch">${btnUp.replace('class="ha-up"','class="ha-up" style="flex:1;justify-content:center"')}${btnShare}<\/div>`:"";
+  const actionsTopRight=act==="corner"?`<div style="display:flex;gap:8px;align-items:center">${btnUp}${btnShare}<\/div>`:"";
+  const reportSlot=act==="chips"?"":`<span style="margin-left:auto;display:flex;gap:16px;align-items:center" class="mono small muted"><span>updated ${readCheckedAgo}<\/span>${lnkReport}<\/span>`;
   return `<section style="background:${TINT4[0]};padding:56px 0 36px"><div style="max-width:1280px;margin:0 auto;padding:0 24px">
+   ${act==="corner"?`<div style="display:flex;justify-content:flex-end;margin:-24px 0 8px">${actionsTopRight}<\/div>`:""}
    <div style="display:grid;grid-template-columns:1fr auto;gap:40px;align-items:end" class="g2">
     <div style="min-width:0">
       <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">${avatar352(40)}${byline352()}<\/div>
       <h1 style="font-size:clamp(44px,7vw,88px);font-weight:900;line-height:.88;letter-spacing:-.03em;text-transform:uppercase;margin-top:20px">${esc(S.name)}<\/h1>
       <p style="margin-top:16px;font-size:18px;color:var(--fg-secondary);max-width:560px">${esc(S.oneLiner)}<\/p>
-      <div style="display:flex;gap:6px;margin-top:20px">${actions352()}<\/div>
+      ${actionsUnderTitle}
     <\/div>
     <div style="display:grid;gap:10px;min-width:260px" class="ha-tiles">
+      ${actionsInColumn}
       <div style="background:var(--lime);color:var(--lime-contrast);padding:18px 20px;box-shadow:4px 4px 0 var(--stroke-strong);cursor:help" title="authored: tools and bundles at list prices">
         <div class="mono" style="font-size:40px;font-weight:900;line-height:1">${price(S.price)}<\/div>
         <div class="kick" style="margin-top:6px;opacity:.8">per month · solo<\/div>
@@ -2310,26 +2324,38 @@ function heroA(){
       <\/a>
     <\/div>
    <\/div>
-   <a href="#s-tools" style="display:flex;align-items:center;gap:8px;margin-top:32px;padding-top:20px;border-top:1px solid var(--stroke);flex-wrap:wrap">
-     <span class="kick muted" style="margin-right:8px">built with<\/span>${toolsSorted.slice(0,shown).map(t=>toolIcn(t,28)).join("")}<span class="chip">+${S.tools.length-shown}<\/span>
-     <span class="mono small muted" style="margin-left:auto">checked ${readCheckedAgo}<\/span>
-   <\/a>
+   <div style="display:flex;align-items:center;gap:8px;margin-top:${rule==="none"?"36px":"32px"};padding-top:${rule==="none"?"0":"20px"};${ruleCss};flex-wrap:wrap">
+     ${label?`<span class="kick muted" style="margin-right:8px">${label}<\/span>`:""}<a href="#s-tools" style="display:flex;gap:8px;align-items:center">${toolsSorted.slice(0,shown).map(t=>toolIcn(t,28)).join("")}<span class="chip" style="border-color:oklch(0.55 0.01 256 / 0.35)">+${S.tools.length-shown}<\/span><\/a>
+     ${reportSlot||`<span class="mono small muted" style="margin-left:auto">updated ${readCheckedAgo}<\/span>`}
+   <\/div>
   <\/div><\/section>
-  <nav id="ha-tabs" class="ha-tabs" aria-label="Sections">
+  <nav id="ha-tabs" class="ha-tabs ha-nav-${nav}" aria-label="Sections">
    <div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:stretch;overflow-x:auto">
     <span class="ha-id"><b>${esc(S.name)}<\/b><span class="lime mono" style="font-size:11px">${priceMo(S.price)}<\/span><\/span>
     ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="n">${s.n}<\/span><span class="t">${s.title}<\/span><span class="s">${s.stat}<\/span><\/a>`).join("")}
    <\/div>
   <\/nav>
   <style>
-   .ha-tabs{position:sticky;top:var(--ptop,0px);z-index:30;background:${TINT4[0]};border-bottom:1px solid var(--stroke);border-top:1px solid var(--stroke)}
-   .ha-tab{display:flex;align-items:baseline;gap:10px;padding:14px 18px 12px;border-right:1px solid var(--stroke);white-space:nowrap;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--fg-muted);box-shadow:inset 0 -3px 0 transparent}
-   .ha-tab:first-of-type{border-left:1px solid var(--stroke)}
+   .ha-up{display:inline-flex;align-items:center;gap:8px;background:none;border:1px solid var(--lime);color:var(--lime);font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;padding:10px 16px;cursor:pointer}
+   .ha-up:hover{background:var(--lime);color:var(--lime-contrast)}.ha-up .tri{font-size:10px}.ha-up b{font-weight:900}
+   .ha-ghost{display:inline-flex;align-items:center;background:none;border:1px solid var(--stroke);color:var(--fg-secondary);font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;padding:10px 16px;cursor:pointer}
+   .ha-ghost:hover{border-color:var(--fg-secondary)}
+   .ha-quiet{font-family:var(--mono);font-size:11px;color:var(--fg-muted);text-decoration:underline dotted;text-underline-offset:3px}.ha-quiet:hover{color:oklch(0.75 0.15 60)}
+   .ha-tabs{position:sticky;top:var(--ptop,0px);z-index:30;background:${TINT4[0]}}
+   .ha-tab{display:flex;align-items:baseline;gap:10px;padding:14px 18px 12px;white-space:nowrap;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--fg-muted);box-shadow:inset 0 -3px 0 transparent}
    .ha-tab .n{color:var(--stroke-strong)}.ha-tab .s{font-weight:400;letter-spacing:.04em;text-transform:none;font-size:11px}
    .ha-tab.on{color:var(--lime);box-shadow:inset 0 -3px 0 var(--lime)}.ha-tab.on .n{color:var(--lime)}
+   .ha-tab:hover{color:var(--fg-primary)}
    .ha-id{display:none;align-items:center;gap:10px;padding:0 18px 0 0;margin-right:6px;font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap}
    .ha-tabs.stuck .ha-id{display:flex}
-   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id{display:none!important}.ha-tab{padding:12px 14px}.ha-tiles{grid-template-columns:1fr 1fr}}
+   /* nav: lines = round 1, quiet = one dim hairline, bare = tint only */
+   .ha-nav-lines{border-top:1px solid var(--stroke);border-bottom:1px solid var(--stroke)}
+   .ha-nav-lines .ha-tab{border-right:1px solid var(--stroke)}.ha-nav-lines .ha-tab:first-of-type{border-left:1px solid var(--stroke)}
+   .ha-nav-quiet{border-bottom:1px solid oklch(0.55 0.01 256 / 0.25)}
+   .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
+   .ha-nav-bare{background:${TINT4[1]}}.ha-nav-bare .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
+   .ha-nav-bare.stuck{box-shadow:0 8px 24px oklch(0 0 0 / .35)}
+   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id{display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{margin-right:20px}.ha-tiles{grid-template-columns:1fr 1fr}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3}}
   <\/style>`;
 }
 
@@ -2361,7 +2387,7 @@ function heroB(){
     <p style="font-size:clamp(20px,2.4vw,30px);line-height:1.3;max-width:900px;margin:36px 0 0;font-weight:500">${esc(S.oneLiner)}<\/p>
     <div style="margin-top:32px;border-top:1px solid var(--stroke);display:flex;gap:20px;flex-wrap:wrap;padding:12px 0" class="mono small muted">
       <span><b class="sec2">${num(U.sessions)}<\/b> sessions<\/span><span><b class="sec2">${U.activeDays}/30<\/b> days<\/span><span><b class="sec2">${W.lead.harnesses}<\/b> harnesses<\/span>
-      <span style="margin-left:auto">checked ${readCheckedAgo}<\/span><\/div>
+      <span style="margin-left:auto">updated ${readCheckedAgo}<\/span><\/div>
   <\/div><\/section>
   <nav id="hb-rail" class="hb-rail" aria-label="Sections">
     <div class="hb-line"><span id="hb-fill"><\/span><\/div>
@@ -2405,7 +2431,7 @@ function heroC(){
         <span class="mono" style="font-size:12px;font-weight:900;color:var(--stroke-strong)">${s.n}<\/span>
         <span><b style="font-size:15px;text-transform:uppercase;letter-spacing:-.01em">${s.title}<\/b><br><span class="small sec2">${s.line}<\/span><\/span>
         <span class="lime">↓<\/span><\/a>`).join("")}
-      <p class="mono small muted" style="padding:12px 20px 0">checked ${readCheckedAgo}<\/p>
+      <p class="mono small muted" style="padding:12px 20px 0">updated ${readCheckedAgo}<\/p>
     <\/div>
    <\/div>
   <\/div><\/section>
@@ -2478,7 +2504,7 @@ function measureAll(){
   for(const [k] of VARIANTS){probe.innerHTML=RENDER[k]();heights[k]=probe.scrollHeight;}
   probe.remove();
 }
-const KNOBS=[["title",["rail","num"]],["bands",["4","2"]],["name",["stats","usage"]],["rows",["acc","tabs"]],["top",["stack","side","merged","hero"]],["exp",["feature","grid","rows"]]];
+const KNOBS=[["title",["rail","num"]],["bands",["4","2"]],["name",["stats","usage"]],["rows",["acc","tabs"]],["top",["stack","side","merged","hero"]],["exp",["feature","grid","rows"]],["act",["stacked","tile","corner","chips"]],["rule",["dim","none","line"]],["lbl",["runs on","tools","none"]],["nav",["quiet","bare","lines"]]];
 function readOpts(){const p=new URLSearchParams(location.search);window.OPTS={};for(const [k,vals]of KNOBS)window.OPTS[k]=vals.includes(p.get(k))?p.get(k):vals[0];}
 function current(){const v=new URLSearchParams(location.search).get("v");return RENDER[v]?v:"v38";}
 function show(k,push){

--- a/prototypes/stack-page-compact/index.html
+++ b/prototypes/stack-page-compact/index.html
@@ -2290,7 +2290,7 @@ const actions352=()=>`<span class="chip" style="cursor:pointer">▲ ${UPVOTES}<\
    ========================================================================= */
 function heroA(){
   const sec=sections352();
-  const shown=8;
+  const shown=S.tools.length<=6?S.tools.length:5;
   const act=OPT("act"), rule=OPT("rule"), lbl=OPT("lbl"), nav=OPT("nav");
   const hair="1px solid oklch(0.55 0.01 256 / 0.25)";
   const ruleCss=rule==="line"?"border-top:1px solid var(--stroke)":rule==="dim"?`border-top:${hair}`:rule==="dim2"?`border-top:${hair};border-bottom:${hair};padding-bottom:20px`:"";
@@ -2307,11 +2307,14 @@ function heroA(){
   return `<section style="background:${TINT4[0]};padding:56px 0 36px"><div style="max-width:1280px;margin:0 auto;padding:0 24px">
    ${act==="corner"?`<div style="display:flex;justify-content:flex-end;margin:-24px 0 8px">${actionsTopRight}<\/div>`:""}
    <div style="display:grid;grid-template-columns:1fr auto;gap:40px;align-items:end" class="g2">
-    <div style="min-width:0">
+    <div style="min-width:0" class="ha-left">
       <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">${avatar352(40)}${byline352()}<\/div>
       <div class="ha-h1w"><h1 class="ha-h1">${esc(S.name)}<\/h1><\/div>
-      <p style="margin-top:16px;font-size:18px;color:var(--fg-secondary);max-width:560px">${esc(S.oneLiner)}<\/p>
+      <p style="margin-top:14px;font-size:18px;color:var(--fg-secondary);max-width:560px">${esc(S.oneLiner)}<\/p>
       ${actionsUnderTitle}
+      <div style="display:flex;align-items:center;gap:10px;margin-top:26px;${ruleCss?ruleCss+";padding-top:16px":""}">
+        ${label?`<span class="kick muted" style="margin-right:8px">${label}<\/span>`:""}<a href="#s-tools" style="display:flex;gap:10px;align-items:center">${toolsSorted.slice(0,shown).map(t=>`<span title="${esc(t.name)}${t.amount>0?" · "+priceMo(t.amount):""}" style="display:inline-flex;cursor:help">${toolIcn(t,36)}<\/span>`).join("")}${S.tools.length>shown?`<span class="chip" title="${toolsSorted.slice(shown).map(t=>esc(t.name)).join(", ")}" style="border-color:oklch(0.55 0.01 256 / 0.35);cursor:help;height:36px">+${S.tools.length-shown}<\/span>`:""}<\/a>
+      <\/div>
     <\/div>
     <div style="display:grid;gap:10px;min-width:260px" class="ha-tiles">
       ${actionsInColumn}
@@ -2324,11 +2327,8 @@ function heroA(){
         <div class="mono" style="font-size:40px;font-weight:900;line-height:1;position:relative">${fmtT(U.totalTokens)}<\/div>
         <div class="kick muted" style="margin-top:6px;position:relative">tokens · 30 days · <span class="lime">${UP} ×${(U.totalTokens/U.prevTokens).toFixed(0)}<\/span><\/div>
       <\/a>
+      ${act==="chips"?"":`<div style="display:flex;justify-content:flex-end;gap:14px;margin-top:-2px" class="mono small muted"><span>updated ${readCheckedAgo}<\/span>${lnkReport}<\/div>`}
     <\/div>
-   <\/div>
-   <div style="display:flex;align-items:center;gap:8px;margin-top:${rule==="none"?"44px":"32px"};padding-top:${rule==="none"?"0":"20px"};padding-bottom:${rule==="none"?"8px":"0"};${ruleCss};flex-wrap:wrap">
-     ${label?`<span class="kick muted" style="margin-right:8px">${label}<\/span>`:""}<a href="#s-tools" style="display:flex;gap:8px;align-items:center">${toolsSorted.slice(0,shown).map(t=>`<span title="${esc(t.name)}${t.amount>0?" · "+priceMo(t.amount):""}" style="display:inline-flex;cursor:help">${toolIcn(t,28)}<\/span>`).join("")}<span class="chip" title="${toolsSorted.slice(shown).map(t=>esc(t.name)).join(", ")}" style="border-color:oklch(0.55 0.01 256 / 0.35);cursor:help">+${S.tools.length-shown}<\/span><\/a>
-     ${reportSlot||`<span class="mono small muted" style="margin-left:auto">updated ${readCheckedAgo}<\/span>`}
    <\/div>
   <\/div><\/section>
   <nav id="ha-tabs" class="ha-tabs ha-nav-${nav}" aria-label="Sections">
@@ -2338,7 +2338,8 @@ function heroA(){
    <\/div>
   <\/nav>
   <style>
-   .ha-h1w{min-height:calc(2 * .88 * clamp(44px,7vw,88px));display:flex;align-items:flex-end;margin-top:20px}
+   .ha-h1w{margin-top:18px}
+   .ha-left{min-height:calc(2 * .88 * clamp(44px,7vw,88px) + 150px)}
    .ha-h1{font-size:clamp(44px,7vw,88px);font-weight:900;line-height:.88;letter-spacing:-.03em;text-transform:uppercase;overflow-wrap:anywhere}
    .ha-up{display:inline-flex;align-items:center;gap:8px;background:none;border:1px solid var(--lime);color:var(--lime);font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;padding:10px 16px;cursor:pointer}
    .ha-up:hover{background:var(--lime);color:var(--lime-contrast)}.ha-up .tri{font-size:10px}.ha-up b{font-weight:900}
@@ -2349,7 +2350,7 @@ function heroA(){
    .ha-tab{display:flex;align-items:baseline;gap:10px;padding:0 18px;white-space:nowrap;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--fg-muted);box-shadow:inset 0 -3px 0 transparent}
    .ha-tab .n{color:var(--stroke-strong)}.ha-tab .s{font-weight:400;letter-spacing:.04em;text-transform:none;font-size:11px}
    .ha-tab .lab{display:inline-flex;gap:10px;align-items:baseline;padding:14px 0 12px;box-shadow:inset 0 -3px 0 transparent}
-   .ha-tab.on{color:var(--lime)}.ha-nav-lines .ha-tab.on{box-shadow:inset 0 -3px 0 var(--lime)}.ha-nav-quiet .ha-tab.on .lab,.ha-nav-bare .ha-tab.on .lab{box-shadow:inset 0 -3px 0 var(--lime)}.ha-tab.on .n{color:var(--lime)}
+   .ha-tab.on{color:var(--lime)}.ha-nav-lines .ha-tab.on{box-shadow:inset 0 -3px 0 var(--lime)}.ha-nav-quiet .ha-tab.on,.ha-nav-bare .ha-tab.on{box-shadow:inset 0 -3px 0 var(--lime)}.ha-tab.on .n{color:var(--lime)}
    .ha-tab:hover{color:var(--fg-primary)}
    .ha-id{display:none;align-items:center;gap:10px;padding:0 18px 0 0;margin-right:6px;font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap}
    .ha-tabs.stuck .ha-id{display:flex}
@@ -2357,11 +2358,11 @@ function heroA(){
    .ha-nav-lines{border-top:1px solid var(--stroke);border-bottom:1px solid var(--stroke)}
    .ha-nav-lines .ha-tab{border-right:1px solid var(--stroke)}.ha-nav-lines .ha-tab:first-of-type{border-left:1px solid var(--stroke)}
    .ha-nav-quiet{border-bottom:1px solid oklch(0.55 0.01 256 / 0.25)}
-   .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:180px;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
+   .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:150px;margin-right:20px;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
    .ha-nav-bare{background:${TINT4[1]}}.ha-nav-bare .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
    .ha-nav-bare.stuck{box-shadow:0 8px 24px oklch(0 0 0 / .35)}
-   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id{display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{margin-right:20px}}
-   @media(max-width:820px){.ha-tiles{grid-template-columns:1fr 1fr;max-width:520px;min-width:0!important}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3;justify-content:flex-start}.ha-tiles .ha-up{flex:none!important}.ha-tiles .kick{font-size:10px;letter-spacing:.15em}}
+   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id{display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{width:auto;margin-right:22px}}
+   @media(max-width:820px){.ha-tiles{grid-template-columns:1fr 1fr;max-width:520px;min-width:0!important}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3;justify-content:flex-start}.ha-tiles .ha-up{flex:none!important}.ha-tiles>div:last-child{grid-column:1/3}.ha-left{min-height:0}.ha-tiles .kick{font-size:10px;letter-spacing:.15em}}
   <\/style>`;
 }
 

--- a/prototypes/stack-page-compact/index.html
+++ b/prototypes/stack-page-compact/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>#351 · whole-page compact pass</title>
+<title>#352 · hero and subnav (over the #351 compact page)</title>
 <style>
 /* PROTOTYPE - throwaway (ticket alp82/aistack#351). Tokens copied from src/styles.css (dark). */
 :root{
@@ -44,7 +44,7 @@ hr.rule{border:0;border-top:1px solid var(--stroke)}
 </head>
 <body>
 <div id="proto-head">
-  <span><b>alp82/aistack#351</b> · whole-page compact pass</span>
+  <span><b>alp82/aistack#352</b> · hero and subnav, over the v37 page from #351</span>
   <span>Alper's Coding Stack · real prod data, 2026-08-30</span>
   <span id="hnote"></span>
 </div>
@@ -2234,9 +2234,240 @@ function renderV37(){
 
 </script>
 <script>
+/* PROTOTYPE - throwaway (ticket alp82/aistack#352). Round 1: three hero and
+   subnav pairs, each rendered over the accepted v37 body from #351. The body
+   is unchanged; only the top of the page and the section navigation differ.
+
+   v38 Masthead + tabs   identity left, two promise tiles right (authored price,
+                         measured tokens), logo strip; sticky tab bar with the
+                         four section stats, identity appears once stuck.
+   v39 Figures first     the four section figures ARE the hero, each a link;
+                         the one-liner follows; a vertical progress rail on wide
+                         screens, a sticky figure strip everywhere else.
+   v40 Contents          name and one-liner left, a "in this stack" ladder
+                         right with one sentence per section; a reading scrubber
+                         pinned under the header, segments sized by section. */
+"use strict";
+
+const UPVOTES=12; // not in slim.json; the demo's stand-in, as in heroV16
+
+/* The four sections of the v37 body, with the anchor ids body352() stamps. */
+function sections352(){
+  return [
+    {n:"01",id:"s-stats",title:OPT("name")==="usage"?"Actual Usage":"Stats",stat:`${fmtT(U.totalTokens)} tokens`,
+     line:`${fmtT(U.totalTokens)} tokens in 30 days, ${num(U.sessions)} sessions on ${W.lead.harnesses} harnesses`},
+    {n:"02",id:"s-projects",title:"Projects",stat:`${P.length} projects`,
+     line:`${P.length} projects, ${num(W.git.commits)} commits in the last 30 days`},
+    {n:"03",id:"s-tools",title:"Tools",stat:`${S.tools.length} tools · ${priceMo(S.price)}`,
+     line:`${S.tools.length} tools for ${priceMo(S.price)}, ${esc(toolsSorted[0].name)} and ${esc(toolsSorted[1].name)} cost the most`},
+    {n:"04",id:"s-guide",title:"Guide",stat:`${guideMin} min read`,
+     line:`${num(S.guide.words)} words by ${esc(S.creator.name.split(" ")[0])}, ${guideMin} min read`},
+  ];
+}
+
+/* The v37 body (everything under the hero), with an id on each section. */
+function body352(){
+  const name=OPT("name")==="usage"?"Actual Usage":"Stats";
+  const rows=OPT("rows")==="tabs"?`<div style="margin-top:36px">${cssTabs("t37")}<\/div>`:`<div style="margin-top:36px">${statsAccordion()}<\/div>`;
+  const ids=["s-stats","s-projects","s-tools","s-guide"];
+  let i=0;
+  const html=sec37(1,"01","// sync",name,`30d · all machines<br>checked ${readCheckedAgo}`,statsTop37()+rows)+
+    sec37(2,"02","// showcase","Projects",P.length+" projects",projGridV16())+
+    sec37(3,"03","// ai components","Tools",`${S.tools.length} tools · ${priceMo(S.price)}`,toolsBodyV16())+
+    sec37(0,"04","// writeup","Guide",guideMin+" min read",guideBodyV16());
+  return html.replace(/<section /g,()=>`<section id="${ids[i++]}" `)+ctaStrip()+MEDIA_G2+
+    `<style>[id^="s-"]{scroll-margin-top:calc(var(--ptop,0px) + 48px)}<\/style>`;
+}
+
+/* shared identity bits */
+const avatar352=px=>`<img src="${S.creator.avatar}" alt="" width="${px}" height="${px}" style="display:block;object-fit:cover;flex:none">`;
+const byline352=()=>`<span class="mono small"><b class="sec2">${esc(S.creator.name)}<\/b> <span class="muted">@${esc(S.creator.handle)}<\/span><\/span><span class="small lime">✓ verified<\/span>`;
+const actions352=()=>`<span class="chip" style="cursor:pointer">▲ ${UPVOTES}<\/span><span class="chip" style="cursor:pointer">Share<\/span><span class="chip" style="cursor:pointer">Report<\/span>`;
+
+/* =========================================================================
+   V38 MASTHEAD + TABS
+   ========================================================================= */
+function heroA(){
+  const sec=sections352();
+  const shown=8;
+  return `<section style="background:${TINT4[0]};padding:56px 0 36px"><div style="max-width:1280px;margin:0 auto;padding:0 24px">
+   <div style="display:grid;grid-template-columns:1fr auto;gap:40px;align-items:end" class="g2">
+    <div style="min-width:0">
+      <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">${avatar352(40)}${byline352()}<\/div>
+      <h1 style="font-size:clamp(44px,7vw,88px);font-weight:900;line-height:.88;letter-spacing:-.03em;text-transform:uppercase;margin-top:20px">${esc(S.name)}<\/h1>
+      <p style="margin-top:16px;font-size:18px;color:var(--fg-secondary);max-width:560px">${esc(S.oneLiner)}<\/p>
+      <div style="display:flex;gap:6px;margin-top:20px">${actions352()}<\/div>
+    <\/div>
+    <div style="display:grid;gap:10px;min-width:260px" class="ha-tiles">
+      <div style="background:var(--lime);color:var(--lime-contrast);padding:18px 20px;box-shadow:4px 4px 0 var(--stroke-strong);cursor:help" title="authored: tools and bundles at list prices">
+        <div class="mono" style="font-size:40px;font-weight:900;line-height:1">${price(S.price)}<\/div>
+        <div class="kick" style="margin-top:6px;opacity:.8">per month · solo<\/div>
+      <\/div>
+      <a href="#s-stats" style="position:relative;border:1px solid var(--stroke);padding:18px 20px;display:block;overflow:hidden" title="measured: tokens across all machines, last 30 days">
+        <div style="position:absolute;inset:0;opacity:.15;pointer-events:none" aria-hidden="true">${spark(U.series,400,80)}<\/div>
+        <div class="mono" style="font-size:40px;font-weight:900;line-height:1;position:relative">${fmtT(U.totalTokens)}<\/div>
+        <div class="kick muted" style="margin-top:6px;position:relative">tokens · 30 days · <span class="lime">${UP} ×${(U.totalTokens/U.prevTokens).toFixed(0)}<\/span><\/div>
+      <\/a>
+    <\/div>
+   <\/div>
+   <a href="#s-tools" style="display:flex;align-items:center;gap:8px;margin-top:32px;padding-top:20px;border-top:1px solid var(--stroke);flex-wrap:wrap">
+     <span class="kick muted" style="margin-right:8px">built with<\/span>${toolsSorted.slice(0,shown).map(t=>toolIcn(t,28)).join("")}<span class="chip">+${S.tools.length-shown}<\/span>
+     <span class="mono small muted" style="margin-left:auto">checked ${readCheckedAgo}<\/span>
+   <\/a>
+  <\/div><\/section>
+  <nav id="ha-tabs" class="ha-tabs" aria-label="Sections">
+   <div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:stretch;overflow-x:auto">
+    <span class="ha-id"><b>${esc(S.name)}<\/b><span class="lime mono" style="font-size:11px">${priceMo(S.price)}<\/span><\/span>
+    ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="n">${s.n}<\/span><span class="t">${s.title}<\/span><span class="s">${s.stat}<\/span><\/a>`).join("")}
+   <\/div>
+  <\/nav>
+  <style>
+   .ha-tabs{position:sticky;top:var(--ptop,0px);z-index:30;background:${TINT4[0]};border-bottom:1px solid var(--stroke);border-top:1px solid var(--stroke)}
+   .ha-tab{display:flex;align-items:baseline;gap:10px;padding:14px 18px 12px;border-right:1px solid var(--stroke);white-space:nowrap;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--fg-muted);box-shadow:inset 0 -3px 0 transparent}
+   .ha-tab:first-of-type{border-left:1px solid var(--stroke)}
+   .ha-tab .n{color:var(--stroke-strong)}.ha-tab .s{font-weight:400;letter-spacing:.04em;text-transform:none;font-size:11px}
+   .ha-tab.on{color:var(--lime);box-shadow:inset 0 -3px 0 var(--lime)}.ha-tab.on .n{color:var(--lime)}
+   .ha-id{display:none;align-items:center;gap:10px;padding:0 18px 0 0;margin-right:6px;font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap}
+   .ha-tabs.stuck .ha-id{display:flex}
+   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id{display:none!important}.ha-tab{padding:12px 14px}.ha-tiles{grid-template-columns:1fr 1fr}}
+  <\/style>`;
+}
+
+/* =========================================================================
+   V39 FIGURES FIRST
+   ========================================================================= */
+function heroB(){
+  const sec=sections352();
+  const figs=[
+    {s:sec[0],big:fmtT(U.totalTokens),unit:"tokens · 30 days",viz:spark(U.series,400,60)},
+    {s:sec[1],big:String(P.length),unit:`projects · ${num(W.git.commits)} commits`,viz:gitBars(56)},
+    {s:sec[2],big:String(S.tools.length),unit:`tools · ${priceMo(S.price)}`,viz:`<div style="display:flex;gap:4px;flex-wrap:wrap;padding:10px 20px 0">${toolsSorted.slice(0,8).map(t=>toolIcn(t,22)).join("")}<\/div>`},
+    {s:sec[3],big:`${guideMin}<span style="font-size:.4em;margin-left:4px">MIN<\/span>`,unit:"guide by the author",viz:`<div style="display:grid;gap:6px;padding:10px 20px 0">${[1,.8,.9,.6,.85].map(w=>`<span style="height:4px;width:${w*100}%;background:var(--fg-muted)"><\/span>`).join("")}<\/div>`},
+  ];
+  const plain=h=>h.replace(/<[^>]*>/g," ");
+  return `<section style="background:${TINT4[0]};padding:40px 0 0"><div style="max-width:1280px;margin:0 auto;padding:0 24px">
+    <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">
+      ${avatar352(28)}<span class="mono" style="font-size:13px;font-weight:900;text-transform:uppercase;letter-spacing:.08em">${esc(S.name)}<\/span>
+      <span class="mono small muted">by ${esc(S.creator.name)} @${esc(S.creator.handle)}<\/span>
+      <span style="margin-left:auto;display:flex;gap:6px">${actions352()}<\/span><\/div>
+    <div class="hb-grid" style="display:grid;grid-template-columns:repeat(4,1fr);margin-top:36px;border:1px solid var(--stroke)">
+      ${figs.map(f=>`<a href="#${f.s.id}" class="hb-fig" style="position:relative;padding:22px 20px 64px;border-right:1px solid var(--stroke);overflow:hidden;display:block;min-width:0">
+        <div style="position:absolute;left:0;right:0;bottom:0;height:44px;opacity:.16;pointer-events:none" aria-hidden="true">${f.viz}<\/div>
+        <div class="kick lime" style="position:relative"><span style="color:var(--stroke-strong)">${f.s.n}<\/span> ${f.s.title}<\/div>
+        <div class="mono" style="font-size:clamp(44px,5.4vw,72px);font-weight:900;line-height:1;margin-top:14px;position:relative">${f.big}<\/div>
+        <div class="kick muted" style="margin-top:8px;position:relative">${f.unit}<\/div>
+        <span class="lime" style="position:absolute;right:16px;top:18px">↓<\/span><\/a>`).join("")}
+    <\/div>
+    <p style="font-size:clamp(20px,2.4vw,30px);line-height:1.3;max-width:900px;margin:36px 0 0;font-weight:500">${esc(S.oneLiner)}<\/p>
+    <div style="margin-top:32px;border-top:1px solid var(--stroke);display:flex;gap:20px;flex-wrap:wrap;padding:12px 0" class="mono small muted">
+      <span><b class="sec2">${num(U.sessions)}<\/b> sessions<\/span><span><b class="sec2">${U.activeDays}/30<\/b> days<\/span><span><b class="sec2">${W.lead.harnesses}<\/b> harnesses<\/span>
+      <span style="margin-left:auto">checked ${readCheckedAgo}<\/span><\/div>
+  <\/div><\/section>
+  <nav id="hb-rail" class="hb-rail" aria-label="Sections">
+    <div class="hb-line"><span id="hb-fill"><\/span><\/div>
+    ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="hb-item"><span class="n">${s.n}<\/span><span class="t">${s.title}<\/span><\/a>`).join("")}
+  <\/nav>
+  <nav id="hb-strip" class="hb-strip" aria-label="Sections">
+    ${figs.map(f=>`<a href="#${f.s.id}" data-spy="${f.s.id}" class="hb-chip"><span class="n">${f.s.n}<\/span><b>${plain(f.big)}<\/b><span class="t">${f.s.title}<\/span><\/a>`).join("")}
+  <\/nav>
+  <style>
+   .hb-fig:last-child{border-right:0!important}
+   .hb-fig:hover .kick.lime{text-decoration:underline}
+   .hb-rail{position:fixed;left:24px;top:50%;transform:translate(-160%,-50%);transition:transform .25s;z-index:30;display:flex;flex-direction:column;gap:14px;padding-left:16px}
+   .hb-rail.shown{transform:translate(0,-50%)}
+   .hb-line{position:absolute;left:0;top:0;bottom:0;width:2px;background:var(--stroke)}
+   .hb-line span{display:block;width:100%;height:0;background:var(--lime)}
+   .hb-item{font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--fg-muted);display:flex;gap:8px;font-weight:700}
+   .hb-item .n{color:var(--stroke-strong)}.hb-item.on{color:var(--lime)}.hb-item.on .n{color:var(--lime)}
+   .hb-strip{display:none;position:sticky;top:var(--ptop,0px);z-index:30;background:${TINT4[0]};border-top:1px solid var(--stroke);border-bottom:1px solid var(--stroke);overflow-x:auto;padding:0 8px}
+   .hb-chip{display:inline-flex;align-items:baseline;gap:6px;padding:10px 12px;font-family:var(--mono);font-size:11px;color:var(--fg-muted);white-space:nowrap;box-shadow:inset 0 -3px 0 transparent;text-transform:uppercase;letter-spacing:.08em}
+   .hb-chip b{color:var(--fg-primary);font-size:13px}.hb-chip .n{color:var(--stroke-strong)}.hb-chip.on{box-shadow:inset 0 -3px 0 var(--lime);color:var(--lime)}.hb-chip.on b,.hb-chip.on .n{color:var(--lime)}
+   @media(max-width:1560px){.hb-rail{display:none}.hb-strip{display:flex}}
+   @media(max-width:820px){.hb-grid{grid-template-columns:1fr 1fr!important}.hb-fig{border-bottom:1px solid var(--stroke)}.hb-fig:nth-child(2n){border-right:0!important}.hb-fig:nth-child(n+3){border-bottom:0}}
+  <\/style>`;
+}
+
+/* =========================================================================
+   V40 CONTENTS + SCRUBBER
+   ========================================================================= */
+function heroC(){
+  const sec=sections352();
+  return `<section style="background:${TINT4[0]};padding:56px 0 48px"><div style="max-width:1280px;margin:0 auto;padding:0 24px">
+   <div style="display:grid;grid-template-columns:minmax(0,7fr) minmax(0,5fr);gap:56px;align-items:start" class="g2">
+    <div style="min-width:0">
+      <h1 style="font-size:clamp(44px,6.4vw,80px);font-weight:900;line-height:.9;letter-spacing:-.03em;text-transform:uppercase">${esc(S.name)}<\/h1>
+      <p style="margin-top:18px;font-size:18px;color:var(--fg-secondary);max-width:540px">${esc(S.oneLiner)}<\/p>
+      <div style="display:flex;align-items:center;gap:12px;margin-top:24px;flex-wrap:wrap">${avatar352(36)}${byline352()}<span style="display:flex;gap:6px;margin-left:8px">${actions352()}<\/span><\/div>
+    <\/div>
+    <div style="border-left:2px solid var(--lime)">
+      <p class="kick lime" style="padding:0 20px 4px">in this stack<\/p>
+      ${sec.map(s=>`<a href="#${s.id}" class="hc-row" style="display:grid;grid-template-columns:36px 1fr auto;gap:12px;align-items:baseline;padding:14px 20px;border-bottom:1px solid var(--stroke)">
+        <span class="mono" style="font-size:12px;font-weight:900;color:var(--stroke-strong)">${s.n}<\/span>
+        <span><b style="font-size:15px;text-transform:uppercase;letter-spacing:-.01em">${s.title}<\/b><br><span class="small sec2">${s.line}<\/span><\/span>
+        <span class="lime">↓<\/span><\/a>`).join("")}
+      <p class="mono small muted" style="padding:12px 20px 0">checked ${readCheckedAgo}<\/p>
+    <\/div>
+   <\/div>
+  <\/div><\/section>
+  <nav id="hc-bar" class="hc-bar" aria-label="Reading progress">
+    <div class="hc-track">${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" data-seg="${s.id}" class="hc-seg"><span class="fill"><\/span><span class="lbl"><span class="n">${s.n}<\/span> <span class="t">${s.title}<\/span><\/span><\/a>`).join("")}<\/div>
+  <\/nav>
+  <style>
+   .hc-row:hover b{color:var(--lime)}
+   .hc-bar{position:fixed;left:0;right:0;top:var(--ptop,0px);z-index:30;background:${TINT4[0]};border-bottom:1px solid var(--stroke);transform:translateY(-110%);transition:transform .2s}
+   .hc-bar.shown{transform:none}
+   .hc-track{display:flex;max-width:1280px;margin:0 auto;padding:0 24px}
+   .hc-seg{position:relative;flex:1 1 0;height:34px;display:flex;align-items:center;border-right:1px solid var(--stroke);overflow:hidden;min-width:0}
+   .hc-seg:first-child{border-left:1px solid var(--stroke)}
+   .hc-seg .fill{position:absolute;left:0;top:0;bottom:0;width:0;background:var(--lime);opacity:.18}
+   .hc-seg .lbl{position:relative;padding:0 12px;font-family:var(--mono);font-size:11px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--fg-muted);white-space:nowrap}
+   .hc-seg .n{color:var(--stroke-strong)}.hc-seg.on .lbl{color:var(--lime)}.hc-seg.on .n{color:var(--lime)}
+   .hc-seg.on::after{content:"";position:absolute;left:0;right:0;bottom:0;height:3px;background:var(--lime)}
+   @media(max-width:700px){.hc-seg .lbl{padding:0 8px}.hc-seg:not(.on) .t{display:none}}
+  <\/style>`;
+}
+
+function renderV38(){return heroA()+body352();}
+function renderV39(){return heroB()+body352();}
+function renderV40(){return heroC()+body352();}
+
+/* ---------- scroll behavior, wired after every render by the template ---------- */
+window.afterRender=function(){
+  if(window._nav352)window._nav352();
+  window._nav352=null;
+  const ptopOf=()=>{const h=document.getElementById("proto-head").offsetHeight;document.documentElement.style.setProperty("--ptop",h+"px");return h;};
+  ptopOf();
+  const spyLinks=[...document.querySelectorAll("[data-spy]")];
+  if(!spyLinks.length)return;
+  const ids=[...new Set(spyLinks.map(a=>a.dataset.spy))];
+  const secs=ids.map(id=>document.getElementById(id)).filter(Boolean);
+  const hero=document.querySelector("#page > section");
+  const onScroll=()=>{
+    const ptop=ptopOf();
+    const line=scrollY+innerHeight*0.3;
+    let cur=null;
+    for(const s of secs){if(s.offsetTop<=line)cur=s.id;}
+    spyLinks.forEach(a=>a.classList.toggle("on",a.dataset.spy===cur));
+    const heroGone=hero.getBoundingClientRect().bottom<ptop;
+    const tabs=document.getElementById("ha-tabs");
+    if(tabs)tabs.classList.toggle("stuck",tabs.getBoundingClientRect().top<=ptop+1);
+    const rail=document.getElementById("hb-rail");
+    if(rail){rail.classList.toggle("shown",heroGone);const p=scrollY/Math.max(1,document.documentElement.scrollHeight-innerHeight);document.getElementById("hb-fill").style.height=(p*100).toFixed(1)+"%";}
+    const bar=document.getElementById("hc-bar");
+    if(bar){bar.classList.toggle("shown",heroGone);
+      secs.forEach(s=>{const seg=bar.querySelector(`[data-seg="${s.id}"]`);if(!seg)return;seg.style.flexGrow=Math.max(1,s.offsetHeight/100);
+        const f=Math.min(1,Math.max(0,(line-s.offsetTop)/s.offsetHeight));seg.querySelector(".fill").style.width=(f*100).toFixed(1)+"%";});}
+  };
+  onScroll();
+  addEventListener("scroll",onScroll,{passive:true});addEventListener("resize",onScroll);
+  window._nav352=()=>{removeEventListener("scroll",onScroll);removeEventListener("resize",onScroll);};
+};
+
+</script>
+<script>
 /* ---------- switcher ---------- */
-const VARIANTS=[["base","Baseline (today)"],["v1","V1 Tight editorial"],["v2","V2 Ledger"],["v3","V3 Mosaic"],["v4","V4 Split rail"],["v5","V5 Digest"],["v6","V6 Magazine"],["v7","V7 Terminal"],["v8","V8 Bento"],["v9","V9 Billboard"],["v10","V10 Blueprint"],["v11","V11 Receipt"],["v12","V12 Ticker"],["v13","V13 Spine"],["v14","V14 Rails"],["v15","V15 Split hero"],["v16","V16 Magazine deep"],["v17","V17 Billboard data"],["v18","V18 Windows"],["v19","V19 Blueprint ed."],["v20","V20 Dossier"],["v21","V21 Chapters"],["v22","V22 Mural"],["v23","V23 Console pro"],["v24","V24 Feature table"],["v25","V25 Story scroll"],["v26","V26 Tonal 4"],["v27","V27 Rail + drawer"],["v28","V28 Distributed"],["v29","V29 Timeline"],["v30","V30 Quiet drawers"],["v31","V31 One moment"],["v32","V32 Simple+details"],["v33","V33 Tabs"],["v34","V34 Distributed"],["v35","V35 Two level"],["v36","V36 Grouped scan"],["v37","V37 Composed"]];
-const RENDER={base:renderBaseline,v1:renderV1,v2:renderV2,v3:renderV3,v4:renderV4,v5:renderV5,v6:renderV6,v7:renderV7,v8:renderV8,v9:renderV9,v10:renderV10,v11:renderV11,v12:renderV12,v13:renderV13,v14:renderV14,v15:renderV15,v16:renderV16,v17:renderV17,v18:renderV18,v19:renderV19,v20:renderV20,v21:renderV21,v22:renderV22,v23:renderV23,v24:renderV24,v25:renderV25,v26:renderV26,v27:renderV27,v28:renderV28,v29:renderV29,v30:renderV30,v31:renderV31,v32:renderV32,v33:renderV33,v34:renderV34,v35:renderV35,v36:renderV36,v37:renderV37};
+const VARIANTS=[["base","Baseline (today)"],["v1","V1 Tight editorial"],["v2","V2 Ledger"],["v3","V3 Mosaic"],["v4","V4 Split rail"],["v5","V5 Digest"],["v6","V6 Magazine"],["v7","V7 Terminal"],["v8","V8 Bento"],["v9","V9 Billboard"],["v10","V10 Blueprint"],["v11","V11 Receipt"],["v12","V12 Ticker"],["v13","V13 Spine"],["v14","V14 Rails"],["v15","V15 Split hero"],["v16","V16 Magazine deep"],["v17","V17 Billboard data"],["v18","V18 Windows"],["v19","V19 Blueprint ed."],["v20","V20 Dossier"],["v21","V21 Chapters"],["v22","V22 Mural"],["v23","V23 Console pro"],["v24","V24 Feature table"],["v25","V25 Story scroll"],["v26","V26 Tonal 4"],["v27","V27 Rail + drawer"],["v28","V28 Distributed"],["v29","V29 Timeline"],["v30","V30 Quiet drawers"],["v31","V31 One moment"],["v32","V32 Simple+details"],["v33","V33 Tabs"],["v34","V34 Distributed"],["v35","V35 Two level"],["v36","V36 Grouped scan"],["v37","V37 Composed"],["v38","V38 Masthead + tabs"],["v39","V39 Figures first"],["v40","V40 Contents + scrubber"]];
+const RENDER={base:renderBaseline,v1:renderV1,v2:renderV2,v3:renderV3,v4:renderV4,v5:renderV5,v6:renderV6,v7:renderV7,v8:renderV8,v9:renderV9,v10:renderV10,v11:renderV11,v12:renderV12,v13:renderV13,v14:renderV14,v15:renderV15,v16:renderV16,v17:renderV17,v18:renderV18,v19:renderV19,v20:renderV20,v21:renderV21,v22:renderV22,v23:renderV23,v24:renderV24,v25:renderV25,v26:renderV26,v27:renderV27,v28:renderV28,v29:renderV29,v30:renderV30,v31:renderV31,v32:renderV32,v33:renderV33,v34:renderV34,v35:renderV35,v36:renderV36,v37:renderV37,v38:renderV38,v39:renderV39,v40:renderV40};
 const page=document.getElementById("page");
 const heights={};
 function measureAll(){
@@ -2249,15 +2480,16 @@ function measureAll(){
 }
 const KNOBS=[["title",["rail","num"]],["bands",["4","2"]],["name",["stats","usage"]],["rows",["acc","tabs"]],["top",["stack","side","merged","hero"]],["exp",["feature","grid","rows"]]];
 function readOpts(){const p=new URLSearchParams(location.search);window.OPTS={};for(const [k,vals]of KNOBS)window.OPTS[k]=vals.includes(p.get(k))?p.get(k):vals[0];}
-function current(){const v=new URLSearchParams(location.search).get("v");return RENDER[v]?v:"v37";}
+function current(){const v=new URLSearchParams(location.search).get("v");return RENDER[v]?v:"v38";}
 function show(k,push){
   readOpts();
   page.innerHTML=RENDER[k]();
+  if(window.afterRender)afterRender();
   if(push){const u=new URL(location);u.searchParams.set("v",k);history.replaceState(null,"",u);}
   const bar=document.getElementById("switcher");
   bar.innerHTML=VARIANTS.map(([id,label])=>`<button class="${id===k?"on":""}" data-v="${id}" title="${label}">${label.split(" ")[0].replace("Baseline","Base")}</button>`).join("")+
-    (k==="v37"?KNOBS.map(([key,vals])=>{const cur=window.OPTS[key];const next=vals[(vals.indexOf(cur)+1)%vals.length];return `<button class="knob" data-k="${key}" data-next="${next}" style="border-left:1px solid var(--stroke);color:var(--lime)">${key}: ${cur}</button>`;}).join(""):"")+
-    `<span class="h" id="hread"></span>`;
+    (/^v(37|38|39|40)$/.test(k)?KNOBS.map(([key,vals])=>{const cur=window.OPTS[key];const next=vals[(vals.indexOf(cur)+1)%vals.length];return `<button class="knob" data-k="${key}" data-next="${next}" style="border-left:1px solid var(--stroke);color:var(--lime)">${key}: ${cur}</button>`;}).join(""):"")+
+    `<button class="knob" style="border-left:1px solid var(--stroke)" title="open this variant in a 390px window" onclick="open(location.href,'m352','width=390,height=780')">📱 390</button><span class="h" id="hread"></span>`;
   bar.querySelectorAll("button[data-v]").forEach(b=>b.onclick=()=>show(b.dataset.v,true));
   bar.querySelectorAll("button.knob").forEach(b=>b.onclick=()=>{const u=new URL(location);u.searchParams.set(b.dataset.k,b.dataset.next);history.replaceState(null,"",u);show(k,false);});
   const hn=document.getElementById("hnote");
@@ -2265,7 +2497,8 @@ function show(k,push){
   const ratio=heights.base?Math.round(heights[k]/heights.base*100):null;
   document.getElementById("hread").textContent=ratio?`${label} · ${ratio}% of baseline height`:label;
   hn.textContent=ratio?`${Math.round(heights[k]/100)/10}k px vs baseline ${Math.round(heights.base/100)/10}k px`:"";
-  window.scrollTo(0,0);
+  const y=Number(new URLSearchParams(location.search).get("y")||0);
+  window.scrollTo(0,y);
 }
 addEventListener("keydown",e=>{
   if(/INPUT|TEXTAREA/.test(document.activeElement.tagName))return;

--- a/prototypes/stack-page-compact/index.html
+++ b/prototypes/stack-page-compact/index.html
@@ -2277,7 +2277,7 @@ function body352(){
     sec37(3,"03","","Tools",`${S.tools.length} tools · ${priceMo(S.price)}`,toolsBodyV16())+
     sec37(0,"04","","Guide",guideMin+" min read",guideBodyV16());
   return html.replace(/<section /g,()=>`<section id="${ids[i++]}" `)+ctaStrip()+MEDIA_G2+
-    `<style>[id^="s-"]{scroll-margin-top:calc(var(--ptop,0px) + 48px)}<\/style>`;
+    `<style>[id^="s-"]{scroll-margin-top:calc(var(--ptop,0px) + 88px)}<\/style>`;
 }
 
 /* shared identity bits */
@@ -2332,10 +2332,15 @@ function heroA(){
    <\/div>
   <\/div><\/section>
   <nav id="ha-tabs" class="ha-tabs ha-nav-${nav}" aria-label="Sections">
+   <div class="ha-idrow"><div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:22px;overflow:hidden">
+     ${avatar352(22)}<b style="font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap">${esc(S.name)}<\/b>
+     <span class="mono small muted" style="white-space:nowrap">${esc(S.creator.name)}<\/span>
+     <span class="mono small" style="margin-left:auto;white-space:nowrap"><span class="lime" style="font-weight:700">${priceMo(S.price)}<\/span><\/span>
+     <span class="mono small" style="display:inline-flex;align-items:center;gap:8px;white-space:nowrap"><span style="width:90px;display:inline-block">${spark(U.series,400,18)}<\/span><b>${fmtT(U.totalTokens)}<\/b> <span class="muted">tokens · 30d<\/span><\/span>
+     <span class="mono small muted" style="white-space:nowrap">▲ ${UPVOTES}<\/span>
+   <\/div><\/div>
    <div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:stretch;overflow-x:auto">
-    <span class="ha-id"><b>${esc(S.name)}<\/b><\/span>
     ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="lab"><span class="n">${s.n}<\/span><span class="t">${s.title}<\/span><\/span><span class="s">${s.stat}<\/span><span class="vis"><\/span><\/a>`).join("")}
-    <span class="ha-price lime mono" style="font-size:11px;font-weight:700">${priceMo(S.price)}<\/span>
    <\/div>
   <\/nav>
   <style>
@@ -2353,18 +2358,16 @@ function heroA(){
    .ha-tab .lab{display:inline-flex;gap:10px;align-items:baseline;padding:14px 0 12px;box-shadow:inset 0 -3px 0 transparent}
    .ha-tab.on{color:var(--lime)}.ha-nav-lines .ha-tab.on{box-shadow:inset 0 -3px 0 var(--lime)}
    .ha-tab .vis{position:absolute;left:0;bottom:0;height:3px;width:0;background:var(--lime)}
-   .ha-price{display:none;align-items:center;margin-left:auto;padding-left:18px;white-space:nowrap}.ha-tabs.stuck .ha-price{display:flex}.ha-tab.on .n{color:var(--lime)}
+   .ha-idrow{display:none;border-bottom:1px solid oklch(0.55 0.01 256 / 0.18);padding:8px 0}.ha-tabs.stuck .ha-idrow{display:block}.ha-tab.on .n{color:var(--lime)}
    .ha-tab:hover{color:var(--fg-primary)}
-   .ha-id{display:none;align-items:center;gap:10px;padding:0 18px 0 0;margin-right:6px;font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap}
-   .ha-tabs.stuck .ha-id{display:flex}
-   /* nav: lines = round 1, quiet = one dim hairline, bare = tint only */
+      /* nav: lines = round 1, quiet = one dim hairline, bare = tint only */
    .ha-nav-lines{border-top:1px solid var(--stroke);border-bottom:1px solid var(--stroke)}
    .ha-nav-lines .ha-tab{border-right:1px solid var(--stroke)}.ha-nav-lines .ha-tab:first-of-type{border-left:1px solid var(--stroke)}
    .ha-nav-quiet{border-bottom:1px solid oklch(0.55 0.01 256 / 0.25)}
-   .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:100px;margin-right:14px;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
+   .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:136px;margin:0;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
    .ha-nav-bare{background:${TINT4[1]}}.ha-nav-bare .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
    .ha-nav-bare.stuck{box-shadow:0 8px 24px oklch(0 0 0 / .35)}
-   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id,.ha-tabs .ha-price{display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{width:auto;margin-right:22px}}
+   @media(max-width:700px){.ha-tab .s{display:none}.ha-idrow>div>*:nth-child(n+3){display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{width:auto;padding-right:22px}}
    @media(max-width:820px){.ha-tiles{grid-template-columns:1fr 1fr;max-width:520px;min-width:0!important}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3;justify-content:flex-start}.ha-tiles .ha-up{flex:none!important}.ha-tiles>div:last-child{grid-column:1/3}.ha-left{min-height:0}.ha-tiles .kick{font-size:10px;letter-spacing:.15em}}
   <\/style>`;
 }

--- a/prototypes/stack-page-compact/template.html
+++ b/prototypes/stack-page-compact/template.html
@@ -55,6 +55,7 @@ hr.rule{border:0;border-top:1px solid var(--stroke)}
 <script>
 "use strict";
 const DATA = JSON.parse(document.getElementById("data").textContent);
+const _nm=new URLSearchParams(location.search).get("name");if(_nm)DATA.stack.name=_nm;
 const S = DATA.stack, U = DATA.usage, W = DATA.wf, P = DATA.projects;
 
 /* ---------- formatters (mirroring measured/copy.ts) ---------- */

--- a/prototypes/stack-page-compact/template.html
+++ b/prototypes/stack-page-compact/template.html
@@ -111,7 +111,7 @@ function measureAll(){
   for(const [k] of VARIANTS){probe.innerHTML=RENDER[k]();heights[k]=probe.scrollHeight;}
   probe.remove();
 }
-const KNOBS=[["title",["rail","num"]],["bands",["4","2"]],["name",["stats","usage"]],["rows",["acc","tabs"]],["top",["stack","side","merged","hero"]],["exp",["feature","grid","rows"]]];
+const KNOBS=[["title",["rail","num"]],["bands",["4","2"]],["name",["stats","usage"]],["rows",["acc","tabs"]],["top",["stack","side","merged","hero"]],["exp",["feature","grid","rows"]],["act",["stacked","tile","corner","chips"]],["rule",["dim","none","line"]],["lbl",["runs on","tools","none"]],["nav",["quiet","bare","lines"]]];
 function readOpts(){const p=new URLSearchParams(location.search);window.OPTS={};for(const [k,vals]of KNOBS)window.OPTS[k]=vals.includes(p.get(k))?p.get(k):vals[0];}
 function current(){const v=new URLSearchParams(location.search).get("v");return RENDER[v]?v:"v38";}
 function show(k,push){

--- a/prototypes/stack-page-compact/template.html
+++ b/prototypes/stack-page-compact/template.html
@@ -112,9 +112,9 @@ function measureAll(){
   for(const [k] of VARIANTS){probe.innerHTML=RENDER[k]();heights[k]=probe.scrollHeight;}
   probe.remove();
 }
-const KNOBS=[["title",["rail","num"]],["bands",["4","2"]],["name",["stats","usage"]],["rows",["acc","tabs"]],["top",["stack","side","merged","hero"]],["exp",["feature","grid","rows"]],["act",["tile","stacked","corner","chips"]],["rule",["none","dim2","dim","line"]],["lbl",["none","runs on","tools"]],["nav",["quiet","bare","lines"]]];
-const KNOBS_352=["act","rule","lbl","nav"];
-function readOpts(){const p=new URLSearchParams(location.search);window.OPTS={};for(const [k,vals]of KNOBS)window.OPTS[k]=vals.includes(p.get(k))?p.get(k):vals[0];}
+const KNOBS=[["title",["rail","num"]],["bands",["4","2"]],["name",["stats","usage"]],["rows",["acc","tabs"]],["top",["stack","side","merged","hero"]],["exp",["feature","grid","rows"]],["act",["tile","stacked","corner","chips"]],["rule",["none","dim2","dim","line"]],["lbl",["none","runs on","tools"]],["nav",["quiet","bare","lines"]],["win",["30d","7d","24h"]]];
+const KNOBS_352=["act","rule","lbl","nav"]; // win is set by the page's own dropdown
+function readOpts(){const p=new URLSearchParams(location.search);window.OPTS={};for(const [k,vals]of KNOBS)window.OPTS[k]=vals.includes(p.get(k))?p.get(k):vals[0];window.WIN_TXT={"30d":"last 30 days","7d":"last 7 days","24h":"last 24 hours"}[window.OPTS.win];}
 function current(){const v=new URLSearchParams(location.search).get("v");return RENDER[v]?v:"v38";}
 function show(k,push){
   readOpts();

--- a/prototypes/stack-page-compact/template.html
+++ b/prototypes/stack-page-compact/template.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>#351 · whole-page compact pass</title>
+<title>#352 · hero and subnav (over the #351 compact page)</title>
 <style>
 /* PROTOTYPE - throwaway (ticket alp82/aistack#351). Tokens copied from src/styles.css (dark). */
 :root{
@@ -44,7 +44,7 @@ hr.rule{border:0;border-top:1px solid var(--stroke)}
 </head>
 <body>
 <div id="proto-head">
-  <span><b>alp82/aistack#351</b> · whole-page compact pass</span>
+  <span><b>alp82/aistack#352</b> · hero and subnav, over the v37 page from #351</span>
   <span>Alper's Coding Stack · real prod data, 2026-08-30</span>
   <span id="hnote"></span>
 </div>
@@ -96,10 +96,11 @@ function phaseStrip(h){
 <script src="variants4.js"></script>
 <script src="variants5.js"></script>
 <script src="variants6.js"></script>
+<script src="variants7.js"></script>
 <script>
 /* ---------- switcher ---------- */
-const VARIANTS=[["base","Baseline (today)"],["v1","V1 Tight editorial"],["v2","V2 Ledger"],["v3","V3 Mosaic"],["v4","V4 Split rail"],["v5","V5 Digest"],["v6","V6 Magazine"],["v7","V7 Terminal"],["v8","V8 Bento"],["v9","V9 Billboard"],["v10","V10 Blueprint"],["v11","V11 Receipt"],["v12","V12 Ticker"],["v13","V13 Spine"],["v14","V14 Rails"],["v15","V15 Split hero"],["v16","V16 Magazine deep"],["v17","V17 Billboard data"],["v18","V18 Windows"],["v19","V19 Blueprint ed."],["v20","V20 Dossier"],["v21","V21 Chapters"],["v22","V22 Mural"],["v23","V23 Console pro"],["v24","V24 Feature table"],["v25","V25 Story scroll"],["v26","V26 Tonal 4"],["v27","V27 Rail + drawer"],["v28","V28 Distributed"],["v29","V29 Timeline"],["v30","V30 Quiet drawers"],["v31","V31 One moment"],["v32","V32 Simple+details"],["v33","V33 Tabs"],["v34","V34 Distributed"],["v35","V35 Two level"],["v36","V36 Grouped scan"],["v37","V37 Composed"]];
-const RENDER={base:renderBaseline,v1:renderV1,v2:renderV2,v3:renderV3,v4:renderV4,v5:renderV5,v6:renderV6,v7:renderV7,v8:renderV8,v9:renderV9,v10:renderV10,v11:renderV11,v12:renderV12,v13:renderV13,v14:renderV14,v15:renderV15,v16:renderV16,v17:renderV17,v18:renderV18,v19:renderV19,v20:renderV20,v21:renderV21,v22:renderV22,v23:renderV23,v24:renderV24,v25:renderV25,v26:renderV26,v27:renderV27,v28:renderV28,v29:renderV29,v30:renderV30,v31:renderV31,v32:renderV32,v33:renderV33,v34:renderV34,v35:renderV35,v36:renderV36,v37:renderV37};
+const VARIANTS=[["base","Baseline (today)"],["v1","V1 Tight editorial"],["v2","V2 Ledger"],["v3","V3 Mosaic"],["v4","V4 Split rail"],["v5","V5 Digest"],["v6","V6 Magazine"],["v7","V7 Terminal"],["v8","V8 Bento"],["v9","V9 Billboard"],["v10","V10 Blueprint"],["v11","V11 Receipt"],["v12","V12 Ticker"],["v13","V13 Spine"],["v14","V14 Rails"],["v15","V15 Split hero"],["v16","V16 Magazine deep"],["v17","V17 Billboard data"],["v18","V18 Windows"],["v19","V19 Blueprint ed."],["v20","V20 Dossier"],["v21","V21 Chapters"],["v22","V22 Mural"],["v23","V23 Console pro"],["v24","V24 Feature table"],["v25","V25 Story scroll"],["v26","V26 Tonal 4"],["v27","V27 Rail + drawer"],["v28","V28 Distributed"],["v29","V29 Timeline"],["v30","V30 Quiet drawers"],["v31","V31 One moment"],["v32","V32 Simple+details"],["v33","V33 Tabs"],["v34","V34 Distributed"],["v35","V35 Two level"],["v36","V36 Grouped scan"],["v37","V37 Composed"],["v38","V38 Masthead + tabs"],["v39","V39 Figures first"],["v40","V40 Contents + scrubber"]];
+const RENDER={base:renderBaseline,v1:renderV1,v2:renderV2,v3:renderV3,v4:renderV4,v5:renderV5,v6:renderV6,v7:renderV7,v8:renderV8,v9:renderV9,v10:renderV10,v11:renderV11,v12:renderV12,v13:renderV13,v14:renderV14,v15:renderV15,v16:renderV16,v17:renderV17,v18:renderV18,v19:renderV19,v20:renderV20,v21:renderV21,v22:renderV22,v23:renderV23,v24:renderV24,v25:renderV25,v26:renderV26,v27:renderV27,v28:renderV28,v29:renderV29,v30:renderV30,v31:renderV31,v32:renderV32,v33:renderV33,v34:renderV34,v35:renderV35,v36:renderV36,v37:renderV37,v38:renderV38,v39:renderV39,v40:renderV40};
 const page=document.getElementById("page");
 const heights={};
 function measureAll(){
@@ -112,15 +113,16 @@ function measureAll(){
 }
 const KNOBS=[["title",["rail","num"]],["bands",["4","2"]],["name",["stats","usage"]],["rows",["acc","tabs"]],["top",["stack","side","merged","hero"]],["exp",["feature","grid","rows"]]];
 function readOpts(){const p=new URLSearchParams(location.search);window.OPTS={};for(const [k,vals]of KNOBS)window.OPTS[k]=vals.includes(p.get(k))?p.get(k):vals[0];}
-function current(){const v=new URLSearchParams(location.search).get("v");return RENDER[v]?v:"v37";}
+function current(){const v=new URLSearchParams(location.search).get("v");return RENDER[v]?v:"v38";}
 function show(k,push){
   readOpts();
   page.innerHTML=RENDER[k]();
+  if(window.afterRender)afterRender();
   if(push){const u=new URL(location);u.searchParams.set("v",k);history.replaceState(null,"",u);}
   const bar=document.getElementById("switcher");
   bar.innerHTML=VARIANTS.map(([id,label])=>`<button class="${id===k?"on":""}" data-v="${id}" title="${label}">${label.split(" ")[0].replace("Baseline","Base")}</button>`).join("")+
-    (k==="v37"?KNOBS.map(([key,vals])=>{const cur=window.OPTS[key];const next=vals[(vals.indexOf(cur)+1)%vals.length];return `<button class="knob" data-k="${key}" data-next="${next}" style="border-left:1px solid var(--stroke);color:var(--lime)">${key}: ${cur}</button>`;}).join(""):"")+
-    `<span class="h" id="hread"></span>`;
+    (/^v(37|38|39|40)$/.test(k)?KNOBS.map(([key,vals])=>{const cur=window.OPTS[key];const next=vals[(vals.indexOf(cur)+1)%vals.length];return `<button class="knob" data-k="${key}" data-next="${next}" style="border-left:1px solid var(--stroke);color:var(--lime)">${key}: ${cur}</button>`;}).join(""):"")+
+    `<button class="knob" style="border-left:1px solid var(--stroke)" title="open this variant in a 390px window" onclick="open(location.href,'m352','width=390,height=780')">📱 390</button><span class="h" id="hread"></span>`;
   bar.querySelectorAll("button[data-v]").forEach(b=>b.onclick=()=>show(b.dataset.v,true));
   bar.querySelectorAll("button.knob").forEach(b=>b.onclick=()=>{const u=new URL(location);u.searchParams.set(b.dataset.k,b.dataset.next);history.replaceState(null,"",u);show(k,false);});
   const hn=document.getElementById("hnote");
@@ -128,7 +130,8 @@ function show(k,push){
   const ratio=heights.base?Math.round(heights[k]/heights.base*100):null;
   document.getElementById("hread").textContent=ratio?`${label} · ${ratio}% of baseline height`:label;
   hn.textContent=ratio?`${Math.round(heights[k]/100)/10}k px vs baseline ${Math.round(heights.base/100)/10}k px`:"";
-  window.scrollTo(0,0);
+  const y=Number(new URLSearchParams(location.search).get("y")||0);
+  window.scrollTo(0,y);
 }
 addEventListener("keydown",e=>{
   if(/INPUT|TEXTAREA/.test(document.activeElement.tagName))return;

--- a/prototypes/stack-page-compact/template.html
+++ b/prototypes/stack-page-compact/template.html
@@ -111,7 +111,8 @@ function measureAll(){
   for(const [k] of VARIANTS){probe.innerHTML=RENDER[k]();heights[k]=probe.scrollHeight;}
   probe.remove();
 }
-const KNOBS=[["title",["rail","num"]],["bands",["4","2"]],["name",["stats","usage"]],["rows",["acc","tabs"]],["top",["stack","side","merged","hero"]],["exp",["feature","grid","rows"]],["act",["stacked","tile","corner","chips"]],["rule",["dim","none","line"]],["lbl",["runs on","tools","none"]],["nav",["quiet","bare","lines"]]];
+const KNOBS=[["title",["rail","num"]],["bands",["4","2"]],["name",["stats","usage"]],["rows",["acc","tabs"]],["top",["stack","side","merged","hero"]],["exp",["feature","grid","rows"]],["act",["tile","stacked","corner","chips"]],["rule",["none","dim2","dim","line"]],["lbl",["none","runs on","tools"]],["nav",["quiet","bare","lines"]]];
+const KNOBS_352=["act","rule","lbl","nav"];
 function readOpts(){const p=new URLSearchParams(location.search);window.OPTS={};for(const [k,vals]of KNOBS)window.OPTS[k]=vals.includes(p.get(k))?p.get(k):vals[0];}
 function current(){const v=new URLSearchParams(location.search).get("v");return RENDER[v]?v:"v38";}
 function show(k,push){
@@ -120,9 +121,15 @@ function show(k,push){
   if(window.afterRender)afterRender();
   if(push){const u=new URL(location);u.searchParams.set("v",k);history.replaceState(null,"",u);}
   const bar=document.getElementById("switcher");
-  bar.innerHTML=VARIANTS.map(([id,label])=>`<button class="${id===k?"on":""}" data-v="${id}" title="${label}">${label.split(" ")[0].replace("Baseline","Base")}</button>`).join("")+
-    (/^v(37|38|39|40)$/.test(k)?KNOBS.map(([key,vals])=>{const cur=window.OPTS[key];const next=vals[(vals.indexOf(cur)+1)%vals.length];return `<button class="knob" data-k="${key}" data-next="${next}" style="border-left:1px solid var(--stroke);color:var(--lime)">${key}: ${cur}</button>`;}).join(""):"")+
+  const more=sessionStorage.getItem("more352")==="1";
+  const vBtns=VARIANTS.map(([id,label])=>`<button class="${id===k?"on":""}" data-v="${id}" title="${label}">${label.split(" ")[0].replace("Baseline","Base")}</button>`).join("");
+  const knobBtn=([key,vals])=>{const cur=window.OPTS[key];const next=vals[(vals.indexOf(cur)+1)%vals.length];return `<button class="knob" data-k="${key}" data-next="${next}" style="border-left:1px solid var(--stroke);color:var(--lime)">${key}: ${cur}</button>`;};
+  const mine=KNOBS.filter(([key])=>KNOBS_352.includes(key)), old=KNOBS.filter(([key])=>!KNOBS_352.includes(key));
+  bar.innerHTML=`<button id="more352" title="show every variant and the v37 toggles">${more?"less":"…"}</button>`+
+    (more?vBtns+old.map(knobBtn).join(""):`<span class="h" style="border:0">${k}</span>`)+
+    (/^v(37|38|39|40)$/.test(k)?mine.map(knobBtn).join(""):"")+
     `<button class="knob" style="border-left:1px solid var(--stroke)" title="open this variant in a 390px window" onclick="open(location.href,'m352','width=390,height=780')">📱 390</button><span class="h" id="hread"></span>`;
+  document.getElementById("more352").onclick=()=>{sessionStorage.setItem("more352",more?"0":"1");show(k,false);};
   bar.querySelectorAll("button[data-v]").forEach(b=>b.onclick=()=>show(b.dataset.v,true));
   bar.querySelectorAll("button.knob").forEach(b=>b.onclick=()=>{const u=new URL(location);u.searchParams.set(b.dataset.k,b.dataset.next);history.replaceState(null,"",u);show(k,false);});
   const hn=document.getElementById("hnote");

--- a/prototypes/stack-page-compact/variants5.js
+++ b/prototypes/stack-page-compact/variants5.js
@@ -27,7 +27,7 @@ function metricBlock(){
     <div style="position:relative;padding:12px">
       <button type="button" onclick="this.querySelector('i').textContent=FACTS[(++this.dataset.i)%FACTS.length]" data-i="0" style="all:unset;cursor:pointer;display:block">
         <span class="mono" style="font-size:clamp(44px,5.4vw,60px);font-weight:900;line-height:1;display:block">${fmtT(U.totalTokens)}</span>
-        <span class="kick muted" style="display:block;margin-top:8px">tokens · last 30 days</span>
+        <span class="kick muted" style="display:block;margin-top:8px">tokens · ${window.WIN_TXT||"last 30 days"}</span>
         <i class="mono small lime" style="display:block;font-style:normal;margin-top:4px">≈ tap for a fun fact</i>
       </button>
       <p class="mono small muted" style="margin-top:6px">${fmtT(FRESH)} fresh · ${fmtT(CACHED)} cached</p>

--- a/prototypes/stack-page-compact/variants6.js
+++ b/prototypes/stack-page-compact/variants6.js
@@ -19,8 +19,8 @@ function sec37(i,n,kick,title,meta,body){
   return `<section style="background:${bg};padding:48px 0"><div style="max-width:1280px;margin:0 auto;padding:0 24px">
     <div style="display:grid;grid-template-columns:170px 1fr;gap:40px" class="rl2">
       <div><div class="mono" style="font-size:48px;font-weight:900;color:var(--lime);line-height:1">${n}</div>
-        <p class="kick lime" style="margin-top:8px">${kick}</p>
-        <h2 style="font-size:21px;font-weight:900;text-transform:uppercase;letter-spacing:-.01em;margin-top:2px">${title}</h2>
+        ${kick?`<p class="kick lime" style="margin-top:8px">${kick}</p>`:""}
+        <h2 style="font-size:21px;font-weight:900;text-transform:uppercase;letter-spacing:-.01em;margin-top:${kick?"2px":"10px"}">${title}</h2>
         <p class="mono small muted" style="margin-top:12px;line-height:1.7">${meta||""}</p></div>
       <div style="min-width:0">${body}</div>
     </div></div></section>`;

--- a/prototypes/stack-page-compact/variants7.js
+++ b/prototypes/stack-page-compact/variants7.js
@@ -96,8 +96,9 @@ function heroA(){
   </div></section>
   <nav id="ha-tabs" class="ha-tabs ha-nav-${nav}" aria-label="Sections">
    <div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:stretch;overflow-x:auto">
-    <span class="ha-id"><b>${esc(S.name)}</b><span class="lime mono" style="font-size:11px">${priceMo(S.price)}</span></span>
-    ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="lab"><span class="n">${s.n}</span><span class="t">${s.title}</span></span><span class="s">${s.stat}</span></a>`).join("")}
+    <span class="ha-id"><b>${esc(S.name)}</b></span>
+    ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="lab"><span class="n">${s.n}</span><span class="t">${s.title}</span></span><span class="s">${s.stat}</span><span class="vis"></span></a>`).join("")}
+    <span class="ha-price lime mono" style="font-size:11px;font-weight:700">${priceMo(S.price)}</span>
    </div>
   </nav>
   <style>
@@ -110,10 +111,12 @@ function heroA(){
    .ha-ghost:hover{border-color:var(--fg-secondary)}
    .ha-quiet{font-family:var(--mono);font-size:11px;color:var(--fg-muted);text-decoration:underline dotted;text-underline-offset:3px}.ha-quiet:hover{color:oklch(0.75 0.15 60)}
    .ha-tabs{position:sticky;top:var(--ptop,0px);z-index:30;background:${TINT4[0]}}
-   .ha-tab{display:flex;align-items:baseline;gap:10px;padding:0 18px;white-space:nowrap;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--fg-muted);box-shadow:inset 0 -3px 0 transparent}
+   .ha-tab{position:relative;display:flex;align-items:baseline;gap:10px;padding:0 18px;white-space:nowrap;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--fg-muted);box-shadow:inset 0 -3px 0 transparent}
    .ha-tab .n{color:var(--stroke-strong)}.ha-tab .s{font-weight:400;letter-spacing:.04em;text-transform:none;font-size:11px}
    .ha-tab .lab{display:inline-flex;gap:10px;align-items:baseline;padding:14px 0 12px;box-shadow:inset 0 -3px 0 transparent}
-   .ha-tab.on{color:var(--lime)}.ha-nav-lines .ha-tab.on{box-shadow:inset 0 -3px 0 var(--lime)}.ha-nav-quiet .ha-tab.on,.ha-nav-bare .ha-tab.on{box-shadow:inset 0 -3px 0 var(--lime)}.ha-tab.on .n{color:var(--lime)}
+   .ha-tab.on{color:var(--lime)}.ha-nav-lines .ha-tab.on{box-shadow:inset 0 -3px 0 var(--lime)}
+   .ha-tab .vis{position:absolute;left:0;bottom:0;height:3px;width:0;background:var(--lime)}
+   .ha-price{display:none;align-items:center;margin-left:auto;padding-left:18px;white-space:nowrap}.ha-tabs.stuck .ha-price{display:flex}.ha-tab.on .n{color:var(--lime)}
    .ha-tab:hover{color:var(--fg-primary)}
    .ha-id{display:none;align-items:center;gap:10px;padding:0 18px 0 0;margin-right:6px;font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap}
    .ha-tabs.stuck .ha-id{display:flex}
@@ -121,10 +124,10 @@ function heroA(){
    .ha-nav-lines{border-top:1px solid var(--stroke);border-bottom:1px solid var(--stroke)}
    .ha-nav-lines .ha-tab{border-right:1px solid var(--stroke)}.ha-nav-lines .ha-tab:first-of-type{border-left:1px solid var(--stroke)}
    .ha-nav-quiet{border-bottom:1px solid oklch(0.55 0.01 256 / 0.25)}
-   .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:150px;margin-right:20px;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
+   .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:100px;margin-right:14px;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
    .ha-nav-bare{background:${TINT4[1]}}.ha-nav-bare .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
    .ha-nav-bare.stuck{box-shadow:0 8px 24px oklch(0 0 0 / .35)}
-   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id{display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{width:auto;margin-right:22px}}
+   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id,.ha-tabs .ha-price{display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{width:auto;margin-right:22px}}
    @media(max-width:820px){.ha-tiles{grid-template-columns:1fr 1fr;max-width:520px;min-width:0!important}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3;justify-content:flex-start}.ha-tiles .ha-up{flex:none!important}.ha-tiles>div:last-child{grid-column:1/3}.ha-left{min-height:0}.ha-tiles .kick{font-size:10px;letter-spacing:.15em}}
   </style>`;
 }
@@ -246,7 +249,11 @@ window.afterRender=function(){
     spyLinks.forEach(a=>a.classList.toggle("on",a.dataset.spy===cur));
     const heroGone=hero.getBoundingClientRect().bottom<ptop;
     const tabs=document.getElementById("ha-tabs");
-    if(tabs)tabs.classList.toggle("stuck",tabs.getBoundingClientRect().top<=ptop+1);
+    if(tabs){tabs.classList.toggle("stuck",tabs.getBoundingClientRect().top<=ptop+1);
+      const vpTop=scrollY+ptop+tabs.offsetHeight,vpBot=scrollY+innerHeight;
+      tabs.querySelectorAll(".ha-tab").forEach(a=>{const s=document.getElementById(a.dataset.spy);if(!s)return;
+        const st=Math.min(1,Math.max(0,(vpTop-s.offsetTop)/s.offsetHeight)),en=Math.min(1,Math.max(0,(vpBot-s.offsetTop)/s.offsetHeight));
+        const vis=a.querySelector(".vis");vis.style.left=(st*100).toFixed(1)+"%";vis.style.width=(Math.max(0,en-st)*100).toFixed(1)+"%";});}
     const rail=document.getElementById("hb-rail");
     if(rail){rail.classList.toggle("shown",heroGone);const p=scrollY/Math.max(1,document.documentElement.scrollHeight-innerHeight);document.getElementById("hb-fill").style.height=(p*100).toFixed(1)+"%";}
     const bar=document.getElementById("hc-bar");

--- a/prototypes/stack-page-compact/variants7.js
+++ b/prototypes/stack-page-compact/variants7.js
@@ -40,7 +40,7 @@ function body352(){
     sec37(3,"03","","Tools",`${S.tools.length} tools · ${priceMo(S.price)}`,toolsBodyV16())+
     sec37(0,"04","","Guide",guideMin+" min read",guideBodyV16());
   return html.replace(/<section /g,()=>`<section id="${ids[i++]}" `)+ctaStrip()+MEDIA_G2+
-    `<style>[id^="s-"]{scroll-margin-top:calc(var(--ptop,0px) + 48px)}</style>`;
+    `<style>[id^="s-"]{scroll-margin-top:calc(var(--ptop,0px) + 88px)}</style>`;
 }
 
 /* shared identity bits */
@@ -95,10 +95,15 @@ function heroA(){
    </div>
   </div></section>
   <nav id="ha-tabs" class="ha-tabs ha-nav-${nav}" aria-label="Sections">
+   <div class="ha-idrow"><div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:22px;overflow:hidden">
+     ${avatar352(22)}<b style="font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap">${esc(S.name)}</b>
+     <span class="mono small muted" style="white-space:nowrap">${esc(S.creator.name)}</span>
+     <span class="mono small" style="margin-left:auto;white-space:nowrap"><span class="lime" style="font-weight:700">${priceMo(S.price)}</span></span>
+     <span class="mono small" style="display:inline-flex;align-items:center;gap:8px;white-space:nowrap"><span style="width:90px;display:inline-block">${spark(U.series,400,18)}</span><b>${fmtT(U.totalTokens)}</b> <span class="muted">tokens · 30d</span></span>
+     <span class="mono small muted" style="white-space:nowrap">▲ ${UPVOTES}</span>
+   </div></div>
    <div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:stretch;overflow-x:auto">
-    <span class="ha-id"><b>${esc(S.name)}</b></span>
     ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="lab"><span class="n">${s.n}</span><span class="t">${s.title}</span></span><span class="s">${s.stat}</span><span class="vis"></span></a>`).join("")}
-    <span class="ha-price lime mono" style="font-size:11px;font-weight:700">${priceMo(S.price)}</span>
    </div>
   </nav>
   <style>
@@ -116,18 +121,16 @@ function heroA(){
    .ha-tab .lab{display:inline-flex;gap:10px;align-items:baseline;padding:14px 0 12px;box-shadow:inset 0 -3px 0 transparent}
    .ha-tab.on{color:var(--lime)}.ha-nav-lines .ha-tab.on{box-shadow:inset 0 -3px 0 var(--lime)}
    .ha-tab .vis{position:absolute;left:0;bottom:0;height:3px;width:0;background:var(--lime)}
-   .ha-price{display:none;align-items:center;margin-left:auto;padding-left:18px;white-space:nowrap}.ha-tabs.stuck .ha-price{display:flex}.ha-tab.on .n{color:var(--lime)}
+   .ha-idrow{display:none;border-bottom:1px solid oklch(0.55 0.01 256 / 0.18);padding:8px 0}.ha-tabs.stuck .ha-idrow{display:block}.ha-tab.on .n{color:var(--lime)}
    .ha-tab:hover{color:var(--fg-primary)}
-   .ha-id{display:none;align-items:center;gap:10px;padding:0 18px 0 0;margin-right:6px;font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap}
-   .ha-tabs.stuck .ha-id{display:flex}
-   /* nav: lines = round 1, quiet = one dim hairline, bare = tint only */
+      /* nav: lines = round 1, quiet = one dim hairline, bare = tint only */
    .ha-nav-lines{border-top:1px solid var(--stroke);border-bottom:1px solid var(--stroke)}
    .ha-nav-lines .ha-tab{border-right:1px solid var(--stroke)}.ha-nav-lines .ha-tab:first-of-type{border-left:1px solid var(--stroke)}
    .ha-nav-quiet{border-bottom:1px solid oklch(0.55 0.01 256 / 0.25)}
-   .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:100px;margin-right:14px;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
+   .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:136px;margin:0;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
    .ha-nav-bare{background:${TINT4[1]}}.ha-nav-bare .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
    .ha-nav-bare.stuck{box-shadow:0 8px 24px oklch(0 0 0 / .35)}
-   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id,.ha-tabs .ha-price{display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{width:auto;margin-right:22px}}
+   @media(max-width:700px){.ha-tab .s{display:none}.ha-idrow>div>*:nth-child(n+3){display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{width:auto;padding-right:22px}}
    @media(max-width:820px){.ha-tiles{grid-template-columns:1fr 1fr;max-width:520px;min-width:0!important}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3;justify-content:flex-start}.ha-tiles .ha-up{flex:none!important}.ha-tiles>div:last-child{grid-column:1/3}.ha-left{min-height:0}.ha-tiles .kick{font-size:10px;letter-spacing:.15em}}
   </style>`;
 }

--- a/prototypes/stack-page-compact/variants7.js
+++ b/prototypes/stack-page-compact/variants7.js
@@ -283,7 +283,8 @@ window.afterRender=function(){
     while(h1.offsetHeight>2*s*.88*1.05&&s>MIN){s-=2;h1.style.fontSize=s+"px";}
   };
   document.querySelectorAll("#ha-tabs .ha-tab").forEach(a=>a.addEventListener("click",e=>{const t=document.getElementById(a.dataset.spy);if(!t)return;e.preventDefault();const nav=document.getElementById("ha-tabs");const ptop=ptopOf();
-    const y=Math.max(nav.offsetTop-ptop,t.offsetTop-ptop-88);scrollTo({top:y,behavior:"smooth"});history.replaceState(null,"","#"+t.id);}));
+    const navTop=hero.offsetTop+hero.offsetHeight; /* nav.offsetTop reports the STUCK position while stuck */
+    const y=Math.max(navTop-ptop,t.offsetTop-ptop-88);scrollTo({top:y,behavior:"smooth"});history.replaceState(null,"","#"+t.id);}));
   const idrow=document.querySelector("#ha-tabs .ha-idrow");if(idrow)idrow.addEventListener("click",()=>scrollTo({top:0,behavior:"smooth"}));
   fitTitle();onScroll();
   const onResize=()=>{fitTitle();onScroll();};

--- a/prototypes/stack-page-compact/variants7.js
+++ b/prototypes/stack-page-compact/variants7.js
@@ -35,7 +35,7 @@ function body352(){
   const rows=OPT("rows")==="tabs"?`<div style="margin-top:36px">${cssTabs("t37")}</div>`:`<div style="margin-top:36px">${statsAccordion()}</div>`;
   const ids=["s-stats","s-projects","s-tools","s-guide"];
   let i=0;
-  const html=sec37(1,"01","// sync",name,`30d · all machines<br>checked ${readCheckedAgo}`,statsTop37()+rows)+
+  const html=sec37(1,"01","// sync",name,`30d · all machines<br>updated ${readCheckedAgo}`,statsTop37()+rows)+
     sec37(2,"02","// showcase","Projects",P.length+" projects",projGridV16())+
     sec37(3,"03","// ai components","Tools",`${S.tools.length} tools · ${priceMo(S.price)}`,toolsBodyV16())+
     sec37(0,"04","// writeup","Guide",guideMin+" min read",guideBodyV16());
@@ -54,15 +54,29 @@ const actions352=()=>`<span class="chip" style="cursor:pointer">▲ ${UPVOTES}</
 function heroA(){
   const sec=sections352();
   const shown=8;
+  const act=OPT("act"), rule=OPT("rule"), lbl=OPT("lbl"), nav=OPT("nav");
+  const ruleCss=rule==="line"?"border-top:1px solid var(--stroke)":rule==="dim"?"border-top:1px solid oklch(0.55 0.01 256 / 0.25)":"";
+  const label=lbl==="runs on"?"runs on":lbl==="tools"?`${S.tools.length} tools`:"";
+  /* the three actions, arranged by importance: upvote > share > report */
+  const btnUp=`<button class="ha-up" type="button"><span class="tri">▲</span> Upvote <b>${UPVOTES}</b></button>`;
+  const btnShare=`<button class="ha-ghost" type="button">Share</button>`;
+  const lnkReport=`<a class="ha-quiet" href="#">Report</a>`;
+  const actionsUnderTitle=act==="stacked"?`<div style="display:flex;gap:10px;margin-top:22px;align-items:center">${btnUp}${btnShare}</div>`:
+    act==="chips"?`<div style="display:flex;gap:6px;margin-top:20px">${actions352()}</div>`:"";
+  const actionsInColumn=act==="tile"?`<div style="display:flex;gap:8px;align-items:stretch">${btnUp.replace('class="ha-up"','class="ha-up" style="flex:1;justify-content:center"')}${btnShare}</div>`:"";
+  const actionsTopRight=act==="corner"?`<div style="display:flex;gap:8px;align-items:center">${btnUp}${btnShare}</div>`:"";
+  const reportSlot=act==="chips"?"":`<span style="margin-left:auto;display:flex;gap:16px;align-items:center" class="mono small muted"><span>updated ${readCheckedAgo}</span>${lnkReport}</span>`;
   return `<section style="background:${TINT4[0]};padding:56px 0 36px"><div style="max-width:1280px;margin:0 auto;padding:0 24px">
+   ${act==="corner"?`<div style="display:flex;justify-content:flex-end;margin:-24px 0 8px">${actionsTopRight}</div>`:""}
    <div style="display:grid;grid-template-columns:1fr auto;gap:40px;align-items:end" class="g2">
     <div style="min-width:0">
       <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">${avatar352(40)}${byline352()}</div>
       <h1 style="font-size:clamp(44px,7vw,88px);font-weight:900;line-height:.88;letter-spacing:-.03em;text-transform:uppercase;margin-top:20px">${esc(S.name)}</h1>
       <p style="margin-top:16px;font-size:18px;color:var(--fg-secondary);max-width:560px">${esc(S.oneLiner)}</p>
-      <div style="display:flex;gap:6px;margin-top:20px">${actions352()}</div>
+      ${actionsUnderTitle}
     </div>
     <div style="display:grid;gap:10px;min-width:260px" class="ha-tiles">
+      ${actionsInColumn}
       <div style="background:var(--lime);color:var(--lime-contrast);padding:18px 20px;box-shadow:4px 4px 0 var(--stroke-strong);cursor:help" title="authored: tools and bundles at list prices">
         <div class="mono" style="font-size:40px;font-weight:900;line-height:1">${price(S.price)}</div>
         <div class="kick" style="margin-top:6px;opacity:.8">per month · solo</div>
@@ -74,26 +88,38 @@ function heroA(){
       </a>
     </div>
    </div>
-   <a href="#s-tools" style="display:flex;align-items:center;gap:8px;margin-top:32px;padding-top:20px;border-top:1px solid var(--stroke);flex-wrap:wrap">
-     <span class="kick muted" style="margin-right:8px">built with</span>${toolsSorted.slice(0,shown).map(t=>toolIcn(t,28)).join("")}<span class="chip">+${S.tools.length-shown}</span>
-     <span class="mono small muted" style="margin-left:auto">checked ${readCheckedAgo}</span>
-   </a>
+   <div style="display:flex;align-items:center;gap:8px;margin-top:${rule==="none"?"36px":"32px"};padding-top:${rule==="none"?"0":"20px"};${ruleCss};flex-wrap:wrap">
+     ${label?`<span class="kick muted" style="margin-right:8px">${label}</span>`:""}<a href="#s-tools" style="display:flex;gap:8px;align-items:center">${toolsSorted.slice(0,shown).map(t=>toolIcn(t,28)).join("")}<span class="chip" style="border-color:oklch(0.55 0.01 256 / 0.35)">+${S.tools.length-shown}</span></a>
+     ${reportSlot||`<span class="mono small muted" style="margin-left:auto">updated ${readCheckedAgo}</span>`}
+   </div>
   </div></section>
-  <nav id="ha-tabs" class="ha-tabs" aria-label="Sections">
+  <nav id="ha-tabs" class="ha-tabs ha-nav-${nav}" aria-label="Sections">
    <div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:stretch;overflow-x:auto">
     <span class="ha-id"><b>${esc(S.name)}</b><span class="lime mono" style="font-size:11px">${priceMo(S.price)}</span></span>
     ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="n">${s.n}</span><span class="t">${s.title}</span><span class="s">${s.stat}</span></a>`).join("")}
    </div>
   </nav>
   <style>
-   .ha-tabs{position:sticky;top:var(--ptop,0px);z-index:30;background:${TINT4[0]};border-bottom:1px solid var(--stroke);border-top:1px solid var(--stroke)}
-   .ha-tab{display:flex;align-items:baseline;gap:10px;padding:14px 18px 12px;border-right:1px solid var(--stroke);white-space:nowrap;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--fg-muted);box-shadow:inset 0 -3px 0 transparent}
-   .ha-tab:first-of-type{border-left:1px solid var(--stroke)}
+   .ha-up{display:inline-flex;align-items:center;gap:8px;background:none;border:1px solid var(--lime);color:var(--lime);font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;padding:10px 16px;cursor:pointer}
+   .ha-up:hover{background:var(--lime);color:var(--lime-contrast)}.ha-up .tri{font-size:10px}.ha-up b{font-weight:900}
+   .ha-ghost{display:inline-flex;align-items:center;background:none;border:1px solid var(--stroke);color:var(--fg-secondary);font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;padding:10px 16px;cursor:pointer}
+   .ha-ghost:hover{border-color:var(--fg-secondary)}
+   .ha-quiet{font-family:var(--mono);font-size:11px;color:var(--fg-muted);text-decoration:underline dotted;text-underline-offset:3px}.ha-quiet:hover{color:oklch(0.75 0.15 60)}
+   .ha-tabs{position:sticky;top:var(--ptop,0px);z-index:30;background:${TINT4[0]}}
+   .ha-tab{display:flex;align-items:baseline;gap:10px;padding:14px 18px 12px;white-space:nowrap;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--fg-muted);box-shadow:inset 0 -3px 0 transparent}
    .ha-tab .n{color:var(--stroke-strong)}.ha-tab .s{font-weight:400;letter-spacing:.04em;text-transform:none;font-size:11px}
    .ha-tab.on{color:var(--lime);box-shadow:inset 0 -3px 0 var(--lime)}.ha-tab.on .n{color:var(--lime)}
+   .ha-tab:hover{color:var(--fg-primary)}
    .ha-id{display:none;align-items:center;gap:10px;padding:0 18px 0 0;margin-right:6px;font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap}
    .ha-tabs.stuck .ha-id{display:flex}
-   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id{display:none!important}.ha-tab{padding:12px 14px}.ha-tiles{grid-template-columns:1fr 1fr}}
+   /* nav: lines = round 1, quiet = one dim hairline, bare = tint only */
+   .ha-nav-lines{border-top:1px solid var(--stroke);border-bottom:1px solid var(--stroke)}
+   .ha-nav-lines .ha-tab{border-right:1px solid var(--stroke)}.ha-nav-lines .ha-tab:first-of-type{border-left:1px solid var(--stroke)}
+   .ha-nav-quiet{border-bottom:1px solid oklch(0.55 0.01 256 / 0.25)}
+   .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
+   .ha-nav-bare{background:${TINT4[1]}}.ha-nav-bare .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
+   .ha-nav-bare.stuck{box-shadow:0 8px 24px oklch(0 0 0 / .35)}
+   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id{display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{margin-right:20px}.ha-tiles{grid-template-columns:1fr 1fr}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3}}
   </style>`;
 }
 
@@ -125,7 +151,7 @@ function heroB(){
     <p style="font-size:clamp(20px,2.4vw,30px);line-height:1.3;max-width:900px;margin:36px 0 0;font-weight:500">${esc(S.oneLiner)}</p>
     <div style="margin-top:32px;border-top:1px solid var(--stroke);display:flex;gap:20px;flex-wrap:wrap;padding:12px 0" class="mono small muted">
       <span><b class="sec2">${num(U.sessions)}</b> sessions</span><span><b class="sec2">${U.activeDays}/30</b> days</span><span><b class="sec2">${W.lead.harnesses}</b> harnesses</span>
-      <span style="margin-left:auto">checked ${readCheckedAgo}</span></div>
+      <span style="margin-left:auto">updated ${readCheckedAgo}</span></div>
   </div></section>
   <nav id="hb-rail" class="hb-rail" aria-label="Sections">
     <div class="hb-line"><span id="hb-fill"></span></div>
@@ -169,7 +195,7 @@ function heroC(){
         <span class="mono" style="font-size:12px;font-weight:900;color:var(--stroke-strong)">${s.n}</span>
         <span><b style="font-size:15px;text-transform:uppercase;letter-spacing:-.01em">${s.title}</b><br><span class="small sec2">${s.line}</span></span>
         <span class="lime">↓</span></a>`).join("")}
-      <p class="mono small muted" style="padding:12px 20px 0">checked ${readCheckedAgo}</p>
+      <p class="mono small muted" style="padding:12px 20px 0">updated ${readCheckedAgo}</p>
     </div>
    </div>
   </div></section>

--- a/prototypes/stack-page-compact/variants7.js
+++ b/prototypes/stack-page-compact/variants7.js
@@ -1,0 +1,228 @@
+/* PROTOTYPE - throwaway (ticket alp82/aistack#352). Round 1: three hero and
+   subnav pairs, each rendered over the accepted v37 body from #351. The body
+   is unchanged; only the top of the page and the section navigation differ.
+
+   v38 Masthead + tabs   identity left, two promise tiles right (authored price,
+                         measured tokens), logo strip; sticky tab bar with the
+                         four section stats, identity appears once stuck.
+   v39 Figures first     the four section figures ARE the hero, each a link;
+                         the one-liner follows; a vertical progress rail on wide
+                         screens, a sticky figure strip everywhere else.
+   v40 Contents          name and one-liner left, a "in this stack" ladder
+                         right with one sentence per section; a reading scrubber
+                         pinned under the header, segments sized by section. */
+"use strict";
+
+const UPVOTES=12; // not in slim.json; the demo's stand-in, as in heroV16
+
+/* The four sections of the v37 body, with the anchor ids body352() stamps. */
+function sections352(){
+  return [
+    {n:"01",id:"s-stats",title:OPT("name")==="usage"?"Actual Usage":"Stats",stat:`${fmtT(U.totalTokens)} tokens`,
+     line:`${fmtT(U.totalTokens)} tokens in 30 days, ${num(U.sessions)} sessions on ${W.lead.harnesses} harnesses`},
+    {n:"02",id:"s-projects",title:"Projects",stat:`${P.length} projects`,
+     line:`${P.length} projects, ${num(W.git.commits)} commits in the last 30 days`},
+    {n:"03",id:"s-tools",title:"Tools",stat:`${S.tools.length} tools · ${priceMo(S.price)}`,
+     line:`${S.tools.length} tools for ${priceMo(S.price)}, ${esc(toolsSorted[0].name)} and ${esc(toolsSorted[1].name)} cost the most`},
+    {n:"04",id:"s-guide",title:"Guide",stat:`${guideMin} min read`,
+     line:`${num(S.guide.words)} words by ${esc(S.creator.name.split(" ")[0])}, ${guideMin} min read`},
+  ];
+}
+
+/* The v37 body (everything under the hero), with an id on each section. */
+function body352(){
+  const name=OPT("name")==="usage"?"Actual Usage":"Stats";
+  const rows=OPT("rows")==="tabs"?`<div style="margin-top:36px">${cssTabs("t37")}</div>`:`<div style="margin-top:36px">${statsAccordion()}</div>`;
+  const ids=["s-stats","s-projects","s-tools","s-guide"];
+  let i=0;
+  const html=sec37(1,"01","// sync",name,`30d · all machines<br>checked ${readCheckedAgo}`,statsTop37()+rows)+
+    sec37(2,"02","// showcase","Projects",P.length+" projects",projGridV16())+
+    sec37(3,"03","// ai components","Tools",`${S.tools.length} tools · ${priceMo(S.price)}`,toolsBodyV16())+
+    sec37(0,"04","// writeup","Guide",guideMin+" min read",guideBodyV16());
+  return html.replace(/<section /g,()=>`<section id="${ids[i++]}" `)+ctaStrip()+MEDIA_G2+
+    `<style>[id^="s-"]{scroll-margin-top:calc(var(--ptop,0px) + 48px)}</style>`;
+}
+
+/* shared identity bits */
+const avatar352=px=>`<img src="${S.creator.avatar}" alt="" width="${px}" height="${px}" style="display:block;object-fit:cover;flex:none">`;
+const byline352=()=>`<span class="mono small"><b class="sec2">${esc(S.creator.name)}</b> <span class="muted">@${esc(S.creator.handle)}</span></span><span class="small lime">✓ verified</span>`;
+const actions352=()=>`<span class="chip" style="cursor:pointer">▲ ${UPVOTES}</span><span class="chip" style="cursor:pointer">Share</span><span class="chip" style="cursor:pointer">Report</span>`;
+
+/* =========================================================================
+   V38 MASTHEAD + TABS
+   ========================================================================= */
+function heroA(){
+  const sec=sections352();
+  const shown=8;
+  return `<section style="background:${TINT4[0]};padding:56px 0 36px"><div style="max-width:1280px;margin:0 auto;padding:0 24px">
+   <div style="display:grid;grid-template-columns:1fr auto;gap:40px;align-items:end" class="g2">
+    <div style="min-width:0">
+      <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">${avatar352(40)}${byline352()}</div>
+      <h1 style="font-size:clamp(44px,7vw,88px);font-weight:900;line-height:.88;letter-spacing:-.03em;text-transform:uppercase;margin-top:20px">${esc(S.name)}</h1>
+      <p style="margin-top:16px;font-size:18px;color:var(--fg-secondary);max-width:560px">${esc(S.oneLiner)}</p>
+      <div style="display:flex;gap:6px;margin-top:20px">${actions352()}</div>
+    </div>
+    <div style="display:grid;gap:10px;min-width:260px" class="ha-tiles">
+      <div style="background:var(--lime);color:var(--lime-contrast);padding:18px 20px;box-shadow:4px 4px 0 var(--stroke-strong);cursor:help" title="authored: tools and bundles at list prices">
+        <div class="mono" style="font-size:40px;font-weight:900;line-height:1">${price(S.price)}</div>
+        <div class="kick" style="margin-top:6px;opacity:.8">per month · solo</div>
+      </div>
+      <a href="#s-stats" style="position:relative;border:1px solid var(--stroke);padding:18px 20px;display:block;overflow:hidden" title="measured: tokens across all machines, last 30 days">
+        <div style="position:absolute;inset:0;opacity:.15;pointer-events:none" aria-hidden="true">${spark(U.series,400,80)}</div>
+        <div class="mono" style="font-size:40px;font-weight:900;line-height:1;position:relative">${fmtT(U.totalTokens)}</div>
+        <div class="kick muted" style="margin-top:6px;position:relative">tokens · 30 days · <span class="lime">${UP} ×${(U.totalTokens/U.prevTokens).toFixed(0)}</span></div>
+      </a>
+    </div>
+   </div>
+   <a href="#s-tools" style="display:flex;align-items:center;gap:8px;margin-top:32px;padding-top:20px;border-top:1px solid var(--stroke);flex-wrap:wrap">
+     <span class="kick muted" style="margin-right:8px">built with</span>${toolsSorted.slice(0,shown).map(t=>toolIcn(t,28)).join("")}<span class="chip">+${S.tools.length-shown}</span>
+     <span class="mono small muted" style="margin-left:auto">checked ${readCheckedAgo}</span>
+   </a>
+  </div></section>
+  <nav id="ha-tabs" class="ha-tabs" aria-label="Sections">
+   <div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:stretch;overflow-x:auto">
+    <span class="ha-id"><b>${esc(S.name)}</b><span class="lime mono" style="font-size:11px">${priceMo(S.price)}</span></span>
+    ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="n">${s.n}</span><span class="t">${s.title}</span><span class="s">${s.stat}</span></a>`).join("")}
+   </div>
+  </nav>
+  <style>
+   .ha-tabs{position:sticky;top:var(--ptop,0px);z-index:30;background:${TINT4[0]};border-bottom:1px solid var(--stroke);border-top:1px solid var(--stroke)}
+   .ha-tab{display:flex;align-items:baseline;gap:10px;padding:14px 18px 12px;border-right:1px solid var(--stroke);white-space:nowrap;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--fg-muted);box-shadow:inset 0 -3px 0 transparent}
+   .ha-tab:first-of-type{border-left:1px solid var(--stroke)}
+   .ha-tab .n{color:var(--stroke-strong)}.ha-tab .s{font-weight:400;letter-spacing:.04em;text-transform:none;font-size:11px}
+   .ha-tab.on{color:var(--lime);box-shadow:inset 0 -3px 0 var(--lime)}.ha-tab.on .n{color:var(--lime)}
+   .ha-id{display:none;align-items:center;gap:10px;padding:0 18px 0 0;margin-right:6px;font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap}
+   .ha-tabs.stuck .ha-id{display:flex}
+   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id{display:none!important}.ha-tab{padding:12px 14px}.ha-tiles{grid-template-columns:1fr 1fr}}
+  </style>`;
+}
+
+/* =========================================================================
+   V39 FIGURES FIRST
+   ========================================================================= */
+function heroB(){
+  const sec=sections352();
+  const figs=[
+    {s:sec[0],big:fmtT(U.totalTokens),unit:"tokens · 30 days",viz:spark(U.series,400,60)},
+    {s:sec[1],big:String(P.length),unit:`projects · ${num(W.git.commits)} commits`,viz:gitBars(56)},
+    {s:sec[2],big:String(S.tools.length),unit:`tools · ${priceMo(S.price)}`,viz:`<div style="display:flex;gap:4px;flex-wrap:wrap;padding:10px 20px 0">${toolsSorted.slice(0,8).map(t=>toolIcn(t,22)).join("")}</div>`},
+    {s:sec[3],big:`${guideMin}<span style="font-size:.4em;margin-left:4px">MIN</span>`,unit:"guide by the author",viz:`<div style="display:grid;gap:6px;padding:10px 20px 0">${[1,.8,.9,.6,.85].map(w=>`<span style="height:4px;width:${w*100}%;background:var(--fg-muted)"></span>`).join("")}</div>`},
+  ];
+  const plain=h=>h.replace(/<[^>]*>/g," ");
+  return `<section style="background:${TINT4[0]};padding:40px 0 0"><div style="max-width:1280px;margin:0 auto;padding:0 24px">
+    <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">
+      ${avatar352(28)}<span class="mono" style="font-size:13px;font-weight:900;text-transform:uppercase;letter-spacing:.08em">${esc(S.name)}</span>
+      <span class="mono small muted">by ${esc(S.creator.name)} @${esc(S.creator.handle)}</span>
+      <span style="margin-left:auto;display:flex;gap:6px">${actions352()}</span></div>
+    <div class="hb-grid" style="display:grid;grid-template-columns:repeat(4,1fr);margin-top:36px;border:1px solid var(--stroke)">
+      ${figs.map(f=>`<a href="#${f.s.id}" class="hb-fig" style="position:relative;padding:22px 20px 64px;border-right:1px solid var(--stroke);overflow:hidden;display:block;min-width:0">
+        <div style="position:absolute;left:0;right:0;bottom:0;height:44px;opacity:.16;pointer-events:none" aria-hidden="true">${f.viz}</div>
+        <div class="kick lime" style="position:relative"><span style="color:var(--stroke-strong)">${f.s.n}</span> ${f.s.title}</div>
+        <div class="mono" style="font-size:clamp(44px,5.4vw,72px);font-weight:900;line-height:1;margin-top:14px;position:relative">${f.big}</div>
+        <div class="kick muted" style="margin-top:8px;position:relative">${f.unit}</div>
+        <span class="lime" style="position:absolute;right:16px;top:18px">↓</span></a>`).join("")}
+    </div>
+    <p style="font-size:clamp(20px,2.4vw,30px);line-height:1.3;max-width:900px;margin:36px 0 0;font-weight:500">${esc(S.oneLiner)}</p>
+    <div style="margin-top:32px;border-top:1px solid var(--stroke);display:flex;gap:20px;flex-wrap:wrap;padding:12px 0" class="mono small muted">
+      <span><b class="sec2">${num(U.sessions)}</b> sessions</span><span><b class="sec2">${U.activeDays}/30</b> days</span><span><b class="sec2">${W.lead.harnesses}</b> harnesses</span>
+      <span style="margin-left:auto">checked ${readCheckedAgo}</span></div>
+  </div></section>
+  <nav id="hb-rail" class="hb-rail" aria-label="Sections">
+    <div class="hb-line"><span id="hb-fill"></span></div>
+    ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="hb-item"><span class="n">${s.n}</span><span class="t">${s.title}</span></a>`).join("")}
+  </nav>
+  <nav id="hb-strip" class="hb-strip" aria-label="Sections">
+    ${figs.map(f=>`<a href="#${f.s.id}" data-spy="${f.s.id}" class="hb-chip"><span class="n">${f.s.n}</span><b>${plain(f.big)}</b><span class="t">${f.s.title}</span></a>`).join("")}
+  </nav>
+  <style>
+   .hb-fig:last-child{border-right:0!important}
+   .hb-fig:hover .kick.lime{text-decoration:underline}
+   .hb-rail{position:fixed;left:24px;top:50%;transform:translate(-160%,-50%);transition:transform .25s;z-index:30;display:flex;flex-direction:column;gap:14px;padding-left:16px}
+   .hb-rail.shown{transform:translate(0,-50%)}
+   .hb-line{position:absolute;left:0;top:0;bottom:0;width:2px;background:var(--stroke)}
+   .hb-line span{display:block;width:100%;height:0;background:var(--lime)}
+   .hb-item{font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--fg-muted);display:flex;gap:8px;font-weight:700}
+   .hb-item .n{color:var(--stroke-strong)}.hb-item.on{color:var(--lime)}.hb-item.on .n{color:var(--lime)}
+   .hb-strip{display:none;position:sticky;top:var(--ptop,0px);z-index:30;background:${TINT4[0]};border-top:1px solid var(--stroke);border-bottom:1px solid var(--stroke);overflow-x:auto;padding:0 8px}
+   .hb-chip{display:inline-flex;align-items:baseline;gap:6px;padding:10px 12px;font-family:var(--mono);font-size:11px;color:var(--fg-muted);white-space:nowrap;box-shadow:inset 0 -3px 0 transparent;text-transform:uppercase;letter-spacing:.08em}
+   .hb-chip b{color:var(--fg-primary);font-size:13px}.hb-chip .n{color:var(--stroke-strong)}.hb-chip.on{box-shadow:inset 0 -3px 0 var(--lime);color:var(--lime)}.hb-chip.on b,.hb-chip.on .n{color:var(--lime)}
+   @media(max-width:1560px){.hb-rail{display:none}.hb-strip{display:flex}}
+   @media(max-width:820px){.hb-grid{grid-template-columns:1fr 1fr!important}.hb-fig{border-bottom:1px solid var(--stroke)}.hb-fig:nth-child(2n){border-right:0!important}.hb-fig:nth-child(n+3){border-bottom:0}}
+  </style>`;
+}
+
+/* =========================================================================
+   V40 CONTENTS + SCRUBBER
+   ========================================================================= */
+function heroC(){
+  const sec=sections352();
+  return `<section style="background:${TINT4[0]};padding:56px 0 48px"><div style="max-width:1280px;margin:0 auto;padding:0 24px">
+   <div style="display:grid;grid-template-columns:minmax(0,7fr) minmax(0,5fr);gap:56px;align-items:start" class="g2">
+    <div style="min-width:0">
+      <h1 style="font-size:clamp(44px,6.4vw,80px);font-weight:900;line-height:.9;letter-spacing:-.03em;text-transform:uppercase">${esc(S.name)}</h1>
+      <p style="margin-top:18px;font-size:18px;color:var(--fg-secondary);max-width:540px">${esc(S.oneLiner)}</p>
+      <div style="display:flex;align-items:center;gap:12px;margin-top:24px;flex-wrap:wrap">${avatar352(36)}${byline352()}<span style="display:flex;gap:6px;margin-left:8px">${actions352()}</span></div>
+    </div>
+    <div style="border-left:2px solid var(--lime)">
+      <p class="kick lime" style="padding:0 20px 4px">in this stack</p>
+      ${sec.map(s=>`<a href="#${s.id}" class="hc-row" style="display:grid;grid-template-columns:36px 1fr auto;gap:12px;align-items:baseline;padding:14px 20px;border-bottom:1px solid var(--stroke)">
+        <span class="mono" style="font-size:12px;font-weight:900;color:var(--stroke-strong)">${s.n}</span>
+        <span><b style="font-size:15px;text-transform:uppercase;letter-spacing:-.01em">${s.title}</b><br><span class="small sec2">${s.line}</span></span>
+        <span class="lime">↓</span></a>`).join("")}
+      <p class="mono small muted" style="padding:12px 20px 0">checked ${readCheckedAgo}</p>
+    </div>
+   </div>
+  </div></section>
+  <nav id="hc-bar" class="hc-bar" aria-label="Reading progress">
+    <div class="hc-track">${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" data-seg="${s.id}" class="hc-seg"><span class="fill"></span><span class="lbl"><span class="n">${s.n}</span> <span class="t">${s.title}</span></span></a>`).join("")}</div>
+  </nav>
+  <style>
+   .hc-row:hover b{color:var(--lime)}
+   .hc-bar{position:fixed;left:0;right:0;top:var(--ptop,0px);z-index:30;background:${TINT4[0]};border-bottom:1px solid var(--stroke);transform:translateY(-110%);transition:transform .2s}
+   .hc-bar.shown{transform:none}
+   .hc-track{display:flex;max-width:1280px;margin:0 auto;padding:0 24px}
+   .hc-seg{position:relative;flex:1 1 0;height:34px;display:flex;align-items:center;border-right:1px solid var(--stroke);overflow:hidden;min-width:0}
+   .hc-seg:first-child{border-left:1px solid var(--stroke)}
+   .hc-seg .fill{position:absolute;left:0;top:0;bottom:0;width:0;background:var(--lime);opacity:.18}
+   .hc-seg .lbl{position:relative;padding:0 12px;font-family:var(--mono);font-size:11px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--fg-muted);white-space:nowrap}
+   .hc-seg .n{color:var(--stroke-strong)}.hc-seg.on .lbl{color:var(--lime)}.hc-seg.on .n{color:var(--lime)}
+   .hc-seg.on::after{content:"";position:absolute;left:0;right:0;bottom:0;height:3px;background:var(--lime)}
+   @media(max-width:700px){.hc-seg .lbl{padding:0 8px}.hc-seg:not(.on) .t{display:none}}
+  </style>`;
+}
+
+function renderV38(){return heroA()+body352();}
+function renderV39(){return heroB()+body352();}
+function renderV40(){return heroC()+body352();}
+
+/* ---------- scroll behavior, wired after every render by the template ---------- */
+window.afterRender=function(){
+  if(window._nav352)window._nav352();
+  window._nav352=null;
+  const ptopOf=()=>{const h=document.getElementById("proto-head").offsetHeight;document.documentElement.style.setProperty("--ptop",h+"px");return h;};
+  ptopOf();
+  const spyLinks=[...document.querySelectorAll("[data-spy]")];
+  if(!spyLinks.length)return;
+  const ids=[...new Set(spyLinks.map(a=>a.dataset.spy))];
+  const secs=ids.map(id=>document.getElementById(id)).filter(Boolean);
+  const hero=document.querySelector("#page > section");
+  const onScroll=()=>{
+    const ptop=ptopOf();
+    const line=scrollY+innerHeight*0.3;
+    let cur=null;
+    for(const s of secs){if(s.offsetTop<=line)cur=s.id;}
+    spyLinks.forEach(a=>a.classList.toggle("on",a.dataset.spy===cur));
+    const heroGone=hero.getBoundingClientRect().bottom<ptop;
+    const tabs=document.getElementById("ha-tabs");
+    if(tabs)tabs.classList.toggle("stuck",tabs.getBoundingClientRect().top<=ptop+1);
+    const rail=document.getElementById("hb-rail");
+    if(rail){rail.classList.toggle("shown",heroGone);const p=scrollY/Math.max(1,document.documentElement.scrollHeight-innerHeight);document.getElementById("hb-fill").style.height=(p*100).toFixed(1)+"%";}
+    const bar=document.getElementById("hc-bar");
+    if(bar){bar.classList.toggle("shown",heroGone);
+      secs.forEach(s=>{const seg=bar.querySelector(`[data-seg="${s.id}"]`);if(!seg)return;seg.style.flexGrow=Math.max(1,s.offsetHeight/100);
+        const f=Math.min(1,Math.max(0,(line-s.offsetTop)/s.offsetHeight));seg.querySelector(".fill").style.width=(f*100).toFixed(1)+"%";});}
+  };
+  onScroll();
+  addEventListener("scroll",onScroll,{passive:true});addEventListener("resize",onScroll);
+  window._nav352=()=>{removeEventListener("scroll",onScroll);removeEventListener("resize",onScroll);};
+};

--- a/prototypes/stack-page-compact/variants7.js
+++ b/prototypes/stack-page-compact/variants7.js
@@ -53,7 +53,7 @@ const actions352=()=>`<span class="chip" style="cursor:pointer">▲ ${UPVOTES}</
    ========================================================================= */
 function heroA(){
   const sec=sections352();
-  const shown=8;
+  const shown=S.tools.length<=6?S.tools.length:5;
   const act=OPT("act"), rule=OPT("rule"), lbl=OPT("lbl"), nav=OPT("nav");
   const hair="1px solid oklch(0.55 0.01 256 / 0.25)";
   const ruleCss=rule==="line"?"border-top:1px solid var(--stroke)":rule==="dim"?`border-top:${hair}`:rule==="dim2"?`border-top:${hair};border-bottom:${hair};padding-bottom:20px`:"";
@@ -70,11 +70,14 @@ function heroA(){
   return `<section style="background:${TINT4[0]};padding:56px 0 36px"><div style="max-width:1280px;margin:0 auto;padding:0 24px">
    ${act==="corner"?`<div style="display:flex;justify-content:flex-end;margin:-24px 0 8px">${actionsTopRight}</div>`:""}
    <div style="display:grid;grid-template-columns:1fr auto;gap:40px;align-items:end" class="g2">
-    <div style="min-width:0">
+    <div style="min-width:0" class="ha-left">
       <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">${avatar352(40)}${byline352()}</div>
       <div class="ha-h1w"><h1 class="ha-h1">${esc(S.name)}</h1></div>
-      <p style="margin-top:16px;font-size:18px;color:var(--fg-secondary);max-width:560px">${esc(S.oneLiner)}</p>
+      <p style="margin-top:14px;font-size:18px;color:var(--fg-secondary);max-width:560px">${esc(S.oneLiner)}</p>
       ${actionsUnderTitle}
+      <div style="display:flex;align-items:center;gap:10px;margin-top:26px;${ruleCss?ruleCss+";padding-top:16px":""}">
+        ${label?`<span class="kick muted" style="margin-right:8px">${label}</span>`:""}<a href="#s-tools" style="display:flex;gap:10px;align-items:center">${toolsSorted.slice(0,shown).map(t=>`<span title="${esc(t.name)}${t.amount>0?" · "+priceMo(t.amount):""}" style="display:inline-flex;cursor:help">${toolIcn(t,36)}</span>`).join("")}${S.tools.length>shown?`<span class="chip" title="${toolsSorted.slice(shown).map(t=>esc(t.name)).join(", ")}" style="border-color:oklch(0.55 0.01 256 / 0.35);cursor:help;height:36px">+${S.tools.length-shown}</span>`:""}</a>
+      </div>
     </div>
     <div style="display:grid;gap:10px;min-width:260px" class="ha-tiles">
       ${actionsInColumn}
@@ -87,11 +90,8 @@ function heroA(){
         <div class="mono" style="font-size:40px;font-weight:900;line-height:1;position:relative">${fmtT(U.totalTokens)}</div>
         <div class="kick muted" style="margin-top:6px;position:relative">tokens · 30 days · <span class="lime">${UP} ×${(U.totalTokens/U.prevTokens).toFixed(0)}</span></div>
       </a>
+      ${act==="chips"?"":`<div style="display:flex;justify-content:flex-end;gap:14px;margin-top:-2px" class="mono small muted"><span>updated ${readCheckedAgo}</span>${lnkReport}</div>`}
     </div>
-   </div>
-   <div style="display:flex;align-items:center;gap:8px;margin-top:${rule==="none"?"44px":"32px"};padding-top:${rule==="none"?"0":"20px"};padding-bottom:${rule==="none"?"8px":"0"};${ruleCss};flex-wrap:wrap">
-     ${label?`<span class="kick muted" style="margin-right:8px">${label}</span>`:""}<a href="#s-tools" style="display:flex;gap:8px;align-items:center">${toolsSorted.slice(0,shown).map(t=>`<span title="${esc(t.name)}${t.amount>0?" · "+priceMo(t.amount):""}" style="display:inline-flex;cursor:help">${toolIcn(t,28)}</span>`).join("")}<span class="chip" title="${toolsSorted.slice(shown).map(t=>esc(t.name)).join(", ")}" style="border-color:oklch(0.55 0.01 256 / 0.35);cursor:help">+${S.tools.length-shown}</span></a>
-     ${reportSlot||`<span class="mono small muted" style="margin-left:auto">updated ${readCheckedAgo}</span>`}
    </div>
   </div></section>
   <nav id="ha-tabs" class="ha-tabs ha-nav-${nav}" aria-label="Sections">
@@ -101,7 +101,8 @@ function heroA(){
    </div>
   </nav>
   <style>
-   .ha-h1w{min-height:calc(2 * .88 * clamp(44px,7vw,88px));display:flex;align-items:flex-end;margin-top:20px}
+   .ha-h1w{margin-top:18px}
+   .ha-left{min-height:calc(2 * .88 * clamp(44px,7vw,88px) + 150px)}
    .ha-h1{font-size:clamp(44px,7vw,88px);font-weight:900;line-height:.88;letter-spacing:-.03em;text-transform:uppercase;overflow-wrap:anywhere}
    .ha-up{display:inline-flex;align-items:center;gap:8px;background:none;border:1px solid var(--lime);color:var(--lime);font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;padding:10px 16px;cursor:pointer}
    .ha-up:hover{background:var(--lime);color:var(--lime-contrast)}.ha-up .tri{font-size:10px}.ha-up b{font-weight:900}
@@ -112,7 +113,7 @@ function heroA(){
    .ha-tab{display:flex;align-items:baseline;gap:10px;padding:0 18px;white-space:nowrap;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--fg-muted);box-shadow:inset 0 -3px 0 transparent}
    .ha-tab .n{color:var(--stroke-strong)}.ha-tab .s{font-weight:400;letter-spacing:.04em;text-transform:none;font-size:11px}
    .ha-tab .lab{display:inline-flex;gap:10px;align-items:baseline;padding:14px 0 12px;box-shadow:inset 0 -3px 0 transparent}
-   .ha-tab.on{color:var(--lime)}.ha-nav-lines .ha-tab.on{box-shadow:inset 0 -3px 0 var(--lime)}.ha-nav-quiet .ha-tab.on .lab,.ha-nav-bare .ha-tab.on .lab{box-shadow:inset 0 -3px 0 var(--lime)}.ha-tab.on .n{color:var(--lime)}
+   .ha-tab.on{color:var(--lime)}.ha-nav-lines .ha-tab.on{box-shadow:inset 0 -3px 0 var(--lime)}.ha-nav-quiet .ha-tab.on,.ha-nav-bare .ha-tab.on{box-shadow:inset 0 -3px 0 var(--lime)}.ha-tab.on .n{color:var(--lime)}
    .ha-tab:hover{color:var(--fg-primary)}
    .ha-id{display:none;align-items:center;gap:10px;padding:0 18px 0 0;margin-right:6px;font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap}
    .ha-tabs.stuck .ha-id{display:flex}
@@ -120,11 +121,11 @@ function heroA(){
    .ha-nav-lines{border-top:1px solid var(--stroke);border-bottom:1px solid var(--stroke)}
    .ha-nav-lines .ha-tab{border-right:1px solid var(--stroke)}.ha-nav-lines .ha-tab:first-of-type{border-left:1px solid var(--stroke)}
    .ha-nav-quiet{border-bottom:1px solid oklch(0.55 0.01 256 / 0.25)}
-   .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:180px;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
+   .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:150px;margin-right:20px;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
    .ha-nav-bare{background:${TINT4[1]}}.ha-nav-bare .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
    .ha-nav-bare.stuck{box-shadow:0 8px 24px oklch(0 0 0 / .35)}
-   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id{display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{margin-right:20px}}
-   @media(max-width:820px){.ha-tiles{grid-template-columns:1fr 1fr;max-width:520px;min-width:0!important}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3;justify-content:flex-start}.ha-tiles .ha-up{flex:none!important}.ha-tiles .kick{font-size:10px;letter-spacing:.15em}}
+   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id{display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{width:auto;margin-right:22px}}
+   @media(max-width:820px){.ha-tiles{grid-template-columns:1fr 1fr;max-width:520px;min-width:0!important}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3;justify-content:flex-start}.ha-tiles .ha-up{flex:none!important}.ha-tiles>div:last-child{grid-column:1/3}.ha-left{min-height:0}.ha-tiles .kick{font-size:10px;letter-spacing:.15em}}
   </style>`;
 }
 

--- a/prototypes/stack-page-compact/variants7.js
+++ b/prototypes/stack-page-compact/variants7.js
@@ -55,7 +55,8 @@ function heroA(){
   const sec=sections352();
   const shown=8;
   const act=OPT("act"), rule=OPT("rule"), lbl=OPT("lbl"), nav=OPT("nav");
-  const ruleCss=rule==="line"?"border-top:1px solid var(--stroke)":rule==="dim"?"border-top:1px solid oklch(0.55 0.01 256 / 0.25)":"";
+  const hair="1px solid oklch(0.55 0.01 256 / 0.25)";
+  const ruleCss=rule==="line"?"border-top:1px solid var(--stroke)":rule==="dim"?`border-top:${hair}`:rule==="dim2"?`border-top:${hair};border-bottom:${hair};padding-bottom:20px`:"";
   const label=lbl==="runs on"?"runs on":lbl==="tools"?`${S.tools.length} tools`:"";
   /* the three actions, arranged by importance: upvote > share > report */
   const btnUp=`<button class="ha-up" type="button"><span class="tri">▲</span> Upvote <b>${UPVOTES}</b></button>`;
@@ -88,8 +89,8 @@ function heroA(){
       </a>
     </div>
    </div>
-   <div style="display:flex;align-items:center;gap:8px;margin-top:${rule==="none"?"36px":"32px"};padding-top:${rule==="none"?"0":"20px"};${ruleCss};flex-wrap:wrap">
-     ${label?`<span class="kick muted" style="margin-right:8px">${label}</span>`:""}<a href="#s-tools" style="display:flex;gap:8px;align-items:center">${toolsSorted.slice(0,shown).map(t=>toolIcn(t,28)).join("")}<span class="chip" style="border-color:oklch(0.55 0.01 256 / 0.35)">+${S.tools.length-shown}</span></a>
+   <div style="display:flex;align-items:center;gap:8px;margin-top:${rule==="none"?"44px":"32px"};padding-top:${rule==="none"?"0":"20px"};padding-bottom:${rule==="none"?"8px":"0"};${ruleCss};flex-wrap:wrap">
+     ${label?`<span class="kick muted" style="margin-right:8px">${label}</span>`:""}<a href="#s-tools" style="display:flex;gap:8px;align-items:center">${toolsSorted.slice(0,shown).map(t=>`<span title="${esc(t.name)}${t.amount>0?" · "+priceMo(t.amount):""}" style="display:inline-flex;cursor:help">${toolIcn(t,28)}</span>`).join("")}<span class="chip" title="${toolsSorted.slice(shown).map(t=>esc(t.name)).join(", ")}" style="border-color:oklch(0.55 0.01 256 / 0.35);cursor:help">+${S.tools.length-shown}</span></a>
      ${reportSlot||`<span class="mono small muted" style="margin-left:auto">updated ${readCheckedAgo}</span>`}
    </div>
   </div></section>
@@ -116,7 +117,7 @@ function heroA(){
    .ha-nav-lines{border-top:1px solid var(--stroke);border-bottom:1px solid var(--stroke)}
    .ha-nav-lines .ha-tab{border-right:1px solid var(--stroke)}.ha-nav-lines .ha-tab:first-of-type{border-left:1px solid var(--stroke)}
    .ha-nav-quiet{border-bottom:1px solid oklch(0.55 0.01 256 / 0.25)}
-   .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
+   .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:180px;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
    .ha-nav-bare{background:${TINT4[1]}}.ha-nav-bare .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
    .ha-nav-bare.stuck{box-shadow:0 8px 24px oklch(0 0 0 / .35)}
    @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id{display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{margin-right:20px}.ha-tiles{grid-template-columns:1fr 1fr}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3}}

--- a/prototypes/stack-page-compact/variants7.js
+++ b/prototypes/stack-page-compact/variants7.js
@@ -35,7 +35,7 @@ function body352(){
   const rows=OPT("rows")==="tabs"?`<div style="margin-top:36px">${cssTabs("t37")}</div>`:`<div style="margin-top:36px">${statsAccordion()}</div>`;
   const ids=["s-stats","s-projects","s-tools","s-guide"];
   let i=0;
-  const html=sec37(1,"01","",name,`30d · all machines<br>updated ${readCheckedAgo}`,statsTop37()+rows)+
+  const html=sec37(1,"01","",name,`${OPT("win")} · all machines<br>updated ${readCheckedAgo}`,statsTop37()+rows)+
     sec37(2,"02","","Projects",P.length+" projects",projGridV16())+
     sec37(3,"03","","Tools",`${S.tools.length} tools · ${priceMo(S.price)}`,toolsBodyV16())+
     sec37(0,"04","","Guide",guideMin+" min read",guideBodyV16());
@@ -97,13 +97,13 @@ function heroA(){
   <nav id="ha-tabs" class="ha-tabs ha-nav-${nav}" aria-label="Sections">
    <div class="ha-idrow"><div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:22px;overflow:hidden">
      ${avatar352(22)}<b style="font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap">${esc(S.name)}</b>
-     <span class="mono small muted" style="white-space:nowrap">${esc(S.creator.name)}</span>
-     <span class="mono small" style="margin-left:auto;white-space:nowrap"><span class="lime" style="font-weight:700">${priceMo(S.price)}</span></span>
-     <span class="mono small" style="display:inline-flex;align-items:center;gap:8px;white-space:nowrap"><span style="width:90px;display:inline-block">${spark(U.series,400,18)}</span><b>${fmtT(U.totalTokens)}</b> <span class="muted">tokens · 30d</span></span>
-     <span class="mono small muted" style="white-space:nowrap">▲ ${UPVOTES}</span>
+     <span class="mono small sec2" style="white-space:nowrap">▲ ${UPVOTES}</span>
+     <span class="mono small lime" style="white-space:nowrap;font-weight:700">${priceMo(S.price)}</span>
+     <span class="mono small" style="margin-left:auto;display:inline-flex;align-items:center;gap:8px;white-space:nowrap"><span style="width:90px;display:inline-block">${spark(U.series,400,18)}</span><b>${fmtT(U.totalTokens)}</b> <span class="muted">tokens</span></span>
    </div></div>
    <div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:stretch;overflow-x:auto">
     ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="lab"><span class="n">${s.n}</span><span class="t">${s.title}</span></span><span class="s">${s.stat}</span><span class="vis"></span></a>`).join("")}
+    <label class="ha-win"><span class="muted">window</span><select onchange="const y=scrollY;const u=new URL(location);u.searchParams.set('win',this.value);history.replaceState(null,'',u);show(current(),false);scrollTo(0,y)">${[["30d","last 30 days"],["7d","last 7 days"],["24h","last 24 hours"]].map(([k,l])=>`<option value="${k}"${OPT("win")===k?" selected":""}>${l}</option>`).join("")}</select></label>
    </div>
   </nav>
   <style>
@@ -121,6 +121,8 @@ function heroA(){
    .ha-tab .lab{display:inline-flex;gap:10px;align-items:baseline;padding:14px 0 12px;box-shadow:inset 0 -3px 0 transparent}
    .ha-tab.on{color:var(--lime)}.ha-nav-lines .ha-tab.on{box-shadow:inset 0 -3px 0 var(--lime)}
    .ha-tab .vis{position:absolute;left:0;bottom:0;height:3px;width:0;background:var(--lime)}
+   .ha-win{margin-left:auto;display:flex;align-items:center;gap:8px;font-family:var(--mono);font-size:11px;white-space:nowrap}
+   .ha-win select{background:var(--bg-shell);color:var(--fg-primary);border:1px solid oklch(0.55 0.01 256 / 0.35);font:inherit;padding:4px 6px;cursor:pointer}
    .ha-idrow{display:none;border-bottom:1px solid oklch(0.55 0.01 256 / 0.18);padding:8px 0}.ha-tabs.stuck .ha-idrow{display:block}.ha-tab.on .n{color:var(--lime)}
    .ha-tab:hover{color:var(--fg-primary)}
       /* nav: lines = round 1, quiet = one dim hairline, bare = tint only */
@@ -130,7 +132,7 @@ function heroA(){
    .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:136px;margin:0;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
    .ha-nav-bare{background:${TINT4[1]}}.ha-nav-bare .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
    .ha-nav-bare.stuck{box-shadow:0 8px 24px oklch(0 0 0 / .35)}
-   @media(max-width:700px){.ha-tab .s{display:none}.ha-idrow>div>*:nth-child(n+3){display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{width:auto;padding-right:22px}}
+   @media(max-width:700px){.ha-tab .s{display:none}.ha-idrow>div>*:nth-child(n+5){display:none!important}.ha-win span{display:none}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{width:auto;padding-right:22px}}
    @media(max-width:820px){.ha-tiles{grid-template-columns:1fr 1fr;max-width:520px;min-width:0!important}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3;justify-content:flex-start}.ha-tiles .ha-up{flex:none!important}.ha-tiles>div:last-child{grid-column:1/3}.ha-left{min-height:0}.ha-tiles .kick{font-size:10px;letter-spacing:.15em}}
   </style>`;
 }
@@ -249,14 +251,15 @@ window.afterRender=function(){
     const line=scrollY+innerHeight*0.3;
     let cur=null;
     for(const s of secs){if(s.offsetTop<=line)cur=s.id;}
-    spyLinks.forEach(a=>a.classList.toggle("on",a.dataset.spy===cur));
+    spyLinks.forEach(a=>{if(!a.classList.contains("ha-tab"))a.classList.toggle("on",a.dataset.spy===cur);});
     const heroGone=hero.getBoundingClientRect().bottom<ptop;
     const tabs=document.getElementById("ha-tabs");
     if(tabs){tabs.classList.toggle("stuck",tabs.getBoundingClientRect().top<=ptop+1);
       const vpTop=scrollY+ptop+tabs.offsetHeight,vpBot=scrollY+innerHeight;
       tabs.querySelectorAll(".ha-tab").forEach(a=>{const s=document.getElementById(a.dataset.spy);if(!s)return;
         const st=Math.min(1,Math.max(0,(vpTop-s.offsetTop)/s.offsetHeight)),en=Math.min(1,Math.max(0,(vpBot-s.offsetTop)/s.offsetHeight));
-        const vis=a.querySelector(".vis");vis.style.left=(st*100).toFixed(1)+"%";vis.style.width=(Math.max(0,en-st)*100).toFixed(1)+"%";});}
+        const vis=a.querySelector(".vis");vis.style.left=(st*100).toFixed(1)+"%";vis.style.width=`calc(${(Math.max(0,en-st)*100).toFixed(1)}%${en>=1&&st<1?" + 1px":""})`;
+        const px=Math.max(0,en-st)*s.offsetHeight;a.classList.toggle("on",px/s.offsetHeight>=.5||px/(vpBot-vpTop)>=.5);});}
     const rail=document.getElementById("hb-rail");
     if(rail){rail.classList.toggle("shown",heroGone);const p=scrollY/Math.max(1,document.documentElement.scrollHeight-innerHeight);document.getElementById("hb-fill").style.height=(p*100).toFixed(1)+"%";}
     const bar=document.getElementById("hc-bar");

--- a/prototypes/stack-page-compact/variants7.js
+++ b/prototypes/stack-page-compact/variants7.js
@@ -35,10 +35,10 @@ function body352(){
   const rows=OPT("rows")==="tabs"?`<div style="margin-top:36px">${cssTabs("t37")}</div>`:`<div style="margin-top:36px">${statsAccordion()}</div>`;
   const ids=["s-stats","s-projects","s-tools","s-guide"];
   let i=0;
-  const html=sec37(1,"01","// sync",name,`30d · all machines<br>updated ${readCheckedAgo}`,statsTop37()+rows)+
-    sec37(2,"02","// showcase","Projects",P.length+" projects",projGridV16())+
-    sec37(3,"03","// ai components","Tools",`${S.tools.length} tools · ${priceMo(S.price)}`,toolsBodyV16())+
-    sec37(0,"04","// writeup","Guide",guideMin+" min read",guideBodyV16());
+  const html=sec37(1,"01","",name,`30d · all machines<br>updated ${readCheckedAgo}`,statsTop37()+rows)+
+    sec37(2,"02","","Projects",P.length+" projects",projGridV16())+
+    sec37(3,"03","","Tools",`${S.tools.length} tools · ${priceMo(S.price)}`,toolsBodyV16())+
+    sec37(0,"04","","Guide",guideMin+" min read",guideBodyV16());
   return html.replace(/<section /g,()=>`<section id="${ids[i++]}" `)+ctaStrip()+MEDIA_G2+
     `<style>[id^="s-"]{scroll-margin-top:calc(var(--ptop,0px) + 48px)}</style>`;
 }
@@ -72,7 +72,7 @@ function heroA(){
    <div style="display:grid;grid-template-columns:1fr auto;gap:40px;align-items:end" class="g2">
     <div style="min-width:0">
       <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">${avatar352(40)}${byline352()}</div>
-      <h1 style="font-size:clamp(44px,7vw,88px);font-weight:900;line-height:.88;letter-spacing:-.03em;text-transform:uppercase;margin-top:20px">${esc(S.name)}</h1>
+      <div class="ha-h1w"><h1 class="ha-h1">${esc(S.name)}</h1></div>
       <p style="margin-top:16px;font-size:18px;color:var(--fg-secondary);max-width:560px">${esc(S.oneLiner)}</p>
       ${actionsUnderTitle}
     </div>
@@ -97,19 +97,22 @@ function heroA(){
   <nav id="ha-tabs" class="ha-tabs ha-nav-${nav}" aria-label="Sections">
    <div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:stretch;overflow-x:auto">
     <span class="ha-id"><b>${esc(S.name)}</b><span class="lime mono" style="font-size:11px">${priceMo(S.price)}</span></span>
-    ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="n">${s.n}</span><span class="t">${s.title}</span><span class="s">${s.stat}</span></a>`).join("")}
+    ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="lab"><span class="n">${s.n}</span><span class="t">${s.title}</span></span><span class="s">${s.stat}</span></a>`).join("")}
    </div>
   </nav>
   <style>
+   .ha-h1w{min-height:calc(2 * .88 * clamp(44px,7vw,88px));display:flex;align-items:flex-end;margin-top:20px}
+   .ha-h1{font-size:clamp(44px,7vw,88px);font-weight:900;line-height:.88;letter-spacing:-.03em;text-transform:uppercase;overflow-wrap:anywhere}
    .ha-up{display:inline-flex;align-items:center;gap:8px;background:none;border:1px solid var(--lime);color:var(--lime);font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;padding:10px 16px;cursor:pointer}
    .ha-up:hover{background:var(--lime);color:var(--lime-contrast)}.ha-up .tri{font-size:10px}.ha-up b{font-weight:900}
    .ha-ghost{display:inline-flex;align-items:center;background:none;border:1px solid var(--stroke);color:var(--fg-secondary);font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;padding:10px 16px;cursor:pointer}
    .ha-ghost:hover{border-color:var(--fg-secondary)}
    .ha-quiet{font-family:var(--mono);font-size:11px;color:var(--fg-muted);text-decoration:underline dotted;text-underline-offset:3px}.ha-quiet:hover{color:oklch(0.75 0.15 60)}
    .ha-tabs{position:sticky;top:var(--ptop,0px);z-index:30;background:${TINT4[0]}}
-   .ha-tab{display:flex;align-items:baseline;gap:10px;padding:14px 18px 12px;white-space:nowrap;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--fg-muted);box-shadow:inset 0 -3px 0 transparent}
+   .ha-tab{display:flex;align-items:baseline;gap:10px;padding:0 18px;white-space:nowrap;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--fg-muted);box-shadow:inset 0 -3px 0 transparent}
    .ha-tab .n{color:var(--stroke-strong)}.ha-tab .s{font-weight:400;letter-spacing:.04em;text-transform:none;font-size:11px}
-   .ha-tab.on{color:var(--lime);box-shadow:inset 0 -3px 0 var(--lime)}.ha-tab.on .n{color:var(--lime)}
+   .ha-tab .lab{display:inline-flex;gap:10px;align-items:baseline;padding:14px 0 12px;box-shadow:inset 0 -3px 0 transparent}
+   .ha-tab.on{color:var(--lime)}.ha-nav-lines .ha-tab.on{box-shadow:inset 0 -3px 0 var(--lime)}.ha-nav-quiet .ha-tab.on .lab,.ha-nav-bare .ha-tab.on .lab{box-shadow:inset 0 -3px 0 var(--lime)}.ha-tab.on .n{color:var(--lime)}
    .ha-tab:hover{color:var(--fg-primary)}
    .ha-id{display:none;align-items:center;gap:10px;padding:0 18px 0 0;margin-right:6px;font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap}
    .ha-tabs.stuck .ha-id{display:flex}
@@ -120,7 +123,8 @@ function heroA(){
    .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:180px;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
    .ha-nav-bare{background:${TINT4[1]}}.ha-nav-bare .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
    .ha-nav-bare.stuck{box-shadow:0 8px 24px oklch(0 0 0 / .35)}
-   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id{display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{margin-right:20px}.ha-tiles{grid-template-columns:1fr 1fr}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3}}
+   @media(max-width:700px){.ha-tab .s{display:none}.ha-tabs .ha-id{display:none!important}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{margin-right:20px}}
+   @media(max-width:820px){.ha-tiles{grid-template-columns:1fr 1fr;max-width:520px;min-width:0!important}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3;justify-content:flex-start}.ha-tiles .ha-up{flex:none!important}.ha-tiles .kick{font-size:10px;letter-spacing:.15em}}
   </style>`;
 }
 
@@ -249,7 +253,20 @@ window.afterRender=function(){
       secs.forEach(s=>{const seg=bar.querySelector(`[data-seg="${s.id}"]`);if(!seg)return;seg.style.flexGrow=Math.max(1,s.offsetHeight/100);
         const f=Math.min(1,Math.max(0,(line-s.offsetTop)/s.offsetHeight));seg.querySelector(".fill").style.width=(f*100).toFixed(1)+"%";});}
   };
-  onScroll();
-  addEventListener("scroll",onScroll,{passive:true});addEventListener("resize",onScroll);
-  window._nav352=()=>{removeEventListener("scroll",onScroll);removeEventListener("resize",onScroll);};
+  /* the title fitter: one line when the font stays above MIN, else two lines */
+  const fitTitle=()=>{
+    const h1=document.querySelector(".ha-h1");if(!h1)return;
+    const MAX=Math.min(88,Math.max(44,innerWidth*0.07)),MIN=44;
+    h1.style.whiteSpace="nowrap";h1.style.fontSize=MAX+"px";
+    const w=h1.parentElement.clientWidth,sw=h1.scrollWidth;
+    const one=Math.min(MAX,MAX*w/sw);
+    if(one>=MIN){h1.style.fontSize=one+"px";return;}
+    h1.style.whiteSpace="normal";
+    let s=MAX;h1.style.fontSize=s+"px";
+    while(h1.offsetHeight>2*s*.88*1.05&&s>MIN){s-=2;h1.style.fontSize=s+"px";}
+  };
+  fitTitle();onScroll();
+  const onResize=()=>{fitTitle();onScroll();};
+  addEventListener("scroll",onScroll,{passive:true});addEventListener("resize",onResize);
+  window._nav352=()=>{removeEventListener("scroll",onScroll);removeEventListener("resize",onResize);};
 };

--- a/prototypes/stack-page-compact/variants7.js
+++ b/prototypes/stack-page-compact/variants7.js
@@ -95,12 +95,12 @@ function heroA(){
    </div>
   </div></section>
   <nav id="ha-tabs" class="ha-tabs ha-nav-${nav}" aria-label="Sections">
-   <div class="ha-idrow"><div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:22px;overflow:hidden">
+   <div class="ha-idrow" title="back to top" onclick="scrollTo({top:0,behavior:'smooth'})"><div class="ha-idin"><div style="max-width:1280px;margin:0 auto;padding:8px 24px;display:flex;align-items:center;gap:22px;overflow:hidden">
      ${avatar352(22)}<b style="font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap">${esc(S.name)}</b>
      <span class="mono small sec2" style="white-space:nowrap">▲ ${UPVOTES}</span>
      <span class="mono small lime" style="white-space:nowrap;font-weight:700">${priceMo(S.price)}</span>
      <span class="mono small" style="margin-left:auto;display:inline-flex;align-items:center;gap:8px;white-space:nowrap"><span style="width:90px;display:inline-block">${spark(U.series,400,18)}</span><b>${fmtT(U.totalTokens)}</b> <span class="muted">tokens</span></span>
-   </div></div>
+   </div></div></div>
    <div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:stretch;overflow-x:auto">
     ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="lab"><span class="n">${s.n}</span><span class="t">${s.title}</span></span><span class="s">${s.stat}</span><span class="vis"></span></a>`).join("")}
     <label class="ha-win"><span class="muted">window</span><select onchange="const y=scrollY;const u=new URL(location);u.searchParams.set('win',this.value);history.replaceState(null,'',u);show(current(),false);scrollTo(0,y)">${[["30d","last 30 days"],["7d","last 7 days"],["24h","last 24 hours"]].map(([k,l])=>`<option value="${k}"${OPT("win")===k?" selected":""}>${l}</option>`).join("")}</select></label>
@@ -123,7 +123,10 @@ function heroA(){
    .ha-tab .vis{position:absolute;left:0;bottom:0;height:3px;width:0;background:var(--lime)}
    .ha-win{margin-left:auto;display:flex;align-items:center;gap:8px;font-family:var(--mono);font-size:11px;white-space:nowrap}
    .ha-win select{background:var(--bg-shell);color:var(--fg-primary);border:1px solid oklch(0.55 0.01 256 / 0.35);font:inherit;padding:4px 6px;cursor:pointer}
-   .ha-idrow{display:none;border-bottom:1px solid oklch(0.55 0.01 256 / 0.18);padding:8px 0}.ha-tabs.stuck .ha-idrow{display:block}.ha-tab.on .n{color:var(--lime)}
+   .ha-idrow{display:grid;grid-template-rows:0fr;opacity:0;cursor:pointer;transition:grid-template-rows .28s cubic-bezier(.2,.7,.2,1),opacity .2s}.ha-idrow .ha-idin{min-height:0;overflow:hidden;border-bottom:1px solid oklch(0.55 0.01 256 / 0.18)}
+   .ha-tabs.stuck .ha-idrow{grid-template-rows:1fr;opacity:1}
+   .ha-tab .vis{transition:left .12s linear,width .12s linear}
+   .ha-tab .lab{transition:color .2s}.ha-tab.on .n{color:var(--lime)}
    .ha-tab:hover{color:var(--fg-primary)}
       /* nav: lines = round 1, quiet = one dim hairline, bare = tint only */
    .ha-nav-lines{border-top:1px solid var(--stroke);border-bottom:1px solid var(--stroke)}
@@ -132,7 +135,7 @@ function heroA(){
    .ha-nav-quiet .ha-tab{padding-left:0;padding-right:0;width:136px;margin:0;flex:none;justify-content:flex-start}.ha-nav-quiet .ha-tab .s{display:none}
    .ha-nav-bare{background:${TINT4[1]}}.ha-nav-bare .ha-tab{padding-left:0;padding-right:0;margin-right:32px}
    .ha-nav-bare.stuck{box-shadow:0 8px 24px oklch(0 0 0 / .35)}
-   @media(max-width:700px){.ha-tab .s{display:none}.ha-idrow>div>*:nth-child(n+5){display:none!important}.ha-win span{display:none}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{width:auto;padding-right:22px}}
+   @media(max-width:700px){.ha-tab .s{display:none}.ha-idrow .ha-idin>div>*:nth-child(n+5){display:none!important}.ha-win span{display:none}.ha-tab{padding:12px 14px}.ha-nav-quiet .ha-tab,.ha-nav-bare .ha-tab{width:auto;padding-right:22px}}
    @media(max-width:820px){.ha-tiles{grid-template-columns:1fr 1fr;max-width:520px;min-width:0!important}.ha-tiles>div:first-child:not(.ha-tile){grid-column:1/3;justify-content:flex-start}.ha-tiles .ha-up{flex:none!important}.ha-tiles>div:last-child{grid-column:1/3}.ha-left{min-height:0}.ha-tiles .kick{font-size:10px;letter-spacing:.15em}}
   </style>`;
 }
@@ -279,6 +282,7 @@ window.afterRender=function(){
     let s=MAX;h1.style.fontSize=s+"px";
     while(h1.offsetHeight>2*s*.88*1.05&&s>MIN){s-=2;h1.style.fontSize=s+"px";}
   };
+  document.querySelectorAll("#ha-tabs .ha-tab").forEach(a=>a.addEventListener("click",e=>{const t=document.getElementById(a.dataset.spy);if(!t)return;e.preventDefault();t.scrollIntoView({behavior:"smooth",block:"start"});history.replaceState(null,"","#"+t.id);}));
   fitTitle();onScroll();
   const onResize=()=>{fitTitle();onScroll();};
   addEventListener("scroll",onScroll,{passive:true});addEventListener("resize",onResize);

--- a/prototypes/stack-page-compact/variants7.js
+++ b/prototypes/stack-page-compact/variants7.js
@@ -69,11 +69,11 @@ function heroA(){
   const reportSlot=act==="chips"?"":`<span style="margin-left:auto;display:flex;gap:16px;align-items:center" class="mono small muted"><span>updated ${readCheckedAgo}</span>${lnkReport}</span>`;
   return `<section style="background:${TINT4[0]};padding:56px 0 36px"><div style="max-width:1280px;margin:0 auto;padding:0 24px">
    ${act==="corner"?`<div style="display:flex;justify-content:flex-end;margin:-24px 0 8px">${actionsTopRight}</div>`:""}
-   <div style="display:grid;grid-template-columns:1fr auto;gap:40px;align-items:end" class="g2">
+   <div style="display:grid;grid-template-columns:1fr auto;gap:64px;align-items:end" class="g2">
     <div style="min-width:0" class="ha-left">
       <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">${avatar352(40)}${byline352()}</div>
       <div class="ha-h1w"><h1 class="ha-h1">${esc(S.name)}</h1></div>
-      <p style="margin-top:14px;font-size:18px;color:var(--fg-secondary);max-width:560px">${esc(S.oneLiner)}</p>
+      <p style="margin-top:14px;font-size:18px;color:var(--fg-secondary)">${esc(S.oneLiner)}</p>
       ${actionsUnderTitle}
       <div style="display:flex;align-items:center;gap:10px;margin-top:26px;${ruleCss?ruleCss+";padding-top:16px":""}">
         ${label?`<span class="kick muted" style="margin-right:8px">${label}</span>`:""}<a href="#s-tools" style="display:flex;gap:10px;align-items:center">${toolsSorted.slice(0,shown).map(t=>`<span title="${esc(t.name)}${t.amount>0?" · "+priceMo(t.amount):""}" style="display:inline-flex;cursor:help">${toolIcn(t,36)}</span>`).join("")}${S.tools.length>shown?`<span class="chip" title="${toolsSorted.slice(shown).map(t=>esc(t.name)).join(", ")}" style="border-color:oklch(0.55 0.01 256 / 0.35);cursor:help;height:36px">+${S.tools.length-shown}</span>`:""}</a>
@@ -95,11 +95,11 @@ function heroA(){
    </div>
   </div></section>
   <nav id="ha-tabs" class="ha-tabs ha-nav-${nav}" aria-label="Sections">
-   <div class="ha-idrow" title="back to top" onclick="scrollTo({top:0,behavior:'smooth'})"><div class="ha-idin"><div style="max-width:1280px;margin:0 auto;padding:8px 24px;display:flex;align-items:center;gap:22px;overflow:hidden">
+   <div class="ha-idrow" title="back to top"><div class="ha-idin"><div style="max-width:1280px;margin:0 auto;padding:8px 24px;display:flex;align-items:center;gap:22px;overflow:hidden">
      ${avatar352(22)}<b style="font-size:12px;font-weight:900;text-transform:uppercase;white-space:nowrap">${esc(S.name)}</b>
      <span class="mono small sec2" style="white-space:nowrap">▲ ${UPVOTES}</span>
      <span class="mono small lime" style="white-space:nowrap;font-weight:700">${priceMo(S.price)}</span>
-     <span class="mono small" style="margin-left:auto;display:inline-flex;align-items:center;gap:8px;white-space:nowrap"><span style="width:90px;display:inline-block">${spark(U.series,400,18)}</span><b>${fmtT(U.totalTokens)}</b> <span class="muted">tokens</span></span>
+     <span class="mono small" style="margin-left:auto;display:inline-flex;align-items:center;gap:14px;white-space:nowrap"><span style="width:70px;display:inline-block">${spark(U.series,400,18)}</span><b>${fmtT(U.totalTokens)}</b> <span class="muted">tokens</span></span>
    </div></div></div>
    <div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;align-items:stretch;overflow-x:auto">
     ${sec.map(s=>`<a href="#${s.id}" data-spy="${s.id}" class="ha-tab"><span class="lab"><span class="n">${s.n}</span><span class="t">${s.title}</span></span><span class="s">${s.stat}</span><span class="vis"></span></a>`).join("")}
@@ -282,7 +282,9 @@ window.afterRender=function(){
     let s=MAX;h1.style.fontSize=s+"px";
     while(h1.offsetHeight>2*s*.88*1.05&&s>MIN){s-=2;h1.style.fontSize=s+"px";}
   };
-  document.querySelectorAll("#ha-tabs .ha-tab").forEach(a=>a.addEventListener("click",e=>{const t=document.getElementById(a.dataset.spy);if(!t)return;e.preventDefault();t.scrollIntoView({behavior:"smooth",block:"start"});history.replaceState(null,"","#"+t.id);}));
+  document.querySelectorAll("#ha-tabs .ha-tab").forEach(a=>a.addEventListener("click",e=>{const t=document.getElementById(a.dataset.spy);if(!t)return;e.preventDefault();const nav=document.getElementById("ha-tabs");const ptop=ptopOf();
+    const y=Math.max(nav.offsetTop-ptop,t.offsetTop-ptop-88);scrollTo({top:y,behavior:"smooth"});history.replaceState(null,"","#"+t.id);}));
+  const idrow=document.querySelector("#ha-tabs .ha-idrow");if(idrow)idrow.addEventListener("click",()=>scrollTo({top:0,behavior:"smooth"}));
   fitTitle();onScroll();
   const onResize=()=>{fitTitle();onScroll();};
   addEventListener("scroll",onScroll,{passive:true});addEventListener("resize",onResize);


### PR DESCRIPTION
Round 1 of the hero and subnav prototype for #352, on the same demo as #355.

Open `prototypes/stack-page-compact/index.html` (built, self-contained) and switch with the bottom bar or `?v=`:

- `?v=v38` Masthead + tabs
- `?v=v39` Figures first (rail on screens wider than 1560px, figure strip otherwise)
- `?v=v40` Contents + scrubber

The "390" button in the bar opens the current variant in a 390px window. Details in `NOTES.md` under "Hero and subnav".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyNote3gSGTmi4g42yQjhC