### PR TITLE
feat: Context row at the head of the Stats section

### DIFF
--- a/src/features/usage/Accordion.tsx
+++ b/src/features/usage/Accordion.tsx
@@ -1,9 +1,14 @@
 import { ChevronDown } from "lucide-react";
 import { type KeyboardEvent, type ReactNode, useRef } from "react";
 import { cn } from "@/lib/utils";
+import { ContextBody, ContextSummary } from "./ContextRow";
+import type { ContextReading } from "./context";
 import { EMPTY_TOPIC, type RangeId } from "./copy";
 import { LeadCard, ScanRow } from "./grid";
 import type { Group, Item } from "./items";
+
+/** The id the Context row answers to in the open-topic state. */
+export const CONTEXT_TOPIC = "context";
 
 /**
  * The five topics under the top block (#356, prototype v37 "feature"): one
@@ -15,6 +20,11 @@ import type { Group, Item } from "./items";
  * the open topic closes on a second click. The open one expands to the
  * topic's lead chart on the left (`LeadCard`) and one scan line per remaining
  * item on the right (`ScanRow`).
+ *
+ * THE CONTEXT ROW LEADS (#359). When the server hands a context reading, it
+ * prints as the first row, before Time, in the same shape as the topics and in
+ * the same exclusive set; the section opens it by default. Its body is the
+ * per-harness grid, not a lead and scan rows. No reading, no row.
  *
  * NOTHING PRINTS TWICE ON THE ACCESSIBLE TREE. The summary row is the
  * heading's name; the watermark behind it (`watermark(group)`, one picture per
@@ -29,6 +39,7 @@ export function UsageAccordion({
 	onChange,
 	range,
 	watermark,
+	context = null,
 }: {
 	groups: readonly Group[];
 	items: (group: Group) => Item[];
@@ -36,24 +47,48 @@ export function UsageAccordion({
 	onChange: (id: string | null) => void;
 	range: RangeId;
 	watermark: (group: Group) => ReactNode;
+	/** The Context row's reading (#359). Null prints no row. */
+	context?: ContextReading;
 }) {
 	const buttons = useRef<(HTMLButtonElement | null)[]>([]);
+	const offset = context ? 1 : 0;
+	const count = groups.length + offset;
 
 	const onKeyDown = (
 		event: KeyboardEvent<HTMLButtonElement>,
 		index: number,
 	) => {
-		const target = topicKeyTarget(event.key, index, groups.length);
+		const target = topicKeyTarget(event.key, index, count);
 		if (target === null) return;
 		event.preventDefault();
 		buttons.current[target]?.focus();
 	};
 
+	const rowProps = (id: string, index: number) => ({
+		id,
+		index,
+		open: value === id,
+		onToggle: () => onChange(value === id ? null : id),
+		onKeyDown,
+		buttonRef: (node: HTMLButtonElement | null) => {
+			buttons.current[index] = node;
+		},
+	});
+
 	return (
 		<div className="mt-9 border-t border-stroke-subtle">
+			{context && (
+				<TopicRow
+					{...rowProps(CONTEXT_TOPIC, 0)}
+					label="Context"
+					summary={<ContextSummary context={context} />}
+					watermark={null}
+				>
+					<ContextBody context={context} />
+				</TopicRow>
+			)}
 			{groups.map((group, index) => {
 				const rows = items(group);
-				const open = value === group.id;
 				// The named lead leads. Without it in this range, the first item with
 				// a body stands in; without that, the first row.
 				const featured =
@@ -61,83 +96,119 @@ export function UsageAccordion({
 					rows.find((item) => item.body !== null) ??
 					rows[0];
 				const scan = featured ? rows.filter((item) => item !== featured) : rows;
-				const picture = watermark(group);
-				const buttonId = `usage-topic-${group.id}`;
-				const panelId = `usage-panel-${group.id}`;
 				return (
-					<div key={group.id} className="border-b border-stroke-subtle">
-						<h3 className="relative m-0">
-							{picture && (
-								<span
-									aria-hidden="true"
-									data-testid="usage-watermark"
-									className="pointer-events-none absolute inset-x-0 inset-y-1.5 overflow-hidden opacity-[0.22] [&>*]:h-full"
-								>
-									{picture}
-								</span>
-							)}
-							<button
-								ref={(node) => {
-									buttons.current[index] = node;
-								}}
-								type="button"
-								id={buttonId}
-								aria-expanded={open}
-								aria-controls={panelId}
-								data-testid="usage-topic"
-								onClick={() => onChange(open ? null : group.id)}
-								onKeyDown={(event) => onKeyDown(event, index)}
-								className="relative flex min-h-16 w-full cursor-pointer items-center gap-4 px-1 py-4 text-left transition-colors hover:bg-bg-panel/50 md:gap-5"
-							>
-								<span className="w-16 shrink-0 font-mono text-[11px] font-bold uppercase tracking-[0.14em] text-accent-lime md:w-20 md:text-xs">
-									{group.label}
-								</span>
-								<span
-									data-testid="usage-summary"
-									className="flex min-w-0 flex-1 flex-wrap gap-x-4 gap-y-1 text-[13px] text-fg-secondary md:text-sm"
-								>
-									{rows.slice(0, 3).map((item) => (
-										<span key={item.id}>
-											<b className="font-mono text-fg-primary">{item.figure}</b>{" "}
-											{item.name.toLowerCase()}
-										</span>
+					<TopicRow
+						key={group.id}
+						{...rowProps(group.id, index + offset)}
+						label={group.label}
+						watermark={watermark(group)}
+						summary={rows.slice(0, 3).map((item) => (
+							<span key={item.id}>
+								<b className="font-mono text-fg-primary">{item.figure}</b>{" "}
+								{item.name.toLowerCase()}
+							</span>
+						))}
+					>
+						{!featured ? (
+							<p className="font-mono text-xs text-fg-muted">{EMPTY_TOPIC}</p>
+						) : (
+							<div className="grid gap-x-9 gap-y-6 md:grid-cols-[minmax(0,23rem)_1fr]">
+								<LeadCard it={featured} range={range} />
+								<div className="border-t border-stroke-subtle">
+									{scan.map((item) => (
+										<ScanRow key={item.id} it={item} range={range} />
 									))}
-								</span>
-								<ChevronDown
-									aria-hidden="true"
-									className={cn(
-										"size-4 shrink-0 text-fg-muted transition-transform",
-										open && "rotate-180",
-									)}
-								/>
-							</button>
-						</h3>
-						{/* A named section is a region: the heading's button labels it. */}
-						{open && (
-							<section
-								id={panelId}
-								aria-labelledby={buttonId}
-								className="pb-7 pl-1 pt-2 md:pl-24"
-							>
-								{!featured ? (
-									<p className="font-mono text-xs text-fg-muted">
-										{EMPTY_TOPIC}
-									</p>
-								) : (
-									<div className="grid gap-x-9 gap-y-6 md:grid-cols-[minmax(0,23rem)_1fr]">
-										<LeadCard it={featured} range={range} />
-										<div className="border-t border-stroke-subtle">
-											{scan.map((item) => (
-												<ScanRow key={item.id} it={item} range={range} />
-											))}
-										</div>
-									</div>
-								)}
-							</section>
+								</div>
+							</div>
 						)}
-					</div>
+					</TopicRow>
 				);
 			})}
+		</div>
+	);
+}
+
+/**
+ * One row of the accordion: the label column, the summary line and the
+ * chevron in a button inside a heading, over the body as a labelled region
+ * when open. The Context row and the five topics share this one shape.
+ */
+function TopicRow({
+	id,
+	index,
+	label,
+	summary,
+	watermark,
+	open,
+	onToggle,
+	onKeyDown,
+	buttonRef,
+	children,
+}: {
+	id: string;
+	index: number;
+	label: string;
+	summary: ReactNode;
+	watermark: ReactNode;
+	open: boolean;
+	onToggle: () => void;
+	onKeyDown: (event: KeyboardEvent<HTMLButtonElement>, index: number) => void;
+	buttonRef: (node: HTMLButtonElement | null) => void;
+	children: ReactNode;
+}) {
+	const buttonId = `usage-topic-${id}`;
+	const panelId = `usage-panel-${id}`;
+	return (
+		<div className="border-b border-stroke-subtle">
+			<h3 className="relative m-0">
+				{watermark && (
+					<span
+						aria-hidden="true"
+						data-testid="usage-watermark"
+						className="pointer-events-none absolute inset-x-0 inset-y-1.5 overflow-hidden opacity-[0.22] [&>*]:h-full"
+					>
+						{watermark}
+					</span>
+				)}
+				<button
+					ref={buttonRef}
+					type="button"
+					id={buttonId}
+					aria-expanded={open}
+					aria-controls={panelId}
+					data-testid="usage-topic"
+					onClick={onToggle}
+					onKeyDown={(event) => onKeyDown(event, index)}
+					className="relative flex min-h-16 w-full cursor-pointer items-center gap-4 px-1 py-4 text-left transition-colors hover:bg-bg-panel/50 md:gap-5"
+				>
+					<span className="w-16 shrink-0 font-mono text-[11px] font-bold uppercase tracking-[0.14em] text-accent-lime md:w-20 md:text-xs">
+						{label}
+					</span>
+					<span
+						data-testid="usage-summary"
+						className="flex min-w-0 flex-1 flex-wrap gap-x-4 gap-y-1 text-[13px] text-fg-secondary md:text-sm"
+					>
+						{summary}
+					</span>
+					<ChevronDown
+						aria-hidden="true"
+						className={cn(
+							"size-4 shrink-0 text-fg-muted transition-transform",
+							open && "rotate-180",
+						)}
+					/>
+				</button>
+			</h3>
+			{/* A named section is a region: the heading's button labels it. */}
+			{open && (
+				<section
+					id={panelId}
+					aria-labelledby={buttonId}
+					className="pb-7 pl-1 pt-2 md:pl-24"
+				>
+					{children}
+				</section>
+			)}
 		</div>
 	);
 }

--- a/src/features/usage/ContextRow.tsx
+++ b/src/features/usage/ContextRow.tsx
@@ -1,0 +1,228 @@
+import { fmtShare, fmtTokens } from "@/features/measured/copy";
+import { cn } from "@/lib/utils";
+import {
+	CONTEXT_HINT,
+	CONTEXT_PAINT,
+	type ContextHarness,
+	type ContextReading,
+	fmtWholeShare,
+	type WaffleCell,
+	waffleCells,
+} from "./context";
+import { harnessLabel } from "./HarnessShareRows";
+
+/**
+ * The Context row (#359, locked prototype `prototype/context-breakdown`): what
+ * a typical API call carries against each harness's window.
+ *
+ * The head line prints the median call and its share of each harness's window.
+ * The body prints one block per harness: the median call, then a 200-cell grid
+ * (one cell is 0.5% of the window) next to its legend. Filled cells are the
+ * median call split into harness, instructions and usual chat; outlined cells
+ * run to the p90; the rest is free. A harness with no known window prints the
+ * legend alone and drops out of the head line's shares.
+ *
+ * The grid is plain spans, so it server-renders like every other chart. The
+ * row ranks nothing: harnesses print in the server's order.
+ */
+
+/** The head line: "118K median call · 12% of the Claude Code window · ...". */
+export function ContextSummary({
+	context,
+}: {
+	context: NonNullable<ContextReading>;
+}) {
+	const first = context.harnesses[0];
+	if (!first) return null;
+	return (
+		<>
+			<span>
+				<b className="font-mono text-accent-lime">
+					{fmtTokens(first.medianCall)}
+				</b>{" "}
+				median call
+			</span>
+			{context.harnesses.map((h) =>
+				h.window === null ? null : (
+					<span key={h.harness}>
+						<b className="font-mono text-fg-primary">
+							{fmtWholeShare(h.medianCall / h.window)}
+						</b>{" "}
+						of the {harnessLabel(h.harness)} window
+					</span>
+				),
+			)}
+		</>
+	);
+}
+
+export function ContextBody({
+	context,
+}: {
+	context: NonNullable<ContextReading>;
+}) {
+	return (
+		<div
+			data-testid="context-body"
+			className="grid gap-x-12 gap-y-8 [grid-template-columns:repeat(auto-fit,minmax(min(420px,100%),1fr))]"
+		>
+			{context.harnesses.map((h) => (
+				<HarnessBlock key={h.harness} h={h} />
+			))}
+		</div>
+	);
+}
+
+function HarnessBlock({ h }: { h: ContextHarness }) {
+	const name = harnessLabel(h.harness);
+	return (
+		<div data-testid="context-harness">
+			<p className="mb-3 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+				<b className="font-mono text-[15px] text-fg-primary">{name}</b>
+				<span className="font-mono text-[22px] font-black leading-none text-fg-primary">
+					{fmtTokens(h.medianCall)}
+				</span>
+				<span className="font-mono text-xs text-fg-muted">
+					{h.window !== null && (
+						<>
+							of {fmtTokens(h.window)} ·{" "}
+							{fmtWholeShare(h.medianCall / h.window)} full ·{" "}
+						</>
+					)}
+					{h.calls.toLocaleString("en-US")} calls
+				</span>
+			</p>
+			{h.window === null ? (
+				<Legend h={h} window={null} />
+			) : (
+				<div className="grid items-start gap-6 sm:grid-cols-[minmax(0,320px)_1fr]">
+					<Waffle h={h} name={name} window={h.window} />
+					<Legend h={h} window={h.window} />
+				</div>
+			)}
+		</div>
+	);
+}
+
+const CELL_STYLE: Record<WaffleCell, React.CSSProperties> = {
+	harness: { background: CONTEXT_PAINT.harness },
+	instructions: { background: CONTEXT_PAINT.instructions },
+	usualChat: { background: CONTEXT_PAINT.usualChat },
+	longChat: {
+		background: "transparent",
+		boxShadow: "inset 0 0 0 1px var(--stroke-strong)",
+	},
+	free: { background: "var(--bg-panel-muted)" },
+};
+
+function Waffle({
+	h,
+	name,
+	window,
+}: {
+	h: ContextHarness;
+	name: string;
+	window: number;
+}) {
+	const cells = waffleCells(h, window);
+	return (
+		<div
+			role="img"
+			aria-label={`${name}: a typical call uses ${fmtTokens(h.medianCall)} of a ${fmtTokens(window)} window`}
+			data-testid="context-waffle"
+			className="grid max-w-[320px] grid-cols-[repeat(20,1fr)] gap-[3px]"
+		>
+			{cells.map((cell, i) => (
+				<span
+					// biome-ignore lint/suspicious/noArrayIndexKey: cells are positional and never reorder, so the index is the identity
+					key={i}
+					data-cell={cell}
+					className="block aspect-square w-full"
+					style={CELL_STYLE[cell]}
+				/>
+			))}
+		</div>
+	);
+}
+
+function Legend({ h, window }: { h: ContextHarness; window: number | null }) {
+	const share = (tokens: number) =>
+		window === null ? null : fmtShare(tokens / window);
+	return (
+		<div data-testid="context-legend">
+			<LegendRow
+				label="harness"
+				tokens={h.harnessTokens}
+				share={share(h.harnessTokens)}
+				title={CONTEXT_HINT.harness}
+				swatch={CELL_STYLE.harness}
+			/>
+			<LegendRow
+				label="instructions"
+				tokens={h.instructionsTokens}
+				share={share(h.instructionsTokens)}
+				title={CONTEXT_HINT.instructions}
+				swatch={CELL_STYLE.instructions}
+			/>
+			<LegendRow
+				label="usual chat"
+				tokens={h.usualChat}
+				share={share(h.usualChat)}
+				title={CONTEXT_HINT.usualChat}
+				swatch={CELL_STYLE.usualChat}
+			/>
+			<LegendRow
+				label="long chat"
+				tokens={h.longChat}
+				share={share(h.longChat)}
+				title={CONTEXT_HINT.longChat}
+				swatch={CELL_STYLE.longChat}
+				className="mt-1.5"
+			/>
+			{window !== null && (
+				<LegendRow
+					label="free"
+					tokens={Math.max(0, window - h.medianCall)}
+					share={share(Math.max(0, window - h.medianCall))}
+					swatch={CELL_STYLE.free}
+				/>
+			)}
+		</div>
+	);
+}
+
+function LegendRow({
+	label,
+	tokens,
+	share,
+	title,
+	swatch,
+	className,
+}: {
+	label: string;
+	tokens: number;
+	share: string | null;
+	title?: string;
+	swatch: React.CSSProperties;
+	className?: string;
+}) {
+	return (
+		<div
+			title={title}
+			className={cn("flex items-baseline gap-2 py-[3px]", className)}
+		>
+			<span
+				aria-hidden="true"
+				className="size-2 shrink-0 self-center"
+				style={swatch}
+			/>
+			<span className="min-w-[104px] font-mono text-xs text-fg-secondary">
+				{label}
+			</span>
+			<b className="font-mono text-xs text-fg-primary">{fmtTokens(tokens)}</b>
+			{share !== null && (
+				<span className="font-mono text-xs text-fg-muted">{share}</span>
+			)}
+		</div>
+	);
+}

--- a/src/features/usage/HarnessShareRows.tsx
+++ b/src/features/usage/HarnessShareRows.tsx
@@ -7,12 +7,17 @@ export const SOURCE_PAINTS = [
 	"var(--source-3)",
 ] as const;
 
-const HARNESS_LABELS: Record<string, string> = {
+export const HARNESS_LABELS: Record<string, string> = {
 	"claude-code": "Claude Code",
 	codex: "Codex",
 	opencode: "opencode",
 	"pi-mono": "Pi",
 };
+
+/** The display name of a harness id, the same one every row on the page uses. */
+export function harnessLabel(name: string): string {
+	return HARNESS_LABELS[name] ?? name;
+}
 
 export type HarnessTokens = { readonly name: string; readonly tokens: number };
 
@@ -39,7 +44,7 @@ export function HarnessShareRows({
 	const rows = [...byHarness.entries()]
 		.map(([name, tokens]) => ({
 			name,
-			label: HARNESS_LABELS[name] ?? name,
+			label: harnessLabel(name),
 			tokens,
 			share: total > 0 ? tokens / total : 0,
 			extra: !stackToolSlugs.includes(name),

--- a/src/features/usage/UsageSection.tsx
+++ b/src/features/usage/UsageSection.tsx
@@ -3,8 +3,9 @@ import { useState } from "react";
 import { KICKER, MEASURED_ANCHOR, TITLE } from "@/features/measured/copy";
 import { Section, SectionHeader } from "@/features/stack-view/ui";
 import { api } from "../../../convex/_generated/api";
-import { UsageAccordion } from "./Accordion";
+import { CONTEXT_TOPIC, UsageAccordion } from "./Accordion";
 import { ControlBar, type MachineChoice } from "./ControlBar";
+import { contextOf } from "./context";
 import { type RangeId, rangeDays } from "./copy";
 import { buildItems, pick, TOPIC, type UsageSource } from "./items";
 import { NeverMeasured, OwnerNotMeasured } from "./NotMeasured";
@@ -28,7 +29,9 @@ import { topicWatermark } from "./watermarks";
  * THE SECTION RANKS NOTHING. The top block is a fixed editorial pick, the
  * accordion holds a fixed order, and the owner has no per-row control.
  *
- * EVERY TOPIC STARTS CLOSED. The five summary rows are the section's second
+ * THE CONTEXT ROW STARTS OPEN AND EVERY TOPIC STARTS CLOSED (#359). The open
+ * state starts at the Context row; a reading with no context prints no such
+ * row, so nothing is open. The five summary rows are the section's second
  * layer; a click opens one, and the depth is one click away on every screen.
  *
  * A null reading renders an INVITATION addressed to the reader, never a
@@ -53,7 +56,7 @@ export function UsageSection({
 		slug: string;
 		ordinal: number;
 	} | null>(null);
-	const [openTopic, setOpenTopic] = useState<string | null>(null);
+	const [openTopic, setOpenTopic] = useState<string | null>(CONTEXT_TOPIC);
 	const ordinal = selection?.slug === slug ? selection.ordinal : null;
 	const machineArg = ordinal === null ? {} : { machineOrdinal: ordinal };
 
@@ -94,6 +97,9 @@ export function UsageSection({
 				? { kind: "legacy", legacy }
 				: null;
 	const items = buildItems(view, source, stackToolSlugs);
+	// #358 adds `context` to the workflow answer. Until it merges the field is
+	// absent, and an absent reading prints no row.
+	const context = contextOf(view);
 
 	return (
 		<Section
@@ -135,6 +141,7 @@ export function UsageSection({
 						value={openTopic}
 						onChange={setOpenTopic}
 						range={range}
+						context={context}
 						watermark={(group) =>
 							topicWatermark(
 								group.id,

--- a/src/features/usage/__tests__/context-row.test.tsx
+++ b/src/features/usage/__tests__/context-row.test.tsx
@@ -1,0 +1,226 @@
+// @vitest-environment jsdom
+/**
+ * The Context row (#359): the first row of the Stats accordion, open by
+ * default, drawn from the reading #358 folds.
+ *
+ *   1. IT LEADS AND STARTS OPEN when the server hands a context reading, and
+ *      it joins the exclusive set: opening Time closes it.
+ *   2. THE HEAD LINE prints the median call in the accent and one share per
+ *      harness with a known window.
+ *   3. THE GRID IS 200 PLAIN CELLS per harness, filled in the fixed order,
+ *      and it server-renders like every other chart.
+ *   4. NO READING, NO ROW: the accordion starts at Time as before.
+ */
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	within,
+} from "@testing-library/react";
+import { getFunctionName } from "convex/server";
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { WorkflowView } from "@/features/workflow/copy";
+import { api } from "../../../../convex/_generated/api";
+import { view as workflowView } from "../../workflow/__tests__/fixture";
+import { ContextBody } from "../ContextRow";
+import { contextOf, waffleCells } from "../context";
+import { PAGE_RANGE } from "../copy";
+import { UsageSection } from "../UsageSection";
+import { contextReading, usage } from "./fixture";
+
+const queryMock = vi.fn();
+
+vi.mock("convex/react", () => ({
+	useQuery: (ref: unknown, args: unknown) => queryMock(ref, args),
+	useMutation: () => vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+	Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+		<a href={to}>{children}</a>
+	),
+}));
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+/** A workflow answer with the #358 field, typed loosely until it merges. */
+function withContext(
+	context: ReturnType<typeof contextReading> | null,
+): WorkflowView {
+	return { ...workflowView(), context } as WorkflowView;
+}
+
+function setup(workflow: WorkflowView | null = withContext(contextReading())) {
+	const names = {
+		usage: getFunctionName(api.measured.getUsageByStackSlug),
+		workflow: getFunctionName(api.workflow.getWorkflowByStackSlug),
+	};
+	queryMock.mockImplementation((ref: Parameters<typeof getFunctionName>[0]) => {
+		const name = getFunctionName(ref);
+		if (name === names.usage) return usage();
+		if (name === names.workflow) return workflow;
+		return undefined;
+	});
+	return render(
+		<UsageSection
+			index={1}
+			slug="alp"
+			isOwner={false}
+			stackToolSlugs={["claude-code", "codex"]}
+			range={PAGE_RANGE}
+		/>,
+	);
+}
+
+const topics = () => screen.getAllByTestId("usage-topic");
+const expanded = () =>
+	topics().filter((row) => row.getAttribute("aria-expanded") === "true");
+
+describe("the Context row", () => {
+	it("leads the accordion and starts open", () => {
+		setup();
+		const first = topics()[0];
+		expect(first.textContent).toMatch(/^Context/);
+		expect(topics()[1].textContent).toMatch(/^Time/);
+		expect(expanded()).toEqual([first]);
+		const region = screen.getByRole("region", { name: /^Context/ });
+		expect(region).toHaveAttribute("id", first.getAttribute("aria-controls"));
+		expect(within(region).getByTestId("context-body")).toBeInTheDocument();
+	});
+
+	it("prints the median call and one share per harness on the head line", () => {
+		setup();
+		const summary = within(topics()[0]).getByTestId("usage-summary");
+		expect(summary.textContent).toBe(
+			"118K median call12% of the Claude Code window42% of the Codex window",
+		);
+		const figures = summary.querySelectorAll("b");
+		expect(figures).toHaveLength(3);
+		expect(figures[0]).toHaveClass("font-mono", "text-accent-lime");
+		expect(figures[1]).toHaveClass("font-mono");
+		expect(figures[1]).not.toHaveClass("text-accent-lime");
+	});
+
+	it("joins the exclusive set: opening Time closes it, a second click closes it", () => {
+		setup();
+		const time = topics()[1];
+		fireEvent.click(time);
+		expect(expanded()).toEqual([time]);
+		expect(screen.queryByTestId("context-body")).toBeNull();
+		fireEvent.click(topics()[0]);
+		expect(expanded()).toEqual([topics()[0]]);
+		fireEvent.click(topics()[0]);
+		expect(expanded()).toHaveLength(0);
+	});
+
+	it("moves focus over the Context row with the arrow keys", () => {
+		setup();
+		const [context, time] = topics();
+		context.focus();
+		fireEvent.keyDown(context, { key: "ArrowDown" });
+		expect(document.activeElement).toBe(time);
+		fireEvent.keyDown(time, { key: "Home" });
+		expect(document.activeElement).toBe(context);
+		fireEvent.keyDown(context, { key: "ArrowUp" });
+		expect(document.activeElement).toBe(topics()[topics().length - 1]);
+	});
+
+	it("draws one block per harness with exactly 200 cells and the legend", () => {
+		setup();
+		const blocks = screen.getAllByTestId("context-harness");
+		expect(blocks).toHaveLength(2);
+		const waffles = screen.getAllByRole("img");
+		expect(waffles).toHaveLength(2);
+		for (const waffle of waffles) {
+			expect(waffle.querySelectorAll("span")).toHaveLength(200);
+		}
+		expect(waffles[0]).toHaveAttribute(
+			"aria-label",
+			"Claude Code: a typical call uses 118K of a 1.0M window",
+		);
+		expect(waffles[1]).toHaveAttribute(
+			"aria-label",
+			"Codex: a typical call uses 109K of a 258K window",
+		);
+		const claude = blocks[0];
+		expect(claude.textContent).toContain("of 1.0M · 12% full · 15,683 calls");
+		const legend = within(claude).getByTestId("context-legend");
+		expect(legend.textContent).toBe(
+			"harness19K1.9%instructions25K2.5%usual chat74K7.4%long chat217K21.7%free882K88.2%",
+		);
+		expect(
+			within(legend).getByTitle(/system prompt and tool definitions/),
+		).toBeInTheDocument();
+		expect(
+			within(legend).getByTitle(/CLAUDE\.md, memory, skills/),
+		).toBeInTheDocument();
+		expect(
+			within(legend).getByTitle(/1 in 10 chats grow past this/),
+		).toBeInTheDocument();
+	});
+
+	it("fills the grid in order: harness, instructions, usual chat, long chat, free", () => {
+		const cells = waffleCells(contextReading().harnesses[0], 1_000_000);
+		expect(cells).toHaveLength(200);
+		const runs = cells.reduce<[string, number][]>((acc, cell) => {
+			const last = acc[acc.length - 1];
+			if (last && last[0] === cell) last[1] += 1;
+			else acc.push([cell, 1]);
+			return acc;
+		}, []);
+		expect(runs).toEqual([
+			["harness", 4],
+			["instructions", 5],
+			["usualChat", 15],
+			["longChat", 28],
+			["free", 148],
+		]);
+		expect(waffleCells(contextReading().harnesses[1], 258_400)).toHaveLength(
+			200,
+		);
+	});
+
+	it("server-renders the grid as plain spans", () => {
+		const html = renderToString(<ContextBody context={contextReading()} />);
+		expect(html.match(/role="img"/g)).toHaveLength(2);
+		expect(html.match(/data-cell="/g)).toHaveLength(400);
+		expect(html).not.toContain("<svg");
+	});
+
+	it("drops the share and the grid for a harness with no known window", () => {
+		const reading = contextReading();
+		reading.harnesses[1].window = null;
+		setup(withContext(reading));
+		const summary = within(topics()[0]).getByTestId("usage-summary");
+		expect(summary.textContent).toBe(
+			"118K median call12% of the Claude Code window",
+		);
+		expect(screen.getAllByRole("img")).toHaveLength(1);
+		const codex = screen.getAllByTestId("context-harness")[1];
+		expect(codex.textContent).toContain("150,881 calls");
+		expect(codex.textContent).not.toContain("full");
+		expect(within(codex).queryByText("free")).toBeNull();
+	});
+
+	it("is absent when the reading has no context, and the accordion starts closed", () => {
+		setup(withContext(null));
+		expect(topics()[0].textContent).toMatch(/^Time/);
+		expect(screen.queryByTestId("context-body")).toBeNull();
+		expect(expanded()).toHaveLength(0);
+		expect(screen.queryByRole("region")).toBeNull();
+	});
+
+	it("is absent when the field is missing or the harness list is empty", () => {
+		expect(contextOf(workflowView())).toBeNull();
+		expect(contextOf({ context: { harnesses: [] } })).toBeNull();
+		expect(contextOf(null)).toBeNull();
+		expect(contextOf(undefined)).toBeNull();
+		setup({ ...workflowView(), context: { harnesses: [] } } as WorkflowView);
+		expect(topics()[0].textContent).toMatch(/^Time/);
+	});
+});

--- a/src/features/usage/__tests__/fixture.ts
+++ b/src/features/usage/__tests__/fixture.ts
@@ -1,3 +1,4 @@
+import type { ContextReading } from "../context";
 import type { RangeId, UsageRead, UsageReading } from "../copy";
 
 /**
@@ -140,4 +141,53 @@ export function legacyUsage(over: Partial<UsageRead> = {}): UsageRead {
 		legacy: legacyFigure(),
 		...over,
 	});
+}
+
+/**
+ * The Context row's reading (#359): the owner's real 30 days to 2026-09-07,
+ * two harnesses. Usual chat and long chat derive from the median and p90 after
+ * the harness and instructions tokens.
+ */
+export function contextReading(): NonNullable<ContextReading> {
+	const harness = (h: {
+		harness: string;
+		window: number | null;
+		calls: number;
+		medianCall: number;
+		p90Call: number;
+		harnessTokens: number;
+		instructionsTokens: number;
+		compactions: number;
+	}) => ({
+		...h,
+		usualChat: Math.max(
+			0,
+			h.medianCall - h.harnessTokens - h.instructionsTokens,
+		),
+		longChat: Math.max(0, h.p90Call - h.harnessTokens - h.instructionsTokens),
+	});
+	return {
+		harnesses: [
+			harness({
+				harness: "claude-code",
+				window: 1_000_000,
+				calls: 15_683,
+				medianCall: 118_090,
+				p90Call: 260_921,
+				harnessTokens: 19_066,
+				instructionsTokens: 25_308,
+				compactions: 0,
+			}),
+			harness({
+				harness: "codex",
+				window: 258_400,
+				calls: 150_881,
+				medianCall: 108_967,
+				p90Call: 184_161,
+				harnessTokens: 11_904,
+				instructionsTokens: 6_611,
+				compactions: 526,
+			}),
+		],
+	};
 }

--- a/src/features/usage/context.ts
+++ b/src/features/usage/context.ts
@@ -1,0 +1,86 @@
+/**
+ * The Context row's reading (#359): what a typical API call carries against
+ * each harness's window, folded by the server (#358).
+ *
+ * TEMPORARY SHAPE. Until #358 merges, the payload of `getWorkflowByStackSlug`
+ * carries no `context` field, so the row types it here and reads it with an
+ * optional-chaining fallback. Replace this type with the generated Convex type
+ * once that PR lands.
+ */
+export type ContextReading = {
+	harnesses: {
+		harness: string; // the harness id used elsewhere in the payload
+		window: number | null; // tokens; null when unknown
+		calls: number;
+		medianCall: number;
+		p90Call: number;
+		harnessTokens: number;
+		instructionsTokens: number;
+		usualChat: number; // medianCall - harnessTokens - instructionsTokens, floored at 0
+		longChat: number; // p90Call - harnessTokens - instructionsTokens, floored at 0
+		compactions: number;
+	}[];
+} | null;
+
+export type ContextHarness = NonNullable<ContextReading>["harnesses"][number];
+
+/** The reading off a workflow answer, absent until #358 ships the field. */
+export function contextOf(view: unknown): ContextReading {
+	const context = (view as { context?: ContextReading } | null | undefined)
+		?.context;
+	if (!context || context.harnesses.length === 0) return null;
+	return context;
+}
+
+/** The three series wear palette slots, never the accent (Charts rule). */
+export const CONTEXT_PAINT = {
+	harness: "var(--chart-4)",
+	instructions: "var(--chart-2)",
+	usualChat: "var(--chart-1)",
+} as const;
+
+export const CONTEXT_HINT = {
+	harness:
+		"what the harness itself sends on every call: system prompt and tool definitions",
+	instructions:
+		"what the owner added: CLAUDE.md, memory, skills, agents, the first prompt",
+	usualChat: "the median call, after the harness and instructions",
+	longChat: "1 in 10 chats grow past this, after the harness and instructions",
+} as const;
+
+/** 200 cells in 20 columns: one cell is 0.5% of the window. */
+export const WAFFLE_CELLS = 200;
+
+export type WaffleCell =
+	| "harness"
+	| "instructions"
+	| "usualChat"
+	| "longChat"
+	| "free";
+
+/**
+ * The fill of the grid, from the top left: harness, instructions and usual
+ * chat up to the median call, outlined cells up to the p90, free after that.
+ */
+export function waffleCells(h: ContextHarness, window: number): WaffleCell[] {
+	const cell = window / WAFFLE_CELLS;
+	const harness = Math.round(h.harnessTokens / cell);
+	const instructions = Math.round(h.instructionsTokens / cell);
+	const filled = Math.max(
+		harness + instructions,
+		Math.round(h.medianCall / cell),
+	);
+	const p90 = Math.min(WAFFLE_CELLS, Math.round(h.p90Call / cell));
+	return Array.from({ length: WAFFLE_CELLS }, (_, i) => {
+		if (i < harness) return "harness";
+		if (i < harness + instructions) return "instructions";
+		if (i < filled) return "usualChat";
+		if (i < p90) return "longChat";
+		return "free";
+	});
+}
+
+/** "12%": a share of the window, whole percent. */
+export function fmtWholeShare(share: number): string {
+	return `${Math.round(share * 100)}%`;
+}


### PR DESCRIPTION
## The row

A **Context** row as the first entry of the Stats accordion, before Time, open by default. Locked render: `prototypes/context-breakdown` (round 3).

- **Head line**: `118K median call · 12% of the Claude Code window · 42% of the Codex window`. Figures in mono bold, the median call in the accent, harness names from the page's display names. A harness with no known window drops out of the shares.
- **Body**: one block per harness, side by side on wide screens (`auto-fit, minmax(420px, 1fr)`), stacked on narrow. Block head: harness name, the median call large, then muted `of 1.0M · 12% full · 15,683 calls`. Under it the waffle (max 320px) next to the legend.
- **Waffle**: 200 plain `span` cells in 20 columns, 3px gap, sharp corners, so it server-renders like the other charts. Fill from the top left: harness, instructions, usual chat up to the median call; outlined cells (inset box-shadow in `--stroke-strong`) up to the p90; the rest `--bg-panel-muted`. `role="img"` with the sentence "Claude Code: a typical call uses 118K of a 1M window". Window null: legend only.
- **Legend**: harness, instructions, usual chat, long chat (outlined square), free. Tokens in mono bold, share of the window muted. Hover titles carry the prototype's definitions. No rule between rows, no notes.
- **Colors**: three series, so palette slots (`--chart-4`, `--chart-2`, `--chart-1`), never the accent. All three tokens exist in `src/styles.css` in both themes.
- `context` null or an empty harness list: no row, and the accordion starts at Time as before.

## How

- `src/features/usage/context.ts`: the `ContextReading` type, `contextOf(view)`, the waffle fill and the palette map.
- `src/features/usage/ContextRow.tsx`: the head line and the body.
- `src/features/usage/Accordion.tsx`: the row markup moves into one shared `TopicRow`, so the Context row is one more row in the same exclusive set (keyboard navigation included) rather than a new component style. `UsageSection` starts the open state at `CONTEXT_TOPIC`.
- `harnessLabel()` exported from `HarnessShareRows.tsx` so the row uses the same names as the harness bars.

## Blocked on #358

This PR is **blocked on #358 for live data**. Until it merges, `getWorkflowByStackSlug` carries no `context` field, so `ContextReading` is typed locally in `src/features/usage/context.ts` and read off the workflow answer with an optional-chaining fallback: the page works as today and prints no row. Once #358 lands, replace `ContextReading` with the generated Convex type and drop the cast in `contextOf`.

## Open

The other rows carry a faint chart behind the head line. The Context row has none here, as in the prototype. The per-call histogram as a backdrop is left for a follow-up.

## Tests

`src/features/usage/__tests__/context-row.test.tsx`: the row renders first and open with the fixture (two harnesses, real numbers), the head line and legend figures, exactly 200 cells per harness in the fixed fill order, a server render of plain spans with no SVG, the null-window fallback, and the row absent when `context` is null, missing, or empty. Existing usage-section tests unchanged and green.

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STFMEvm4Wr9esnczxcdRSj
