### PR TITLE
feat(cli): add Cursor sync and measured statistics

### DIFF
--- a/convex/leaderboard.test.ts
+++ b/convex/leaderboard.test.ts
@@ -227,6 +227,15 @@ async function staleSync(
 }
 
 describe('leaderboard.get', () => {
+  test('includes Cursor tokens and history in the normal harness filter', async () => {
+    const t = convexTest(schema, modules)
+    const stack = await seedStack(t, { name: 'Cursor Stack' })
+    await sync(t, stack.stackId, { totalTokens: 1234, harness: 'cursor' })
+    const board = await t.query(api.leaderboard.get, {})
+    expect(board.rows[0]).toMatchObject({ tokens: 1234, harnesses: ['cursor'] })
+    expect(board.harnesses.some(h => h.key === 'cursor')).toBe(true)
+  })
+
   test('ranks living stacks by measured tokens and excludes low quality', async () => {
     const t = convexTest(schema, modules)
     const small = await seedStack(t, { name: 'Small' })

--- a/convex/measured.test.ts
+++ b/convex/measured.test.ts
@@ -2507,3 +2507,32 @@ describe('getUsageByStackSlug publishes the inventory and the machines', () => {
     ).toMatchObject({ hasDays: false, inventory: [] })
   })
 })
+
+
+describe('Cursor statistics integration', () => {
+  test('publishes inventory, machine-filtered usage, history and cost consent through existing queries', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, shortId } = await seedStack(t, { publishCost: true })
+    const slug = `my-stack-${shortId}`
+    for (const [machine, input] of [['desktop', 1000], ['laptop', 2000]] as const) {
+      await t.mutation(internal.measured.publishSnapshot, {
+        stackId, machine,
+        payload: payload({ harness: { name: 'cursor', version: null } }),
+        measuredDays: usageWire(today(), { harness: 'cursor', input, usd: input / 1000000 }),
+      })
+    }
+    const usage = await t.query(api.measured.getUsageByStackSlug, { slug })
+    expect(usage?.inventory.map(h => h.harness)).toEqual(['cursor', 'cursor'])
+    expect(usage?.machines).toHaveLength(2)
+    expect(usage?.current?.totalTokens).toBe(3000)
+    expect(usage?.current?.cost).not.toBeNull()
+    expect(usage?.series).toMatchObject([{ date: today(), tokens: 3000 }])
+    const laptop = await t.query(api.measured.getUsageByStackSlug, { slug, machineOrdinal: 2 })
+    expect(laptop?.current?.totalTokens).toBe(2000)
+    await t.run(ctx => ctx.db.patch(stackId, { publishCost: false, publishWorkflow: false }))
+    const privateCost = await t.query(api.measured.getUsageByStackSlug, { slug })
+    expect(privateCost?.current?.cost).toBeNull()
+    expect(privateCost?.current?.totalTokens).toBe(3000)
+    expect(await t.query(api.workflow.getWorkflowByStackSlug, { slug })).toBeNull()
+  })
+})

--- a/docs/research/cursor-autosync-validation-2026-09.md
+++ b/docs/research/cursor-autosync-validation-2026-09.md
@@ -1,0 +1,20 @@
+# Cursor automatic sync lifecycle validation
+
+Implements [Implement Cursor automatic sync and connection lifecycle](https://github.com/alp82/aistack/issues/392), following the accepted attribution contract.
+
+The trigger is the user-level `stop` array in `~/.cursor/hooks.json`. Project hooks are not installed. [Cursor's hook reference](https://cursor.com/docs/hooks), checked 2026-09-10, documents that user configuration reloads automatically and is unavailable to cloud agents. The hook ignores event input and returns no output. It stores no event sidecar, email, credentials or history. Retained history already supplies the supported workflow metrics.
+
+Installation preserves foreign stop commands, other events and settings. Reinstallation replaces the exact owned command across supported platform variants. Invalid configuration and write errors return a failed installation result, so measurement detection cannot masquerade as an installed trigger. Enable and reconciliation use the existing stack permission; disable closes the local gate before attempting removal or the remote revoke. Automatic runs never reinstall or ask for approval.
+
+Launchers run the existing latest-npx command with its cached fallback in a detached process. Unix launchers use nohup (plus setsid on Linux); Windows explicitly invokes noninteractive PowerShell and Start-Process with encoded fixed script text to avoid differences in the parent shell's quoting. All child standard streams are discarded. Cursor failures remain in the existing local log and next manual-sync status, with no hook JSON or follow-up message.
+
+Checks actually run:
+
+- Temporary configuration tests: coexistence, repeated install, removal, malformed and unsupported configuration, write failures.
+- Linux subprocess execution of both Unix launcher variants using a synthetic npx executable: detachment, discarded hook stdin, empty output and offline fallback. This does not establish native macOS execution.
+- Windows command construction and decoded launcher assertions only.
+- Consent lifecycle, missing-trigger reconciliation without prompts, removal failure after local revocation, failure-output suppression and repeated-stop throttle tests.
+- Existing collector failure/cache tests, plus a synthetic SQLite credential replacement: a renewed token is reread with the same account scope, while another account uses a different scope.
+- Targeted autosync and Cursor account/scan suites, no-em-dash check, CLI TypeScript check and bundled build.
+
+Native checks still required for release: owner-approved manual sync and automatic Cursor stop delivery against the intended backend; actual unattended login reuse, expired/unavailable access fallback and reuse after Cursor renews its login; native macOS and Windows launcher execution and GUI PATH availability. The owner runs interactive login and sync in their own terminal. No native credentials, private history, paid sessions or owner approval gates were accessed during these checks. No version bump, push, deployment or publication is claimed.

--- a/docs/research/cursor-collection-implementation-2026-09.md
+++ b/docs/research/cursor-collection-implementation-2026-09.md
@@ -1,0 +1,42 @@
+# Cursor collection implementation
+
+Implements [Implement Cursor usage collection and historical sync](https://github.com/alp82/aistack/issues/389) under the [accepted acquisition and accounting contract](https://github.com/alp82/aistack/issues/388#issuecomment-5617625795).
+
+## Acquisition and accounting
+
+The normal `cursor` harness adapter is registered alongside the existing adapters. Discovery reads retained source timestamps, including previously cached evidence, so an unreadable or temporarily missing source reaches the shared incomplete-scan gate. File modification times never date usage. `CURSOR_DATA_PATH` names the reader's workspaceStorage root; `CURSOR_STORE_ROOT` retains the reader's Store override. Default IDE paths cover Linux/XDG, macOS Application Support and Windows APPDATA. The reader naturally reconciles Composer, transcripts and retained CLI/ACP Store representations by native conversation.
+
+`cursor-history` is pinned to npm release 0.18.0 and remains an external runtime dependency in the published CLI. The adapter explicitly selects its built-in `node:sqlite` driver. The workspace disables build scripts for its transitive `better-sqlite3` dependency; synthetic Composer and overlapping-transcript reads pass without that native binary. Hydrated session resolution is authoritative: a summary can be partial before loading a complete resolved session. Unreadable, malformed, ambiguous, limited or corrupt sources withhold measured-day replacement.
+
+A narrow supplemental read retrieves Composer token fields by native bubble ID, plus the old inline representation. This avoids the reader's flattened `tokenUsage`, which cannot distinguish reported zero from absent output or a context estimate. The supplemental read uses a read-only SQLite transaction. A changing global database/WAL stamp invalidates the scan rather than combining inconsistent source versions.
+
+Each assistant contribution prefers its own recorded input/output fields. Missing input can use its preceding user message's recorded/context/dry-run count, then `ceil(userText.length / 4)`, consumed once. Missing output independently uses `ceil(assistantText.length / 4)`. Explicit zero remains zero. The normalized local cache retains bucket provenance. No billed-cents inference, system/tool-content invention, reasoning split or per-call Context distribution is introduced. Native copied response prefixes count once within the installation.
+
+Stored message timestamps are authoritative. Ordered untimed records interpolate evenly between stored message/session anchors; a single anchor dates them without inventing duration. Matched usage events can supply anchors to otherwise undated history. Without anchors, models and installation inventory remain available but no dated token contribution is invented.
+
+Personal dashboard JSON uses the qualified `get-filtered-usage-events` endpoint, fixed 30-day UTC query windows, page size 100 and a maximum of 100 pages per window. A page failure, changed total, malformed bucket, repeated page or cap rejects that window. Native event IDs deduplicate; identical-looking ID-less events retain their multiplicity. Only native conversation IDs found in local history are included. Explicit cloud events and background-composer IDs are excluded. Billing-only events do not replace supported local counts. API totals supersede local tokens for the same conversation and UTC date while preserving the local source for workflow projection. API model labels, including Auto, remain their own attribution.
+
+The installation cache stores normalized contributions, account hashes and complete query windows, never credentials or transcript text. Writes use a private temporary file and atomic rename. A successful complete window replaces its prior contents. A now-empty historical window retains previously complete evidence because remote retention can expire. Failed requests retain previous complete windows. A five-minute refresh interval avoids duplicate snapshot/history fetches in one sync. Account changes reset enrichment; a missing login can use the last account's complete local cache. Corrupt caches, disappearing local contributions or partial local reads withhold the machine's measured-day block. Cache repair must preserve this gate; deleting a corrupt cache is not automatically proof that replacing existing server days is safe.
+
+Usage goes through the existing aggregate, shared pricing, name filtering, consent, per-day builder, fingerprint and manifest. Cursor participates in the existing acknowledged session-date hints, with a separate scope from Grok, so corrections include former dates even when they become empty. All raw workspace paths remain local and pass through the existing opaque project-ID seam.
+
+## Authentication and native limitations
+
+Automatic enrichment reads only `ItemTable` key `cursorAuth/accessToken` in the installation's global SQLite store. The JWT subject derives the dashboard cookie in memory and scopes cached enrichment by a hash. No API key, browser-cookie import, reconnect screen or new interactive authentication exists.
+
+The adapter never invokes macOS Keychain, Windows credential UI or a secret-service helper. The qualified Keychain command cannot guarantee it will not prompt, so a Keychain-only installation uses local history and any complete prior cache. Linux, macOS and Windows installations with a usable SQLite login can attempt the same transport. Cursor owns login renewal; later scans re-read the token. Native authenticated success, actual field population/retention, OS credential-storage availability and real account join coverage remain UNRUN. This implementation and its smoke scripts accessed no owner's credentials, private history or paid sessions.
+
+## Checks performed
+
+- Frozen dependency installation, CLI TypeScript check and production CLI build pass.
+- The representative qualification fixtures are copied into `packages/cli/src/harness/cursor/fixtures`. They remain wholly synthetic. Native SQLite tests exercise the installed reader, not a reader mock.
+- Cursor tests cover local-only readings, missing/explicit-zero fields, text estimates, context provenance, API precedence, unmatched/cloud IDs, equal timestamps across conversations, ID-less multiplicity, native-prefix deduplication, repeated refresh, account changes, later-page failure, missing login, UTC interpolation/correction, malformed cache/database, disappeared sources and local-only project privacy/consent.
+- Shared harness, staging, usage and workflow-rule regression tests pass. The added staging case checks former-date rebuilding and complete withholding of machine days on an incomplete Cursor scan.
+- `node scripts/verify-cursor-package.mjs` passes on Node 24.15.0. `pnpm dlx node@22.13.0 scripts/verify-cursor-package.mjs` passes on the CLI's supported minimum. These invoke the actual production bundle's read-only MCP preview with synthetic SQLite, a child-only `os.homedir()` loader and blocked network. They do not invoke interactive sync or publish.
+- No production data, deployment or publication was performed.
+
+## Handoff
+
+`packages/cli/src/harness/cursor/local.ts` exports `readLocal`, returning `LocalRead.sessions: LocalSession[]`, hydrated reader sessions and token evidence. `evidence.ts` exports `messageTimes`, `localContributions` and `reconcile`. `scan.ts` owns aggregation and the Cursor reducer slot. Workflow projection belongs to the dependent workflow ticket: use the retained sessions and interpolated dates while keeping unsupported timing/Context absent. The reader's public session shape does not expose a structural parent-session field; resolve only demonstrated local structural references rather than inventing a parent.
+
+Automatic stop hooks, hook-sidecar enrichment, catalog/consumer polish, owner native smoke checks and release are the remaining map tickets. This collection change does not install any hook and does not claim those tasks complete.

--- a/docs/research/cursor-integration-validation-2026-09.md
+++ b/docs/research/cursor-integration-validation-2026-09.md
@@ -1,0 +1,73 @@
+# Cursor integration validation and release handoff
+
+Status on 2026-09-10: automated acceptance passed. Native acceptance is UNRUN and awaits the owner's release disposition in [Validate Cursor integration and release readiness](https://github.com/alp82/aistack/issues/393). This report does not claim publication or close that ticket.
+
+## Integrated changes
+
+Validated together on `task/cursor-collection`:
+
+- `003f5dbd`: usage collection and historical sync.
+- `1ed0a53c`: workflow metrics and machine inventory.
+- `03214ffe`: shared pricing and statistics consumers.
+- `f06028ff`: stop-hook automatic sync and connection lifecycle.
+
+The existing wire and backend harness handling accept Cursor without a schema migration or a new catalog model. Models use the normal vendor identifiers and pricing catalog. Auto stays unpriced when it cannot resolve. These changes add no Cursor-specific disclaimer, accuracy badge or coverage UI. The existing cost consent, source citation and coverage behavior remain the presentation contract.
+
+The collection, workflow and autosync implementation reports in this directory document the formulas, defaults and supported evidence. Local missing text-token buckets use `ceil(text.length / 4)` once, explicit zero survives, matched API conversation/day totals replace local totals, and unsupported per-call Context and timing remain absent. SQLite login reuse is unattended; Keychain-only installations use local evidence and cached enrichment. No separate login or native credential helper is introduced.
+
+## Checks performed
+
+All commands ran on the combined implementation, using synthetic inputs where a source/account is needed:
+
+```sh
+pnpm exec vitest run packages/cli/src/harness packages/cli/src/autosync packages/cli/src/sync packages/cli/src/usage packages/workflow-rules packages/pricing convex/measured.test.ts convex/workflow.test.ts convex/leaderboard.test.ts src/features/activity/__tests__/feed.test.ts src/features/leaderboard/__tests__/leaderboard-page.test.tsx src/features/usage/__tests__/harness-label.test.ts src/features/workflow/__tests__/harness-label.test.ts src/__tests__/no-em-dash.test.ts
+pnpm exec vitest run packages/cli/src/workflow packages/cli/src/payload.test.ts packages/cli/src/scanner.test.ts
+pnpm --filter @use-aistack/cli build
+node scripts/verify-cursor-package.mjs
+pnpm dlx node@22.13.0 scripts/verify-cursor-package.mjs
+pnpm exec tsc --noEmit -p packages/cli/tsconfig.json
+pnpm build
+pnpm exec biome check packages/cli/src/index.ts
+node packages/cli/dist/index.js sync --help
+git diff --check
+```
+
+- First suite: 50 files, 847 tests passed. Supplementary workflow/scanner suite: 6 files, 33 tests passed. The supplementary command's payload filename filter matched no extra file; shared payload tests ran within the first suite's harness coverage.
+- CLI build and typecheck passed. After the help correction, its Biome check, rebuilt CLI and actual `sync --help` output passed. Production web client, SSR and Nitro build passed, with build chunk-size warnings.
+- Actual production CLI bundle's read-only MCP preview passed on Node 24.15.0 and supported minimum 22.13.0. Synthetic SQLite resolves through the installed pinned reader and writes the expected normalized local cache. The child has an isolated home and blocked network; it does not publish or invoke interactive sync.
+- The integrated suites cover missing/zero fields, local/API overlap, account changes and credential reread, UTC corrections, delayed replacement, ID-less multiplicity, failures and preserved cache, incomplete machine-day withholding, consent-off extraction/pricing, workflow and inventory privacy, two-machine backend histories, pricing and existing display labels.
+- Autosync checks cover installation/removal ownership, malformed config, remote permission order, local disable on removal failure, shared throttle and silent failures. Both Unix command variants execute with synthetic npx on Linux, including offline fallback. Windows command construction is checked without claiming native execution.
+- Diff inspection found no new wire version, database migration or accuracy UI. Updated CLI help to describe harness hooks now that Cursor uses stop instead of SessionStart. No other implementation defect was identified by this validation.
+
+No owner credentials, private retained history, paid session, real interactive sync, production rows or deployment were used. No version was changed. The test evidence establishes the synthetic paths and shared backend behavior; it does not establish a real Cursor account's current field population or native hook delivery.
+
+## Native checks and practical release impact
+
+| Check | Status | Practical impact |
+| --- | --- | --- |
+| Owner-approved manual sync to the local app and inspection of resulting usage/history | UNRUN | Real retained history may expose formats or joins the synthetic reader fixtures do not cover. |
+| Real Cursor stop delivery through the configured hook | UNRUN | Automatic refresh depends on Cursor invoking the command with a usable GUI PATH. The existing manual path remains available if delivery fails. |
+| Actual SQLite login reuse, unavailable/expired access and Cursor renewal | UNRUN | Enrichment success and join coverage remain unverified on a real account. Local estimates and complete-cache fallback are implemented and tested. |
+| Native macOS and Windows execution, including GUI PATH | UNRUN | Launcher text/platform paths are tested synthetically; native shell and environment behavior is unverified. |
+
+These gaps affect the promised real acquisition and automatic-refresh paths, so their release treatment needs the explicit owner disposition required by the validation ticket. They do not justify an exhaustive donor programme or paid session requirement. The Grok Build precedent deferred native checks to post-release user validation after an explicit owner decision. That decision has not yet been recorded for Cursor.
+
+Recommended disposition: accept these exact UNRUN checks as staged post-release owner/user validation, retaining their status and asking for normal user feedback. Alternatively, hold publication until the owner runs the feasible local manual and native stop checks and reports the results; unavailable platform checks still need a disposition. No synthetic result is relabelled as native success.
+
+The installed hook intentionally invokes npm `@latest`, with the existing cached fallback. Before the Cursor release is published, a real stop event can therefore run the older published collector. Pre-release synthetic launcher tests use a controlled executable; they are not evidence that the installed hook has run the new collector against an owner account.
+
+## Owner smoke procedure
+
+For a chosen native smoke run, the owner signs into the local app, builds the CLI, and runs the AGENTS.md local login/sync instructions in their own terminal. If the local stack is missing, sync the production export to dev first and sign in again. Approve only the preview intended for localhost. Check the stack's token/model totals, retained-day behavior, Actual Usage rows and inventory. A second sync should preserve the reading without duplicate days. No new paid activity is required.
+
+Automatic sync needs its normal explicit opt-in. After the Cursor package is published, enable it against the intended backend with `AISTACK_URL=http://localhost:3019 node packages/cli/dist/index.js sync --auto on` when checking dev. Ensure the Cursor process launching the hook also inherits the intended `AISTACK_URL`; otherwise the released hook uses its normal production default. Check a naturally occurring stop event and the existing autosync log/status, respecting the shared six-hour throttle. Disable through `sync --auto off` when finished. Do not bypass the CLI's interactive gate or reset consent/throttle state to manufacture a pass.
+
+## Backend-first release handoff
+
+[Deploy Cursor backend support and publish the CLI](https://github.com/alp82/aistack/issues/394) owns all publication:
+
+1. Record the owner's disposition or actual native outcomes on the validation ticket before closing acceptance.
+2. Integrate the four implementation commits and this report using a Conventional Commit CLI feature title. Preserve unrelated workspace changes. Resolve any current-main drift through the normal review workflow; this report validates the local combined branch, not a future merge commit.
+3. Wait for the `deploy-convex.yml` workflow on the merged main commit. There is no Cursor migration in this change. If later integration requires a migration, run it only via the server wrapper after its code is deployed.
+4. Let Release Please choose the CLI version and release PR. Merge that PR only after compatible backend deployment and the acceptance disposition. `publish-cli.yml` publishes its release commit through npm OIDC. Do not bump the package version or publish manually.
+5. Verify the deployed commit, GitHub release, successful publishing workflow and npm artifact/version. Repeat the safe packaged smoke on the released artifact. Record native feedback with its actual status. Normal release copy can say that Cursor history now appears in sync and statistics, and that automatic sync uses the user-level stop hook.

--- a/docs/research/cursor-integration-validation-2026-09.md
+++ b/docs/research/cursor-integration-validation-2026-09.md
@@ -1,6 +1,6 @@
 # Cursor integration validation and release handoff
 
-Status on 2026-09-10: automated acceptance passed. Native acceptance is UNRUN and awaits the owner's release disposition in [Validate Cursor integration and release readiness](https://github.com/alp82/aistack/issues/393). This report does not claim publication or close that ticket.
+Status on 2026-09-10: automated acceptance passed. The owner explicitly approved proceeding with release while deferring real Cursor manual sync, account-login reuse and native hook checks to post-release validation. Native checks remain UNRUN. [Validate Cursor integration and release readiness](https://github.com/alp82/aistack/issues/393) is accepted with that disposition; this report does not claim publication.
 
 ## Integrated changes
 
@@ -50,9 +50,9 @@ No owner credentials, private retained history, paid session, real interactive s
 | Actual SQLite login reuse, unavailable/expired access and Cursor renewal | UNRUN | Enrichment success and join coverage remain unverified on a real account. Local estimates and complete-cache fallback are implemented and tested. |
 | Native macOS and Windows execution, including GUI PATH | UNRUN | Launcher text/platform paths are tested synthetically; native shell and environment behavior is unverified. |
 
-These gaps affect the promised real acquisition and automatic-refresh paths, so their release treatment needs the explicit owner disposition required by the validation ticket. They do not justify an exhaustive donor programme or paid session requirement. The Grok Build precedent deferred native checks to post-release user validation after an explicit owner decision. That decision has not yet been recorded for Cursor.
+These gaps affect the promised real acquisition and automatic-refresh paths. On 2026-09-10, the owner explicitly approved proceeding with release while deferring real Cursor manual sync, account-login reuse and native hook checks to post-release validation, replying "yes do it" to that question in the live session. This supplies the validation ticket's required release disposition and follows the Grok Build precedent. It does not establish native success or introduce a paid session requirement.
 
-Recommended disposition: accept these exact UNRUN checks as staged post-release owner/user validation, retaining their status and asking for normal user feedback. Alternatively, hold publication until the owner runs the feasible local manual and native stop checks and reports the results; unavailable platform checks still need a disposition. No synthetic result is relabelled as native success.
+Accepted disposition: these exact UNRUN checks are staged post-release owner/user validation. Retain their status and ask for normal user feedback. No synthetic result is relabelled as native success.
 
 The installed hook intentionally invokes npm `@latest`, with the existing cached fallback. Before the Cursor release is published, a real stop event can therefore run the older published collector. Pre-release synthetic launcher tests use a controlled executable; they are not evidence that the installed hook has run the new collector against an owner account.
 
@@ -66,7 +66,7 @@ Automatic sync needs its normal explicit opt-in. After the Cursor package is pub
 
 [Deploy Cursor backend support and publish the CLI](https://github.com/alp82/aistack/issues/394) owns all publication:
 
-1. Record the owner's disposition or actual native outcomes on the validation ticket before closing acceptance.
+1. Carry the recorded owner-approved post-release deferral into the release handoff and retain each UNRUN status until actual feedback supplies an outcome.
 2. Integrate the four implementation commits and this report using a Conventional Commit CLI feature title. Preserve unrelated workspace changes. Resolve any current-main drift through the normal review workflow; this report validates the local combined branch, not a future merge commit.
 3. Wait for the `deploy-convex.yml` workflow on the merged main commit. There is no Cursor migration in this change. If later integration requires a migration, run it only via the server wrapper after its code is deployed.
 4. Let Release Please choose the CLI version and release PR. Merge that PR only after compatible backend deployment and the acceptance disposition. `publish-cli.yml` publishes its release commit through npm OIDC. Do not bump the package version or publish manually.

--- a/docs/research/cursor-workflow-implementation-2026-09.md
+++ b/docs/research/cursor-workflow-implementation-2026-09.md
@@ -1,0 +1,29 @@
+# Cursor workflow and inventory implementation
+
+Implements [Integrate Cursor workflow metrics and machine inventory](https://github.com/alp82/aistack/issues/390), under the accepted [Cursor attribution and estimation contract](https://github.com/alp82/aistack/issues/388#issuecomment-5617625795).
+
+## Projection
+
+`packages/cli/src/harness/cursor/workflow.ts` feeds retained messages and the collection adapter's reconciled usage into the existing harness reducer. No new wire shape, rule package, row order or UI is introduced.
+
+- User timestamps anchor session starts without adding question turns. Each retained assistant message contributes a turn, with `ask_question` marking a question back.
+- Tool calls supply activity, native search counts and existing phase classification. Native read/edit/terminal variants are mapped to the established reducer names. Native names remain in inventory, behind the adapter's literal builtin allowlist and existing private-name filtering.
+- Model routing uses reconciled token buckets. A matched API conversation/day supersedes its local token estimate but leaves its local tool activity intact. Unknown models remain unknown.
+- Native Composer message IDs and source-native tool IDs deduplicate copied prefixes across sessions. Non-native identities are scoped to their conversation. Newly performed child activity still counts.
+- The sidechain bit establishes subagent routing and tool counts. A native `parentMessageId` resolving to a retained main message additionally establishes a structural parent for the reducer. No session relationship is inferred from text or timestamps. Unlinked sidechains cannot establish fan-out. The reader exposes no general parent-session field.
+- Canonical absolute workspace paths stay in local reducer sources for the existing Git extraction and workspace-day joins. Usage and machine inventory continue through the existing persistent opaque project identifier.
+- Untimed evidence can contribute observed inventory, but contributes no invented workflow or Git day. Date interpolation follows the collection adapter's existing anchors and does not establish per-call duration.
+
+Accumulated turn input, context snapshots and dry-run estimates never become a per-call Context distribution. Turn latency, reasoning-token counts, native effort and compaction remain absent because this selected projection has no qualified evidence for those fields. No prospective sidecar is required to supply the supported historical rows. The automatic-sync ticket owns the stop-hook lifecycle.
+
+## Inventory and consent
+
+The existing scanner already discovers Cursor rules and skills; the existing MCP discovery reads project and user Cursor configuration and strips credential fields. This change reuses those paths. Configuration alone creates no observed call. Explicit `mcp__server__tool` names identify their server; single-underscore `mcp_server_tool` names resolve only against configured Cursor server names, longest prefix first, instead of inventing a server split. Unrecognized names remain subject to shared fail-closed filtering.
+
+Stage passes the stack's `publishWorkflow` flag to historical scans and disables redundant Cursor workflow reduction during snapshot scans. When false, Cursor retains usage and observed inventory but returns an empty workflow and no local Git joins. Shared day consent drops workflow blocks, and the existing backend read gate hides stored readings after consent is disabled. The price and cost consent pipeline is unchanged.
+
+## Validation
+
+Synthetic checks exercise API/local precedence with tools retained, phases/searches/questions, routing, missing Context and duration, structural child activity and copied-prefix dedup, undated inventory, workflow-off extraction, configured versus observed MCP/skills, private-name filtering and opaque workspace IDs.
+
+The targeted shared reducer, phase-rule, staging, payload, configured resource discovery and backend workflow tests pass. CLI TypeScript checks pass. No native account, private history, interactive sync, deployment or publication was performed for this ticket.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # @use-aistack/cli
 
-Measure and share your AI stack. The CLI scans local history from Claude Code, Codex, Grok Build, opencode and Pi, shows you exactly what would go up, and publishes only after you approve in your terminal.
+Measure and share your AI stack. The CLI scans local history from Claude Code, Codex, Cursor, Grok Build, opencode and Pi, shows you exactly what would go up, and publishes only after you approve in your terminal.
 
 Run on-demand with `npx` - no install required:
 
@@ -24,7 +24,7 @@ After a manual sync, the CLI offers auto-sync with three choices: Enable, Maybe 
 
 ### `npx @use-aistack/cli sync --auto on` / `off`
 
-Optional: keep your stack fresh without manual syncs. `on` asks your stack for permission, then writes a `SessionStart` hook for the harnesses you actually use: `~/.claude/settings.json` for Claude Code, `~/.codex/hooks.json` for Codex, and `$GROK_HOME/hooks/aistack.json` (default `~/.grok/hooks/aistack.json`) for Grok Build. The hook runs a silent sync at most once every 6 hours when a session starts. Grok Build needs a new session or hook reload after installation. `off` disables local publication first, removes the owned hooks, then takes the remote permission back. If removal fails, the disabled local gate still prevents publication and the next interactive sync can retry reconciliation.
+Optional: keep your stack fresh without manual syncs. `on` asks your stack for permission, then writes hooks for the harnesses you actually use. The `SessionStart` paths are: `~/.claude/settings.json` for Claude Code, `~/.codex/hooks.json` for Codex, and `$GROK_HOME/hooks/aistack.json` (default `~/.grok/hooks/aistack.json`) for Grok Build. Cursor uses a user-level `stop` hook in `~/.cursor/hooks.json` and reloads that configuration automatically. Its trigger runs when the agent finishes a turn. The other hooks run when a session starts. All triggers share one silent sync throttle, at most once every 6 hours. Existing user hooks are preserved. Grok Build needs a new session or hook reload after installation. `off` disables local publication first, removes the owned hooks, then takes the remote permission back. If removal fails, the disabled local gate still prevents publication and the next interactive sync can retry reconciliation.
 
 ```sh
 npx @use-aistack/cli sync --auto on            # enable, default every 6h

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@clack/prompts": "^0.10.0",
     "commander": "^13.1.0",
+    "cursor-history": "0.18.0",
     "ignore": "^7.0.0",
     "open": "^10.1.0",
     "picocolors": "^1.1.0",

--- a/packages/cli/src/autosync/cursorHook.test.ts
+++ b/packages/cli/src/autosync/cursorHook.test.ts
@@ -1,0 +1,121 @@
+import { execFileSync } from "node:child_process";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import {
+	cursorAutoSyncHookInstalled,
+	cursorHookCommand,
+	installCursorAutoSyncHook,
+	removeCursorAutoSyncHook,
+} from "./cursorHook.js";
+
+let dir: string;
+let file: string;
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "cursor-hook-"));
+	file = join(dir, "home with spaces", "hooks.json");
+	mkdirSync(join(dir, "home with spaces"));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+test("install, reinstall and removal preserve foreign stop entries, events and settings", () => {
+	const foreign = {
+		version: 1,
+		extra: true,
+		hooks: {
+			stop: [
+				{ command: "echo mine", matcher: "completed" },
+				{ command: "npx @use-aistack/cli sync --auto" },
+			],
+			afterFileEdit: [{ command: "format" }],
+		},
+	};
+	writeFileSync(file, JSON.stringify(foreign));
+	expect(cursorAutoSyncHookInstalled(file)).toBe(false);
+	for (const os of ["linux", "darwin", "win32"] as const) {
+		expect(installCursorAutoSyncHook(file, os).ok).toBe(true);
+		expect(installCursorAutoSyncHook(file, os).ok).toBe(true);
+		expect(cursorAutoSyncHookInstalled(file)).toBe(true);
+		expect(JSON.parse(readFileSync(file, "utf8")).hooks.stop).toHaveLength(3);
+	}
+	expect(removeCursorAutoSyncHook(file).ok).toBe(true);
+	expect(JSON.parse(readFileSync(file, "utf8"))).toEqual(foreign);
+	expect(cursorAutoSyncHookInstalled(file)).toBe(false);
+	expect(removeCursorAutoSyncHook(file).message).toBe(
+		"no Cursor hook to remove",
+	);
+});
+test.each([
+	"{ broken",
+	"[]",
+	'{"version":2}',
+	'{"hooks":{"stop":[null]}}',
+	'{"hooks":{"stop":{}}}',
+])("rejects malformed configuration without rewriting: %s", (content) => {
+	writeFileSync(file, content);
+	expect(installCursorAutoSyncHook(file).ok).toBe(false);
+	expect(removeCursorAutoSyncHook(file).ok).toBe(false);
+	expect(cursorAutoSyncHookInstalled(file)).toBe(false);
+	expect(readFileSync(file, "utf8")).toBe(content);
+});
+test("reports write failures as lifecycle results", () => {
+	expect(installCursorAutoSyncHook(join(file, "not-a-directory")).ok).toBe(
+		true,
+	);
+	expect(installCursorAutoSyncHook(file).ok).toBe(false);
+});
+test("Windows uses an explicit noninteractive launcher with no hook output or input", () => {
+	const command = cursorHookCommand("win32");
+	expect(command).toMatch(
+		/^powershell.exe -NoProfile -NonInteractive -EncodedCommand /,
+	);
+	const script = Buffer.from(
+		command.split(" ").at(-1) ?? "",
+		"base64",
+	).toString("utf16le");
+	expect(script).toContain("Start-Process");
+	expect(script).toContain("AISTACK_HOOK_SOURCE=cursor");
+	expect(script).toContain("<NUL >NUL 2>&1");
+	expect(script).toContain("--prefer-offline");
+});
+test.each(["linux", "darwin"] as const)(
+	"%s shell detaches, discards hook input and uses offline fallback",
+	async (os) => {
+		const receipt = join(dir, "receipt");
+		const npx = join(dir, "npx");
+		writeFileSync(
+			npx,
+			'#!/bin/sh\nread -r ignored || :\nprintf "%s %s\\n" "$AISTACK_HOOK_SOURCE" "$*" >> "$HOOK_TEST_RECEIPT"\ncase "$*" in *latest*) exit 1;; esac\n',
+			{ mode: 0o755 },
+		);
+		const output = execFileSync("sh", ["-c", cursorHookCommand(os)], {
+			input: '{"email":"private@example.test"}',
+			env: {
+				...process.env,
+				PATH: `${dir}:${process.env.PATH}`,
+				HOOK_TEST_RECEIPT: receipt,
+			},
+			encoding: "utf8",
+			timeout: 2000,
+		});
+		expect(output).toBe("");
+		await expect
+			.poll(() => {
+				try {
+					return readFileSync(receipt, "utf8");
+				} catch {
+					return "";
+				}
+			})
+			.toBe(
+				"cursor -y @use-aistack/cli@latest sync --auto\ncursor -y --prefer-offline @use-aistack/cli sync --auto\n",
+			);
+	},
+);

--- a/packages/cli/src/autosync/cursorHook.ts
+++ b/packages/cli/src/autosync/cursorHook.ts
@@ -1,0 +1,102 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { dirname, join } from "node:path";
+import { AUTO_SYNC_HOOK_COMMAND, type HookResult } from "./hook.js";
+
+// The accepted scope is user-wide. Project hooks would also run in cloud agents.
+export const CURSOR_HOOK_FILE = join(homedir(), ".cursor", "hooks.json");
+
+export function cursorHookCommand(os: NodeJS.Platform = platform()): string {
+	if (os === "win32") {
+		const script = `Start-Process -WindowStyle Hidden -FilePath 'cmd.exe' -ArgumentList '/d /s /c "set AISTACK_HOOK_SOURCE=cursor&& (${AUTO_SYNC_HOOK_COMMAND}) <NUL >NUL 2>&1"'`;
+		return `powershell.exe -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(script, "utf16le").toString("base64")}`;
+	}
+	const detach = os === "darwin" ? "nohup" : "setsid nohup";
+	return `${detach} sh -c 'export AISTACK_HOOK_SOURCE=cursor; ${AUTO_SYNC_HOOK_COMMAND}' </dev/null >/dev/null 2>&1 &`;
+}
+
+type Entry = Record<string, unknown>;
+interface Config {
+	version?: unknown;
+	hooks?: Record<string, Entry[]>;
+	[key: string]: unknown;
+}
+function read(file: string): Config {
+	if (!existsSync(file)) return {};
+	const value: unknown = JSON.parse(readFileSync(file, "utf8"));
+	if (!value || typeof value !== "object" || Array.isArray(value))
+		throw new Error("expected a JSON object");
+	const config = value as Config;
+	if (config.version !== undefined && config.version !== 1)
+		throw new Error("unsupported hooks version");
+	if (
+		config.hooks !== undefined &&
+		(!config.hooks ||
+			typeof config.hooks !== "object" ||
+			Array.isArray(config.hooks) ||
+			Object.values(config.hooks).some(
+				(entries) =>
+					!Array.isArray(entries) ||
+					entries.some(
+						(entry) =>
+							!entry || typeof entry !== "object" || Array.isArray(entry),
+					),
+			))
+	)
+		throw new Error("malformed hooks object");
+	return config;
+}
+function isOurs(entry: Entry): boolean {
+	// Exact generated commands avoid claiming another user's command that happens
+	// to invoke the CLI. Recognize all supported OS definitions when removing.
+	return ["linux", "darwin", "win32"].some(
+		(os) => entry.command === cursorHookCommand(os as NodeJS.Platform),
+	);
+}
+function update(
+	file: string,
+	install: boolean,
+	os: NodeJS.Platform,
+): HookResult {
+	try {
+		const config = read(file);
+		const existing = config.hooks?.stop ?? [];
+		const kept = existing.filter((entry) => !isOurs(entry));
+		if (!install && kept.length === existing.length)
+			return { ok: true, message: "no Cursor hook to remove" };
+		if (install) kept.push({ command: cursorHookCommand(os) });
+		const hooks = { ...config.hooks };
+		if (kept.length) hooks.stop = kept;
+		else delete hooks.stop;
+		if (Object.keys(hooks).length) config.hooks = hooks;
+		else delete config.hooks;
+		if (install) config.version = 1;
+		mkdirSync(dirname(file), { recursive: true });
+		writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`);
+		return {
+			ok: true,
+			message: `Cursor stop hook ${install ? "written to" : "removed from"} ${file}`,
+		};
+	} catch (error) {
+		return {
+			ok: false,
+			message: `Could not ${install ? "install" : "remove"} Cursor hook in ${file}: ${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
+}
+export function installCursorAutoSyncHook(
+	file = CURSOR_HOOK_FILE,
+	os = platform(),
+): HookResult {
+	return update(file, true, os);
+}
+export function removeCursorAutoSyncHook(file = CURSOR_HOOK_FILE): HookResult {
+	return update(file, false, platform());
+}
+export function cursorAutoSyncHookInstalled(file = CURSOR_HOOK_FILE): boolean {
+	try {
+		return (read(file).hooks?.stop ?? []).some(isOurs);
+	} catch {
+		return false;
+	}
+}

--- a/packages/cli/src/autosync/optin.test.ts
+++ b/packages/cli/src/autosync/optin.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { getSettings, saveSettings } from "../config.js";
-import { claudeAdapter, codexAdapter, grokAdapter } from "../harness/index.js";
+import {
+	claudeAdapter,
+	codexAdapter,
+	cursorAdapter,
+	grokAdapter,
+} from "../harness/index.js";
 import {
 	disableAutoSync,
 	type EnableDeps,
@@ -24,6 +29,15 @@ import {
  * gate, the hooks are just the triggers). Every dep is injected - a test that
  * touches the REAL ~/.claude/settings.json or ~/.codex/hooks.json is a bug.
  */
+
+vi.mock("./cursorHook.js", () => ({
+	cursorAutoSyncHookInstalled: () => false,
+	installCursorAutoSyncHook: () => ({ ok: true, message: "written" }),
+	removeCursorAutoSyncHook: () => ({
+		ok: true,
+		message: "no Cursor hook to remove",
+	}),
+}));
 
 const selectMock = vi.hoisted(() => vi.fn());
 vi.mock("@clack/prompts", () => ({
@@ -774,4 +788,62 @@ describe("offerAutoSyncOptIn", () => {
 		expect(installCodexHook).toHaveBeenCalledOnce();
 		expect(getSettings(settingsFile).autoSync?.enabled).toBe(true);
 	});
+});
+
+test("Cursor activity installs its stop trigger and reconciles a missing hook without asking", async () => {
+	const installCursorHook = vi.fn(() => ({ ok: true, message: "written" }));
+	const options = {
+		settingsFile,
+		...linked,
+		detectedImpl: async () => [cursorAdapter],
+		installCursorHook,
+		cursorHookInstalledImpl: () => false,
+	};
+	expect((await enableAutoSync(6, options)).message).toContain(
+		"Cursor session is active",
+	);
+	expect(getSettings(settingsFile).autoSync?.enabled).toBe(true);
+	expect(
+		(await reconcileAutoSync({ enabled: true, frequencyHours: 6 }, options))
+			?.ok,
+	).toBe(true);
+	expect(installCursorHook).toHaveBeenCalledTimes(2);
+	expect(
+		await reconcileAutoSync(
+			{ enabled: true, frequencyHours: 6 },
+			{ ...options, cursorHookInstalledImpl: () => true },
+		),
+	).toBeNull();
+	expect(selectMock).not.toHaveBeenCalled();
+});
+test("Cursor trigger failures do not claim installation; disable gates first even if removal fails", async () => {
+	expect(
+		(
+			await enableAutoSync(6, {
+				settingsFile,
+				...linked,
+				detectedImpl: async () => [cursorAdapter],
+				installCursorHook: () => ({ ok: false, message: "read only" }),
+			})
+		).ok,
+	).toBe(false);
+	expect(getSettings(settingsFile).autoSync).toBeUndefined();
+	saveSettings(
+		{ autoSync: { enabled: true, frequencyHours: 6 } },
+		settingsFile,
+	);
+	const remove = () => ({ ok: true, message: "no hook to remove" });
+	const result = await disableAutoSync({
+		settingsFile,
+		...linked,
+		removeHook: remove,
+		removeCodexHook: remove,
+		removeGrokHook: remove,
+		removeCursorHook: () => {
+			expect(getSettings(settingsFile).autoSync?.enabled).toBe(false);
+			return { ok: false, message: "read only" };
+		},
+	});
+	expect(result.ok).toBe(false);
+	expect(result.message).toContain("nothing will publish");
 });

--- a/packages/cli/src/autosync/optin.ts
+++ b/packages/cli/src/autosync/optin.ts
@@ -25,6 +25,7 @@ import {
 } from "../config.js";
 import { CLAUDE_HARNESS_NAME } from "../harness/claude/adapter.js";
 import { CODEX_HARNESS_NAME } from "../harness/codex/adapter.js";
+import { CURSOR_HARNESS_NAME } from "../harness/cursor/adapter.js";
 import { GROK_HARNESS_NAME } from "../harness/grok/adapter.js";
 import {
 	type AutoSyncPermission,
@@ -41,6 +42,11 @@ import {
 	installCodexAutoSyncHook,
 	removeCodexAutoSyncHook,
 } from "./codexHook.js";
+import {
+	cursorAutoSyncHookInstalled,
+	installCursorAutoSyncHook,
+	removeCursorAutoSyncHook,
+} from "./cursorHook.js";
 import {
 	grokAutoSyncHookInstalled,
 	installGrokAutoSyncHook,
@@ -59,6 +65,9 @@ export interface EnableDeps {
 	removeHook?: () => HookResult;
 	installCodexHook?: () => HookResult;
 	removeCodexHook?: () => HookResult;
+	installCursorHook?: () => HookResult;
+	removeCursorHook?: () => HookResult;
+	cursorHookInstalledImpl?: () => boolean;
 	installGrokHook?: () => HookResult;
 	removeGrokHook?: () => HookResult;
 	/** Is the Claude Code trigger already on this machine? */
@@ -141,6 +150,11 @@ export async function enableAutoSync(
 		if (!grokResult.ok) return grokResult;
 	}
 
+	if (names.has(CURSOR_HARNESS_NAME)) {
+		const result = (deps.installCursorHook ?? installCursorAutoSyncHook)();
+		if (!result.ok) return result;
+	}
+
 	saveSettings(
 		{
 			autoSyncAnswered: true,
@@ -151,7 +165,7 @@ export async function enableAutoSync(
 	return {
 		ok: true,
 		message: [
-			`Auto-sync is on. It runs about every ${frequencyHours}h when a ${harnessListLabel(detected)} session starts. Turn it off any time: npx @use-aistack/cli sync --auto off`,
+			`Auto-sync is on. It runs about every ${frequencyHours}h when a ${harnessListLabel(detected)} ${names.has(CURSOR_HARNESS_NAME) ? "session is active" : "session starts"}. Turn it off any time: npx @use-aistack/cli sync --auto off`,
 			...(trustLine ? [trustLine] : []),
 		].join("\n"),
 	};
@@ -190,7 +204,8 @@ export async function disableAutoSync(
 	const result = (deps.removeHook ?? removeAutoSyncHook)();
 	const codexResult = (deps.removeCodexHook ?? removeCodexAutoSyncHook)();
 	const grokResult = (deps.removeGrokHook ?? removeGrokAutoSyncHook)();
-	const failures = [result, codexResult, grokResult]
+	const cursorResult = (deps.removeCursorHook ?? removeCursorAutoSyncHook)();
+	const failures = [result, codexResult, grokResult, cursorResult]
 		.filter((r) => !r.ok)
 		.map((r) => r.message);
 
@@ -259,6 +274,7 @@ export async function reconcileAutoSync(
 			(deps.removeHook ?? removeAutoSyncHook)(),
 			(deps.removeCodexHook ?? removeCodexAutoSyncHook)(),
 			(deps.removeGrokHook ?? removeGrokAutoSyncHook)(),
+			(deps.removeCursorHook ?? removeCursorAutoSyncHook)(),
 		];
 		const failures = results.filter((result) => !result.ok);
 		if (failures.length > 0) {
@@ -310,6 +326,12 @@ export async function reconcileAutoSync(
 		deps.installGrokHook ?? installGrokAutoSyncHook,
 	);
 
+	install(
+		CURSOR_HARNESS_NAME,
+		deps.cursorHookInstalledImpl ?? cursorAutoSyncHookInstalled,
+		deps.installCursorHook ?? installCursorAutoSyncHook,
+	);
+
 	if (failures.length > 0) {
 		return {
 			ok: false,
@@ -335,8 +357,8 @@ export async function reconcileAutoSync(
 		ok: true,
 		message:
 			installed.length > 0
-				? `Auto-sync is on for this stack. Installed the ${installed.join(" and ")} trigger on this machine; it runs about every ${frequencyHours}h when a session starts.`
-				: `Auto-sync is on for this stack. It runs about every ${frequencyHours}h when a ${harnessListLabel(detected)} session starts.`,
+				? `Auto-sync is on for this stack. Installed the ${installed.join(" and ")} trigger on this machine; it runs about every ${frequencyHours}h during session activity.`
+				: `Auto-sync is on for this stack. It runs about every ${frequencyHours}h when a ${harnessListLabel(detected)} ${names.has(CURSOR_HARNESS_NAME) ? "session is active" : "session starts"}.`,
 	};
 }
 
@@ -383,13 +405,14 @@ export async function offerAutoSyncOptIn(
 	const detected = await (deps.detectedImpl ?? detectedAdapters)();
 	if (detected.length === 0) return false;
 
+	const names = new Set(detected.map((adapter) => adapter.name));
 	const answer = await p.select({
 		message: "Keep this stack fresh automatically every 6 hours?",
 		options: [
 			{
 				value: "enable",
 				label: "Enable",
-				hint: `a silent sync at most every 6 hours when a ${harnessListLabel(detected)} session starts`,
+				hint: `a silent sync at most every 6 hours when a ${harnessListLabel(detected)} ${names.has(CURSOR_HARNESS_NAME) ? "session is active" : "session starts"}`,
 			},
 			{
 				value: "later",

--- a/packages/cli/src/autosync/run.test.ts
+++ b/packages/cli/src/autosync/run.test.ts
@@ -459,3 +459,29 @@ describe("appendLogLine", () => {
 		expect(lines[lines.length - 1]).toBe(`line ${SYNC_LOG_MAX_LINES + 49}`);
 	});
 });
+
+test("Cursor failures remain silent and repeated stop events share the attempt throttle", async () => {
+	vi.stubEnv("AISTACK_HOOK_SOURCE", "cursor");
+	try {
+		saveSettings(
+			{
+				autoSync: { enabled: true, frequencyHours: 6 },
+				autoSyncState: { consecutiveFailures: 2 },
+			},
+			settingsFile,
+		);
+		const stageImpl = vi.fn(async () => {
+			throw new Error("offline");
+		});
+		const options = deps({ stageImpl });
+		await runAutoSync(options);
+		await runAutoSync(options);
+		expect(stageImpl).toHaveBeenCalledOnce();
+		expect(options.emit).not.toHaveBeenCalled();
+		expect(getSettings(settingsFile).autoSyncState?.consecutiveFailures).toBe(
+			3,
+		);
+	} finally {
+		vi.unstubAllEnvs();
+	}
+});

--- a/packages/cli/src/autosync/run.ts
+++ b/packages/cli/src/autosync/run.ts
@@ -60,7 +60,7 @@ export type AutoSyncDeps = {
 	loadConfigImpl?: typeof loadSyncConfig;
 	/** Where the systemMessage JSON goes. Defaults to stdout. */
 	emit?: (line: string) => void;
-	/** Grok hooks keep stdout empty, including failure escalation. */
+	/** Cursor and Grok hooks keep stdout empty, including failure escalation. */
 	suppressOutput?: boolean;
 	reservationFile?: string;
 };
@@ -242,7 +242,8 @@ export async function runAutoSync(deps: AutoSyncDeps): Promise<void> {
 	if (
 		shouldWarn &&
 		deps.suppressOutput !== true &&
-		process.env.AISTACK_HOOK_SOURCE !== "grok"
+		process.env.AISTACK_HOOK_SOURCE !== "grok" &&
+		process.env.AISTACK_HOOK_SOURCE !== "cursor"
 	) {
 		emit(
 			JSON.stringify({

--- a/packages/cli/src/harness/cursor/account.test.ts
+++ b/packages/cli/src/harness/cursor/account.test.ts
@@ -1,0 +1,104 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, expect, it, vi } from "vitest";
+import { existingAccount, fetchWindow } from "./account.js";
+import usagePage from "./fixtures/usage-page.json";
+
+const directories: string[] = [];
+afterEach(async () => {
+	for (const d of directories.splice(0))
+		await rm(d, { recursive: true, force: true });
+});
+const account = { scope: "synthetic-account", cookie: "synthetic-cookie" };
+const from = Date.UTC(2026, 8, 10);
+const to = from + 86_400_000;
+
+it("preserves two equal-timestamp ID-less events from qualified JSON and omits absent/cloud joins", async () => {
+	const fetcher = vi
+		.fn<typeof fetch>()
+		.mockResolvedValue(Response.json(usagePage));
+	const rows = await fetchWindow(account, from, to, fetcher);
+	expect(rows).toHaveLength(2);
+	expect(rows.map((r) => r.buckets.input)).toEqual([100, 80]);
+	expect(rows[0].buckets.cacheWrite).toBe(40);
+	expect(rows[1].buckets.cacheWrite).toBeUndefined();
+	const [, request] = fetcher.mock.calls[0];
+	expect(request?.redirect).toBe("error");
+	expect(JSON.parse(String(request?.body))).toEqual({
+		startDate: from,
+		endDate: to - 1,
+		page: 1,
+		pageSize: 100,
+	});
+});
+it("deduplicates native IDs without deduplicating identical ID-less events", async () => {
+	const event = usagePage.usageEventsDisplay[0];
+	const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+		Response.json({
+			usageEventsDisplay: [
+				{ ...event, id: "a" },
+				{ ...event, id: "a" },
+				event,
+				event,
+			],
+		}),
+	);
+	expect(await fetchWindow(account, from, to, fetcher)).toHaveLength(3);
+});
+it("rejects repeated pages, later-page failure, inconsistent totals and malformed token buckets", async () => {
+	const events = Array.from({ length: 100 }, (_, i) => ({
+		...usagePage.usageEventsDisplay[0],
+		id: String(i),
+	}));
+	const repeat = vi
+		.fn<typeof fetch>()
+		.mockImplementation(async () =>
+			Response.json({ usageEventsDisplay: events }),
+		);
+	await expect(fetchWindow(account, from, to, repeat)).rejects.toThrow(
+		"Repeated",
+	);
+	const fail = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(
+			Response.json({ usageEventsDisplay: events, totalUsageEventsCount: 101 }),
+		)
+		.mockResolvedValueOnce(new Response("", { status: 401 }));
+	await expect(fetchWindow(account, from, to, fail)).rejects.toThrow(
+		"unavailable",
+	);
+	const malformed = vi.fn<typeof fetch>().mockResolvedValue(
+		Response.json({
+			usageEventsDisplay: [{ ...events[0], tokenUsage: { inputTokens: -1 } }],
+		}),
+	);
+	await expect(fetchWindow(account, from, to, malformed)).rejects.toThrow(
+		"bucket",
+	);
+});
+it("reuses only a synthetic existing SQLite login, identifies account changes and tolerates missing auth", async () => {
+	const dir = await mkdtemp(path.join(tmpdir(), "cursor-auth-"));
+	directories.push(dir);
+	const root = path.join(dir, "workspaceStorage");
+	await mkdir(path.join(dir, "globalStorage"));
+	expect(await existingAccount(root)).toBeNull();
+	const db = new DatabaseSync(path.join(dir, "globalStorage", "state.vscdb"));
+	db.exec("CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)");
+	const token = (sub: string) =>
+		`header.${Buffer.from(JSON.stringify({ sub })).toString("base64url")}.signature`;
+	const put = (sub: string) =>
+		db
+			.prepare("INSERT OR REPLACE INTO ItemTable VALUES (?, ?)")
+			.run("cursorAuth/accessToken", token(sub));
+	put("auth0|synthetic-one");
+	const first = await existingAccount(root);
+	expect(first?.cookie).toBe(
+		`synthetic-one%3A%3A${token("auth0|synthetic-one")}`,
+	);
+	expect(first?.scope).not.toContain("synthetic");
+	put("auth0|synthetic-two");
+	expect((await existingAccount(root))?.scope).not.toBe(first?.scope);
+	db.close();
+});

--- a/packages/cli/src/harness/cursor/account.test.ts
+++ b/packages/cli/src/harness/cursor/account.test.ts
@@ -98,6 +98,16 @@ it("reuses only a synthetic existing SQLite login, identifies account changes an
 		`synthetic-one%3A%3A${token("auth0|synthetic-one")}`,
 	);
 	expect(first?.scope).not.toContain("synthetic");
+	// Cursor renews its own login; the next read uses the replacement token
+	// without changing this account's cache scope or asking for authentication.
+	const renewed = `${token("auth0|synthetic-one")}-renewed`;
+	db.prepare("INSERT OR REPLACE INTO ItemTable VALUES (?, ?)").run(
+		"cursorAuth/accessToken",
+		renewed,
+	);
+	const refreshed = await existingAccount(root);
+	expect(refreshed?.scope).toBe(first?.scope);
+	expect(refreshed?.cookie).toBe(`synthetic-one%3A%3A${renewed}`);
 	put("auth0|synthetic-two");
 	expect((await existingAccount(root))?.scope).not.toBe(first?.scope);
 	db.close();

--- a/packages/cli/src/harness/cursor/account.ts
+++ b/packages/cli/src/harness/cursor/account.ts
@@ -1,0 +1,150 @@
+import { createHash } from "node:crypto";
+import { asObj, asStr } from "../shared/aggregate.js";
+import { type Contribution, count, timestamp } from "./evidence.js";
+import { globalDb } from "./local.js";
+
+export type Account = { scope: string; cookie: string };
+export const digest = (value: string) =>
+	createHash("sha256").update(value).digest("hex");
+/** Only the credential already stored in SQLite is unattended on every platform.
+ * Keychain APIs may display an OS prompt, so this path deliberately never calls them.
+ */
+export async function existingAccount(root: string): Promise<Account | null> {
+	let db: import("node:sqlite").DatabaseSync | undefined;
+	try {
+		const { DatabaseSync } = await import("node:sqlite");
+		db = new DatabaseSync(globalDb(root), { readOnly: true });
+		const row = db
+			.prepare("SELECT value FROM ItemTable WHERE key = ?")
+			.get("cursorAuth/accessToken");
+		if (typeof row?.value !== "string") return null;
+		const token = row.value.trim().replace(/^"|"$/g, "");
+		const claims = asObj(
+			JSON.parse(
+				Buffer.from(token.split(".")[1] ?? "", "base64url").toString("utf8"),
+			),
+		);
+		const subject = asStr(claims?.sub);
+		if (
+			!subject ||
+			claims?.type === "api_key_token" ||
+			!/^[\w|:-]+$/.test(subject) ||
+			!/^[A-Za-z0-9_.-]+$/.test(token)
+		)
+			return null;
+		const user = subject.split("|").at(-1);
+		if (!user) return null;
+		// Expired access still identifies the account, so it cannot fall back to a different account cache.
+		return { scope: digest(subject), cookie: `${user}%3A%3A${token}` };
+	} catch {
+		return null;
+	} finally {
+		db?.close();
+	}
+}
+
+export function apiContribution(value: unknown): Contribution | null {
+	const raw = asObj(value);
+	if (!raw) throw new Error("Invalid Cursor event");
+	const session = asStr(raw.conversationId);
+	if (!session || raw.cloudAgentId || session.startsWith("bc-")) return null;
+	const tsMs = timestamp(raw.timestamp);
+	const usage = raw.tokenUsage == null ? {} : asObj(raw.tokenUsage);
+	if (tsMs === null || !usage) throw new Error("Invalid Cursor event");
+	const buckets: Contribution["buckets"] = {};
+	for (const [key, field] of [
+		["input", "inputTokens"],
+		["output", "outputTokens"],
+		["cacheRead", "cacheReadTokens"],
+		["cacheWrite", "cacheWriteTokens"],
+	] as const) {
+		if (usage[field] === undefined || usage[field] === null) continue;
+		const value = count(usage[field]);
+		if (value === undefined) throw new Error("Invalid Cursor token bucket");
+		buckets[key] = value;
+	}
+	const id = asStr(raw.id) ?? asStr(raw.eventId);
+	return {
+		session,
+		...(id ? { id } : {}),
+		tsMs,
+		model: asStr(raw.model) ?? "unknown",
+		buckets,
+		source: "api",
+	};
+}
+
+/** A capped, repeated, malformed or failed page rejects the entire fixed query window. */
+export async function fetchWindow(
+	account: Account,
+	from: number,
+	to: number,
+	fetchImpl: typeof fetch = fetch,
+): Promise<Contribution[]> {
+	const out: Contribution[] = [];
+	const pages = new Set<string>();
+	const eventIds = new Set<string>();
+	let total: number | undefined;
+	let retrieved = 0;
+	const pageSize = 100;
+	for (let page = 1; page <= 100; page++) {
+		const response = await fetchImpl(
+			"https://cursor.com/api/dashboard/get-filtered-usage-events",
+			{
+				method: "POST",
+				redirect: "error",
+				signal: AbortSignal.timeout(15_000),
+				headers: {
+					"Content-Type": "application/json",
+					Origin: "https://cursor.com",
+					Cookie: `WorkosCursorSessionToken=${account.cookie}`,
+				},
+				body: JSON.stringify({
+					startDate: from,
+					endDate: to - 1,
+					page,
+					pageSize,
+				}),
+			},
+		);
+		if (!response.ok) throw new Error("Cursor usage unavailable");
+		const payload = asObj(await response.json());
+		const events = payload?.usageEventsDisplay;
+		if (!Array.isArray(events) || events.length > pageSize)
+			throw new Error("Invalid Cursor page");
+		if (payload?.totalUsageEventsCount !== undefined) {
+			const reported = count(payload.totalUsageEventsCount);
+			if (
+				reported === undefined ||
+				!Number.isInteger(reported) ||
+				(total !== undefined && total !== reported)
+			)
+				throw new Error("Cursor page count changed");
+			total = reported;
+		}
+		if (events.length) {
+			const key = digest(JSON.stringify(events));
+			if (pages.has(key)) throw new Error("Repeated Cursor page");
+			pages.add(key);
+		}
+		retrieved += events.length;
+		for (const value of events) {
+			const event = apiContribution(value);
+			if (!event) continue;
+			if (event.tsMs < from || event.tsMs >= to)
+				throw new Error("Cursor event outside query");
+			if (event.id && eventIds.has(event.id)) continue;
+			if (event.id) eventIds.add(event.id);
+			out.push(event);
+		}
+		if (total !== undefined && retrieved > total)
+			throw new Error("Invalid Cursor page count");
+		if (
+			(total !== undefined && retrieved === total) ||
+			(total === undefined && events.length < pageSize)
+		)
+			return out;
+		if (!events.length) throw new Error("Incomplete Cursor pages");
+	}
+	throw new Error("Cursor page limit");
+}

--- a/packages/cli/src/harness/cursor/adapter.ts
+++ b/packages/cli/src/harness/cursor/adapter.ts
@@ -1,0 +1,46 @@
+import type { HarnessAdapter } from "../types.js";
+import { cachedEvents, cacheFile, loadCache } from "./cache.js";
+import { messageTimes } from "./evidence.js";
+import { dataPath, readLocal, storeRoot } from "./local.js";
+import { scan } from "./scan.js";
+
+export const CURSOR_HARNESS_NAME = "cursor";
+export const CURSOR_BUILTIN_TOOLS: ReadonlySet<string> = new Set();
+export const cursorAdapter: HarnessAdapter = {
+	name: CURSOR_HARNESS_NAME,
+	builtinTools: CURSOR_BUILTIN_TOOLS,
+	async detect(options) {
+		const roots = options.roots ?? [dataPath()];
+		for (const root of roots) {
+			const held = await loadCache(cacheFile(root, storeRoot()));
+			if (
+				!held.complete ||
+				[
+					...held.value.local,
+					...cachedEvents(held.value, new Set(held.value.sessions)),
+				].some((row) => row.tsMs >= options.sinceMs)
+			)
+				return true;
+			const local = await readLocal(root);
+			// A discovered unreadable source must reach scanComplete, never silently disappear.
+			if (
+				!local.complete ||
+				local.sessions.some(({ session }) =>
+					messageTimes(session).some((t) => t !== null && t >= options.sinceMs),
+				)
+			)
+				return true;
+			// Undated retained history can gain its first usable anchor from dashboard enrichment.
+			if (
+				local.sessions.some(
+					({ session }) =>
+						session.messages.length > 0 &&
+						messageTimes(session).every((t) => t === null),
+				)
+			)
+				return true;
+		}
+		return false;
+	},
+	scan,
+};

--- a/packages/cli/src/harness/cursor/adapter.ts
+++ b/packages/cli/src/harness/cursor/adapter.ts
@@ -3,9 +3,10 @@ import { cachedEvents, cacheFile, loadCache } from "./cache.js";
 import { messageTimes } from "./evidence.js";
 import { dataPath, readLocal, storeRoot } from "./local.js";
 import { scan } from "./scan.js";
+import { CURSOR_BUILTIN_TOOLS } from "./workflow.js";
 
 export const CURSOR_HARNESS_NAME = "cursor";
-export const CURSOR_BUILTIN_TOOLS: ReadonlySet<string> = new Set();
+export { CURSOR_BUILTIN_TOOLS } from "./workflow.js";
 export const cursorAdapter: HarnessAdapter = {
 	name: CURSOR_HARNESS_NAME,
 	builtinTools: CURSOR_BUILTIN_TOOLS,

--- a/packages/cli/src/harness/cursor/cache.ts
+++ b/packages/cli/src/harness/cursor/cache.ts
@@ -1,0 +1,155 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import { asObj } from "../shared/aggregate.js";
+import { type Account, digest, fetchWindow } from "./account.js";
+import { type Contribution, count, timestamp } from "./evidence.js";
+
+export type CachedWindow = {
+	from: number;
+	to: number;
+	fetchedAt: number;
+	events: Contribution[];
+};
+export type CursorCache = {
+	version: 1;
+	account: string | null;
+	windows: Record<string, CachedWindow>;
+	local: Contribution[];
+	sessions: string[];
+};
+export const emptyCache = (): CursorCache => ({
+	version: 1,
+	account: null,
+	windows: {},
+	local: [],
+	sessions: [],
+});
+export const cacheFile = (root: string, store: string) =>
+	path.join(
+		homedir(),
+		".config",
+		"aistack",
+		"cursor",
+		`${digest(`${root}\0${store}`)}.json`,
+	);
+
+function validContribution(value: unknown): value is Contribution {
+	const row = asObj(value);
+	const buckets = asObj(row?.buckets);
+	return (
+		!!row &&
+		typeof row.session === "string" &&
+		typeof row.model === "string" &&
+		timestamp(row.tsMs) !== null &&
+		(row.id === undefined || typeof row.id === "string") &&
+		(row.source === "api" || row.source === "local") &&
+		!!buckets &&
+		["input", "output", "cacheRead", "cacheWrite"].every(
+			(k) => buckets[k] === undefined || count(buckets[k]) !== undefined,
+		)
+	);
+}
+export async function loadCache(
+	file: string,
+): Promise<{ value: CursorCache; complete: boolean }> {
+	try {
+		const raw = asObj(JSON.parse(await readFile(file, "utf8")));
+		const windows = asObj(raw?.windows);
+		if (
+			raw?.version !== 1 ||
+			!(raw.account === null || typeof raw.account === "string") ||
+			!Array.isArray(raw.sessions) ||
+			!raw.sessions.every((id) => typeof id === "string") ||
+			!Array.isArray(raw.local) ||
+			!raw.local.every(validContribution) ||
+			!windows
+		)
+			throw new Error("Invalid cache");
+		for (const value of Object.values(windows)) {
+			const w = asObj(value);
+			if (
+				!w ||
+				timestamp(w.from) === null ||
+				timestamp(w.to) === null ||
+				timestamp(w.fetchedAt) === null ||
+				!Array.isArray(w.events) ||
+				!w.events.every(validContribution)
+			)
+				throw new Error("Invalid window");
+		}
+		return { value: raw as CursorCache, complete: true };
+	} catch (error) {
+		return {
+			value: emptyCache(),
+			complete: (error as NodeJS.ErrnoException).code === "ENOENT",
+		};
+	}
+}
+export async function saveCache(
+	file: string,
+	value: CursorCache,
+): Promise<void> {
+	await mkdir(path.dirname(file), { recursive: true, mode: 0o700 });
+	const temporary = `${file}.${process.pid}.${Date.now()}.tmp`;
+	await writeFile(temporary, JSON.stringify(value), { mode: 0o600 });
+	await rename(temporary, file);
+}
+
+const WINDOW_MS = 30 * 86_400_000;
+/** Complete normalized windows replace atomically. ID-less multiplicity is never hashed away. */
+export async function refreshAccount(input: {
+	cache: CursorCache;
+	account: Account | null;
+	sinceMs: number;
+	now: number;
+	sessionIds: Set<string>;
+	fetchImpl?: typeof fetch;
+}): Promise<CursorCache> {
+	const { cache, account, now, sessionIds } = input;
+	if (!account) return cache;
+	const changed = cache.account !== account.scope;
+	const next: CursorCache = {
+		...cache,
+		account: account.scope,
+		windows: changed ? {} : { ...cache.windows },
+	};
+	// A complete query can still omit activity older than the service's retention.
+	// Preserve empty historical windows previously populated; refresh today's window normally.
+	for (
+		let from = Math.floor(input.sinceMs / WINDOW_MS) * WINDOW_MS;
+		from <= now;
+		from += WINDOW_MS
+	) {
+		const to = Math.min(from + WINDOW_MS, now + 1);
+		const key = String(from);
+		const previous = next.windows[key];
+		if (previous && now - previous.fetchedAt < 300_000) continue;
+		try {
+			const events = (
+				await fetchWindow(account, from, to, input.fetchImpl)
+			).filter((e) => sessionIds.has(e.session));
+			if (previous?.events.length && events.length === 0 && to <= now) continue;
+			next.windows[key] = { from, to, fetchedAt: now, events };
+		} catch {
+			// A first run may still publish complete local evidence. Existing enrichment survives.
+			// Stop after an auth/network failure, rather than retrying every historical window.
+			break;
+		}
+	}
+	return next;
+}
+export function cachedEvents(
+	cache: CursorCache,
+	sessionIds: Set<string>,
+): Contribution[] {
+	const seen = new Set<string>();
+	return Object.values(cache.windows)
+		.sort((a, b) => b.fetchedAt - a.fetchedAt || b.from - a.from)
+		.flatMap((w) => w.events)
+		.filter((e) => {
+			if (!sessionIds.has(e.session) || (e.id && seen.has(e.id))) return false;
+			if (e.id) seen.add(e.id);
+			return true;
+		});
+}

--- a/packages/cli/src/harness/cursor/evidence.test.ts
+++ b/packages/cli/src/harness/cursor/evidence.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { apiContribution } from "./account.js";
+import {
+	localContributions,
+	messageTimes,
+	reconcile,
+	tokenEvidence,
+} from "./evidence.js";
+
+import { AT, session } from "./fixtures.js";
+
+describe("Cursor evidence", () => {
+	it("keeps explicit zero and records context/dry-run provenance without inventing output", () => {
+		expect(
+			tokenEvidence({
+				tokenCount: { inputTokens: 0, outputTokens: 0 },
+				contextWindowStatusAtCreation: { tokensUsed: 500 },
+			}),
+		).toMatchObject({
+			input: 0,
+			output: 0,
+			inputSource: "reported",
+			outputSource: "reported",
+		});
+		expect(
+			tokenEvidence({ contextWindowStatusAtCreation: { tokensUsed: 500 } }),
+		).toMatchObject({ input: 500, output: undefined, inputSource: "context" });
+		expect(
+			tokenEvidence({
+				promptDryRunInfo: JSON.stringify({
+					fullConversationTokenCount: { numTokens: 400 },
+				}),
+			}),
+		).toMatchObject({ input: 400, inputSource: "dry-run" });
+	});
+	it("estimates missing output independently and never adds text to a recorded bucket", () => {
+		const s = session();
+		const context = new Map([
+			[
+				"reply",
+				tokenEvidence({ contextWindowStatusAtCreation: { tokensUsed: 1000 } }),
+			],
+		]);
+		expect(
+			localContributions({ session: s, tokens: context })[0].buckets,
+		).toMatchObject({ input: 1000, output: 2, outputSource: "text" });
+		context.set(
+			"reply",
+			tokenEvidence({ tokenCount: { inputTokens: 100, outputTokens: 0 } }),
+		);
+		expect(
+			localContributions({ session: s, tokens: context })[0].buckets,
+		).toMatchObject({ input: 100, output: 0 });
+	});
+	it("replaces the overlapping conversation/day with API totals and keeps other conversations", () => {
+		const local = localContributions({ session: session(), tokens: new Map() });
+		const other = localContributions({
+			session: session({ id: "other" }),
+			tokens: new Map(),
+		});
+		const api = apiContribution({
+			conversationId: "local-session",
+			timestamp: AT,
+			model: "auto",
+			tokenUsage: { inputTokens: 800 },
+		});
+		if (!api) throw new Error("Expected fixture contribution");
+		expect(reconcile([...local, ...other], [api])).toEqual([...other, api]);
+		expect(api.buckets.output).toBeUndefined();
+		expect(api.model).toBe("auto");
+	});
+	it("excludes absent, cloud and background-composer identities", () => {
+		for (const event of [
+			{},
+			{ conversationId: "x", cloudAgentId: "cloud" },
+			{ conversationId: "bc-x" },
+		])
+			expect(apiContribution(event)).toBeNull();
+	});
+	it("interpolates untimed records between real anchors across UTC midnight", () => {
+		const s = session({
+			createdAtSource: "epoch-unknown",
+			metadata: undefined,
+		});
+		s.messages = [
+			s.messages[0],
+			{ ...s.messages[1], id: "middle", timestampSource: "inferred-previous" },
+			s.messages[1],
+		];
+		s.messages[0].timestamp = "2026-09-09T23:59:58Z";
+		s.messages[2].timestamp = "2026-09-10T00:00:02Z";
+		expect(messageTimes(s)).toEqual([
+			Date.parse("2026-09-09T23:59:58Z"),
+			Date.parse("2026-09-10T00:00:00Z"),
+			Date.parse("2026-09-10T00:00:02Z"),
+		]);
+	});
+	it("never uses mtime or scan time for an undated transcript", () => {
+		const s = session({ createdAtSource: "epoch-unknown" });
+		s.messages = s.messages.map((m) => ({ ...m, timestampSource: "unknown" }));
+		expect(messageTimes(s)).toEqual([null, null]);
+		expect(localContributions({ session: s, tokens: new Map() })).toEqual([]);
+		s.createdAtSource = "store-meta";
+		expect(messageTimes(s)).toEqual([AT, AT]);
+	});
+});

--- a/packages/cli/src/harness/cursor/evidence.ts
+++ b/packages/cli/src/harness/cursor/evidence.ts
@@ -1,0 +1,214 @@
+import type { Message, Session } from "cursor-history";
+import { asObj, asStr } from "../shared/aggregate.js";
+
+export type Buckets = {
+	input?: number;
+	output?: number;
+	cacheRead?: number;
+	cacheWrite?: number;
+};
+export type TokenEvidence = Buckets & {
+	inputSource?: "reported" | "context" | "dry-run" | "text";
+	outputSource?: "reported" | "text";
+};
+export type Contribution = {
+	session: string;
+	id?: string;
+	nativeId?: string;
+	tsMs: number;
+	model: string;
+	buckets: TokenEvidence;
+	source: "api" | "local";
+	sidechain?: boolean;
+};
+export type LocalSession = {
+	session: Session;
+	/** Keyed raw token scalars only. The reader's flattened pair loses zero/presence. */
+	tokens: Map<string, TokenEvidence>;
+};
+
+export function timestamp(value: unknown): number | null {
+	const n =
+		typeof value === "number"
+			? value
+			: typeof value === "string"
+				? /^\d+$/.test(value)
+					? Number(value)
+					: Date.parse(value)
+				: NaN;
+	return Number.isFinite(n) && n > 0 && n < 8.64e15 ? n : null;
+}
+export function count(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0
+		? value
+		: undefined;
+}
+
+/** Direct buckets win individually, including explicit zero. No cents conversion. */
+export function tokenEvidence(value: unknown): TokenEvidence {
+	const raw = asObj(value) ?? {};
+	const direct = asObj(raw.tokenCount);
+	const usage = asObj(raw.usage);
+	for (const [obj, fields] of [
+		[
+			direct,
+			["inputTokens", "outputTokens", "cacheReadTokens", "cacheWriteTokens"],
+		],
+		[
+			usage,
+			[
+				"input_tokens",
+				"output_tokens",
+				"cache_read_input_tokens",
+				"cache_creation_input_tokens",
+			],
+		],
+	] as const) {
+		for (const field of fields)
+			if (obj?.[field] != null && count(obj[field]) === undefined)
+				throw new Error("Invalid Cursor token evidence");
+	}
+	const out: TokenEvidence = {};
+	out.input = count(direct?.inputTokens) ?? count(usage?.input_tokens);
+	out.output = count(direct?.outputTokens) ?? count(usage?.output_tokens);
+	out.cacheRead =
+		count(direct?.cacheReadTokens) ?? count(usage?.cache_read_input_tokens);
+	out.cacheWrite =
+		count(direct?.cacheWriteTokens) ??
+		count(usage?.cache_creation_input_tokens);
+	if (out.input !== undefined) out.inputSource = "reported";
+	if (out.output !== undefined) out.outputSource = "reported";
+	if (out.input === undefined) {
+		const context = count(asObj(raw.contextWindowStatusAtCreation)?.tokensUsed);
+		if (context !== undefined) {
+			out.input = context;
+			out.inputSource = "context";
+		} else if (typeof raw.promptDryRunInfo === "string") {
+			try {
+				const dry = asObj(JSON.parse(raw.promptDryRunInfo));
+				const estimate =
+					count(asObj(dry?.fullConversationTokenCount)?.numTokens) ??
+					count(asObj(dry?.userMessageTokenCount)?.numTokens);
+				if (estimate !== undefined) {
+					out.input = estimate;
+					out.inputSource = "dry-run";
+				}
+			} catch {
+				/* optional estimate */
+			}
+		}
+	}
+	return out;
+}
+
+const directTimes = new Set([
+	"composer-created-at",
+	"composer-timing",
+	"store-turn-timing",
+]);
+/** Interpolate only date attribution. This does not establish call latency. */
+export function messageTimes(
+	session: Session,
+	api: Contribution[] = [],
+): Array<number | null> {
+	const times = session.messages.map((m) =>
+		directTimes.has(m.timestampSource ?? "") ? timestamp(m.timestamp) : null,
+	);
+	const anchors: Array<{ index: number; time: number }> = [];
+	for (const [index, time] of times.entries())
+		if (time !== null) anchors.push({ index, time });
+	const start =
+		session.createdAtSource !== "epoch-unknown"
+			? timestamp(session.timestamp)
+			: null;
+	const end =
+		session.lastUpdatedAtSource !== "epoch-unknown"
+			? timestamp(session.metadata?.lastModified)
+			: null;
+	const apiTimes = api
+		.filter((e) => e.session === session.id)
+		.map((e) => e.tsMs);
+	if (!anchors.some((a) => a.index === 0)) {
+		const time = start ?? (apiTimes.length ? Math.min(...apiTimes) : null);
+		if (time !== null) anchors.unshift({ index: -1, time });
+	}
+	const last = session.messages.length;
+	if (last && !anchors.some((a) => a.index === last - 1)) {
+		const time = end ?? (apiTimes.length ? Math.max(...apiTimes) : null);
+		if (time !== null) anchors.push({ index: last, time });
+	}
+	for (let i = 0; i < times.length; i++) {
+		if (times[i] !== null) continue;
+		const before = anchors.filter((a) => a.index < i).at(-1);
+		const after = anchors.find((a) => a.index > i);
+		if (before && after && after.time >= before.time)
+			times[i] = Math.round(
+				before.time +
+					((after.time - before.time) * (i - before.index)) /
+						(after.index - before.index),
+			);
+		else times[i] = before?.time ?? after?.time ?? null;
+	}
+	return times;
+}
+
+export function localContributions(
+	local: LocalSession,
+	api: Contribution[] = [],
+): Contribution[] {
+	const { session, tokens } = local;
+	const times = messageTimes(session, api);
+	const out: Contribution[] = [];
+	let pending: Message | undefined;
+	const seen = new Set<string>();
+	for (const [i, message] of session.messages.entries()) {
+		if (message.id && seen.has(message.id)) continue;
+		if (message.id) seen.add(message.id);
+		if (message.role === "user") {
+			pending = message;
+			continue;
+		}
+		const own = tokens.get(message.id ?? "") ?? {};
+		const user = tokens.get(pending?.id ?? "") ?? {};
+		const input = own.input !== undefined ? own : user;
+		const buckets: TokenEvidence = {
+			...own,
+			input:
+				input.input ??
+				(pending ? Math.ceil(pending.content.length / 4) : undefined),
+			inputSource: input.inputSource ?? (pending ? "text" : undefined),
+			output: own.output ?? Math.ceil(message.content.length / 4),
+			outputSource: own.outputSource ?? "text",
+		};
+		pending = undefined;
+		const tsMs = times[i];
+		if (tsMs === null) continue;
+		out.push({
+			session: session.id,
+			...(message.id ? { id: message.id } : {}),
+			...(message.identityOrigin === "composer-native" && message.id
+				? { nativeId: message.id }
+				: {}),
+			tsMs,
+			model: asStr(message.model) ?? "unknown",
+			buckets,
+			source: "local",
+			...(message.isSidechain ? { sidechain: true } : {}),
+		});
+	}
+	return out;
+}
+
+/** API events without a response join supersede the conversation's UTC-day total. */
+export function reconcile(
+	local: Contribution[],
+	api: Contribution[],
+): Contribution[] {
+	const grain = (c: Contribution) =>
+		`${c.session}\0${new Date(c.tsMs).toISOString().slice(0, 10)}`;
+	const reported = api.filter((row) =>
+		Object.values(row.buckets).some((value) => typeof value === "number"),
+	);
+	const grains = new Set(reported.map(grain));
+	return [...local.filter((c) => !grains.has(grain(c))), ...reported];
+}

--- a/packages/cli/src/harness/cursor/fixtures.ts
+++ b/packages/cli/src/harness/cursor/fixtures.ts
@@ -1,0 +1,29 @@
+import type { Session } from "cursor-history";
+export const AT = Date.UTC(2026, 8, 10, 12);
+export const session = (overrides: Partial<Session> = {}): Session => ({
+	id: "local-session",
+	workspace: "/synthetic/project",
+	canonicalWorkspacePath: "/synthetic/project",
+	timestamp: new Date(AT).toISOString(),
+	createdAtSource: "composer-metadata",
+	resolutionState: "complete",
+	messageCount: 2,
+	messages: [
+		{
+			id: "user",
+			role: "user",
+			content: "12345678",
+			timestamp: new Date(AT).toISOString(),
+			timestampSource: "composer-created-at",
+		},
+		{
+			id: "reply",
+			role: "assistant",
+			content: "abcdefgh",
+			model: "claude-sonnet-4-6",
+			timestamp: new Date(AT + 1000).toISOString(),
+			timestampSource: "composer-timing",
+		},
+	],
+	...overrides,
+});

--- a/packages/cli/src/harness/cursor/fixtures/composer-rows.json
+++ b/packages/cli/src/harness/cursor/fixtures/composer-rows.json
@@ -1,0 +1,64 @@
+[
+	{
+		"table": "ItemTable",
+		"key": "composer.composerData",
+		"value": {
+			"allComposers": [
+				{
+					"composerId": "11111111-1111-4111-8111-111111111111"
+				}
+			]
+		}
+	},
+	{
+		"table": "cursorDiskKV",
+		"key": "composerData:11111111-1111-4111-8111-111111111111",
+		"value": {
+			"composerId": "11111111-1111-4111-8111-111111111111",
+			"createdAt": 1788998400000,
+			"fullConversationHeadersOnly": [
+				{
+					"bubbleId": "user-1",
+					"type": 1
+				},
+				{
+					"bubbleId": "assistant-1",
+					"type": 2
+				}
+			]
+		}
+	},
+	{
+		"table": "cursorDiskKV",
+		"key": "bubbleId:11111111-1111-4111-8111-111111111111:user-1",
+		"value": {
+			"bubbleId": "user-1",
+			"type": 1,
+			"createdAt": "2026-09-10T00:00:00.000Z",
+			"text": "Read the example file."
+		}
+	},
+	{
+		"table": "cursorDiskKV",
+		"key": "bubbleId:11111111-1111-4111-8111-111111111111:assistant-1",
+		"value": {
+			"bubbleId": "assistant-1",
+			"type": 2,
+			"text": "",
+			"modelInfo": {
+				"modelName": "claude-sonnet-4-6"
+			},
+			"timingInfo": {
+				"clientRpcSendTime": 1788998401000,
+				"clientStartTime": 1788998401000,
+				"clientEndTime": 1788998402000
+			},
+			"toolFormerData": {
+				"name": "read_file",
+				"params": "{\"target_file\":\"/synthetic/project/example.ts\"}",
+				"result": "export const example = 1;",
+				"status": "completed"
+			}
+		}
+	}
+]

--- a/packages/cli/src/harness/cursor/fixtures/transcript.jsonl
+++ b/packages/cli/src/harness/cursor/fixtures/transcript.jsonl
@@ -1,0 +1,2 @@
+{"role": "user", "message": {"content": [{"type": "text", "text": "Read the example file."}]}}
+{"role": "assistant", "message": {"content": [{"type": "tool_use", "id": "synthetic-tool-1", "name": "read_file", "input": {"target_file": "/synthetic/project/example.ts"}}]}}

--- a/packages/cli/src/harness/cursor/fixtures/usage-page.json
+++ b/packages/cli/src/harness/cursor/fixtures/usage-page.json
@@ -1,0 +1,47 @@
+{
+	"totalUsageEventsCount": 4,
+	"usageEventsDisplay": [
+		{
+			"timestamp": "1788998401000",
+			"conversationId": "11111111-1111-4111-8111-111111111111",
+			"model": "claude-sonnet-4-6",
+			"kind": "USAGE_EVENT_KIND_INCLUDED",
+			"chargedCents": 0,
+			"tokenUsage": {
+				"inputTokens": 100,
+				"outputTokens": 20,
+				"cacheReadTokens": 300,
+				"cacheWriteTokens": 40,
+				"totalCents": 0.25
+			}
+		},
+		{
+			"timestamp": "1788998401000",
+			"conversationId": "11111111-1111-4111-8111-111111111111",
+			"model": "claude-sonnet-4-6",
+			"kind": "USAGE_EVENT_KIND_INCLUDED",
+			"chargedCents": 0,
+			"tokenUsage": {
+				"inputTokens": 80,
+				"outputTokens": 10,
+				"cacheReadTokens": 0
+			}
+		},
+		{
+			"timestamp": "1788998401000",
+			"conversationId": "22222222-2222-4222-8222-222222222222",
+			"model": "claude-sonnet-4-6",
+			"kind": "USAGE_EVENT_KIND_INCLUDED",
+			"chargedCents": 0,
+			"cloudAgentId": "synthetic-cloud",
+			"tokenUsage": {
+				"inputTokens": 15,
+				"outputTokens": 5
+			}
+		},
+		{
+			"timestamp": "1788998402000",
+			"model": "auto"
+		}
+	]
+}

--- a/packages/cli/src/harness/cursor/local.test.ts
+++ b/packages/cli/src/harness/cursor/local.test.ts
@@ -1,0 +1,133 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import rows from "./fixtures/composer-rows.json";
+import { dataPath, readLocal } from "./local.js";
+
+let dir: string;
+let root: string;
+beforeEach(async () => {
+	dir = await mkdtemp(path.join(tmpdir(), "cursor-local-"));
+	root = path.join(dir, "User", "workspaceStorage");
+	vi.stubEnv("CURSOR_DATA_PATH", root);
+	vi.stubEnv("CURSOR_STORE_ROOT", path.join(dir, "store"));
+});
+afterEach(async () => {
+	vi.unstubAllEnvs();
+	await rm(dir, { recursive: true, force: true });
+});
+
+async function createSource() {
+	const workspace = path.join(root, "synthetic");
+	await mkdir(workspace, { recursive: true });
+	await mkdir(path.join(dir, "User", "globalStorage"), { recursive: true });
+	await writeFile(
+		path.join(workspace, "workspace.json"),
+		JSON.stringify({ folder: "file:///synthetic/project" }),
+	);
+	const global = new DatabaseSync(
+		path.join(dir, "User", "globalStorage", "state.vscdb"),
+	);
+	const local = new DatabaseSync(path.join(workspace, "state.vscdb"));
+	global.exec(
+		"CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT); CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)",
+	);
+	local.exec("CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)");
+	for (const row of rows) {
+		const target = row.table === "cursorDiskKV" ? global : local;
+		target
+			.prepare(`INSERT INTO ${row.table} VALUES (?, ?)`)
+			.run(row.key, JSON.stringify(row.value));
+	}
+	local.close();
+	global.close();
+}
+
+it("resolves the qualified Composer fixture with the packaged node:sqlite reader", async () => {
+	await createSource();
+	const reading = await readLocal(root);
+	expect(
+		reading.complete,
+		JSON.stringify(reading.sessions.map((s) => s.session.resolution)),
+	).toBe(true);
+	expect(reading.sessions).toHaveLength(1);
+	expect(reading.sessions[0].session.id).toBe(
+		"11111111-1111-4111-8111-111111111111",
+	);
+	expect(reading.sessions[0].session.canonicalWorkspacePath).toBe(
+		"/synthetic/project",
+	);
+	expect(reading.sessions[0].session.messages).toHaveLength(2);
+	expect(reading.sessions[0].session.messages[1].toolCalls?.[0].name).toBe(
+		"read_file",
+	);
+});
+it("reconciles a transcript copy once and retains explicit-zero raw token evidence", async () => {
+	await createSource();
+	const id = "11111111-1111-4111-8111-111111111111";
+	const transcriptRoot = path.join(
+		dir,
+		"store",
+		"projects",
+		"synthetic",
+		"agent-transcripts",
+	);
+	await mkdir(transcriptRoot, { recursive: true });
+	await writeFile(
+		path.join(transcriptRoot, `${id}.jsonl`),
+		await readFile(
+			new URL("./fixtures/transcript.jsonl", import.meta.url),
+			"utf8",
+		),
+	);
+	const db = new DatabaseSync(
+		path.join(dir, "User", "globalStorage", "state.vscdb"),
+	);
+	const key = `bubbleId:${id}:assistant-1`;
+	const record = rows.find((r) => r.key === key);
+	if (!record) throw new Error("Expected fixture record");
+	db.prepare("UPDATE cursorDiskKV SET value = ? WHERE key = ?").run(
+		JSON.stringify({
+			...record.value,
+			tokenCount: { inputTokens: 50, outputTokens: 0 },
+		}),
+		key,
+	);
+	db.close();
+	const reading = await readLocal(root);
+	expect(
+		reading.complete,
+		JSON.stringify(reading.sessions.map((s) => s.session.resolution)),
+	).toBe(true);
+	expect(reading.sessions).toHaveLength(1);
+	expect(reading.sessions[0].tokens.get("assistant-1")).toMatchObject({
+		input: 50,
+		output: 0,
+		outputSource: "reported",
+	});
+});
+it("distinguishes no installation from an unreadable retained database", async () => {
+	expect((await readLocal(root)).complete).toBe(true);
+	await mkdir(path.join(dir, "User", "globalStorage"), { recursive: true });
+	await writeFile(
+		path.join(dir, "User", "globalStorage", "state.vscdb"),
+		"not a database",
+	);
+	expect((await readLocal(root)).complete).toBe(false);
+});
+it("discovers Windows, XDG and configured workspace roots without scanning another platform", () => {
+	expect(dataPath({ APPDATA: "/windows/data" }, "/home/test", "win32")).toBe(
+		"/windows/data/Cursor/User/workspaceStorage",
+	);
+	expect(dataPath({ XDG_CONFIG_HOME: "/config" }, "/home/test", "linux")).toBe(
+		"/config/Cursor/User/workspaceStorage",
+	);
+	expect(dataPath({}, "/home/test", "darwin")).toBe(
+		"/home/test/Library/Application Support/Cursor/User/workspaceStorage",
+	);
+	expect(
+		dataPath({ CURSOR_DATA_PATH: "/configured" }, "/home/test", "linux"),
+	).toBe("/configured");
+});

--- a/packages/cli/src/harness/cursor/local.ts
+++ b/packages/cli/src/harness/cursor/local.ts
@@ -1,0 +1,199 @@
+import { stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import type { Session, SessionReadContext } from "cursor-history";
+import { asObj, asStr } from "../shared/aggregate.js";
+import { emptyScanStats, type ScanStats } from "../shared/window.js";
+import {
+	type LocalSession,
+	type TokenEvidence,
+	tokenEvidence,
+} from "./evidence.js";
+
+/** Cursor's user-data override is a workspaceStorage path, as in cursor-history. */
+export function dataPath(
+	env = process.env,
+	home = homedir(),
+	platform = process.platform,
+): string {
+	if (env.CURSOR_DATA_PATH) return path.resolve(env.CURSOR_DATA_PATH);
+	const base =
+		platform === "darwin"
+			? path.join(home, "Library", "Application Support")
+			: platform === "win32"
+				? env.APPDATA || path.join(home, "AppData", "Roaming")
+				: env.XDG_CONFIG_HOME || path.join(home, ".config");
+	return path.join(base, "Cursor", "User", "workspaceStorage");
+}
+export const storeRoot = () =>
+	process.env.CURSOR_STORE_ROOT || path.join(homedir(), ".cursor");
+export const globalDb = (root: string) =>
+	path.join(path.dirname(root), "globalStorage", "state.vscdb");
+
+async function exists(file: string): Promise<boolean> {
+	try {
+		await stat(file);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code !== "ENOENT";
+	}
+}
+export async function hasLocalSource(root = dataPath()): Promise<boolean> {
+	return (
+		await Promise.all(
+			[
+				root,
+				globalDb(root),
+				path.join(storeRoot(), "projects"),
+				path.join(storeRoot(), "chats"),
+				path.join(storeRoot(), "acp-sessions"),
+			].map(exists),
+		)
+	).some(Boolean);
+}
+
+type Sqlite = import("node:sqlite").DatabaseSync;
+/** Supplemental read only for fields the selected reader flattens. No transcript parser. */
+export async function readTokenEvidence(
+	root: string,
+	session: Session,
+): Promise<Map<string, TokenEvidence>> {
+	const out = new Map<string, TokenEvidence>();
+	if (!session.messages.some((m) => m.identityOrigin?.startsWith("composer")))
+		return out;
+	const file = globalDb(root);
+	if (!(await exists(file))) return out;
+	const { DatabaseSync } = await import("node:sqlite");
+	const db: Sqlite = new DatabaseSync(file, { readOnly: true });
+	try {
+		db.exec("BEGIN");
+		const table = db
+			.prepare(
+				"SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'cursorDiskKV'",
+			)
+			.get();
+		if (!table) return out;
+		const query = db.prepare(`SELECT json_object(
+			'tokenCount', json_extract(value, '$.tokenCount'),
+			'usage', json_extract(value, '$.usage'),
+			'contextWindowStatusAtCreation', json_extract(value, '$.contextWindowStatusAtCreation'),
+			'promptDryRunInfo', json_extract(value, '$.promptDryRunInfo')) AS evidence
+			FROM cursorDiskKV WHERE key = ?`);
+		for (const message of session.messages) {
+			if (!message.id || message.identityOrigin !== "composer-native") continue;
+			const row = query.get(`bubbleId:${session.id}:${message.id}`);
+			if (typeof row?.evidence === "string")
+				out.set(message.id, tokenEvidence(JSON.parse(row.evidence)));
+		}
+		// Older Composer headers can retain inline bubbles instead of split keys.
+		const header = db
+			.prepare(
+				"SELECT json_extract(value, '$.conversation') AS conversation FROM cursorDiskKV WHERE key = ?",
+			)
+			.get(`composerData:${session.id}`);
+		if (typeof header?.conversation === "string") {
+			const conversation: unknown = JSON.parse(header.conversation);
+			if (Array.isArray(conversation))
+				for (const [index, raw] of conversation.entries()) {
+					const obj = asObj(raw);
+					const id = asStr(obj?.bubbleId) ?? asStr(obj?.id) ?? `msg:${index}`;
+					if (!out.has(id)) out.set(id, tokenEvidence(raw));
+				}
+		}
+		return out;
+	} finally {
+		db.close();
+	}
+}
+
+async function sourceStamp(root: string): Promise<string> {
+	const values = await Promise.all(
+		[globalDb(root), `${globalDb(root)}-wal`].map(async (file) => {
+			try {
+				const info = await stat(file);
+				return `${info.size}:${info.mtimeMs}`;
+			} catch {
+				return "unavailable";
+			}
+		}),
+	);
+	return values.join("/");
+}
+
+export type LocalRead = {
+	sessions: LocalSession[];
+	complete: boolean;
+	stats: ScanStats;
+};
+/** Errors never escape with paths, prompts or database values. */
+export async function readLocal(
+	root = dataPath(),
+	onProgress?: (files: number) => void,
+): Promise<LocalRead> {
+	const stats = emptyScanStats();
+	const out: LocalRead = { sessions: [], complete: true, stats };
+	if (!(await hasLocalSource(root))) return out;
+	const before = await sourceStamp(root);
+	let context: SessionReadContext | undefined;
+	try {
+		const reader = await import("cursor-history");
+		const options = {
+			dataPath: root,
+			sqliteDriver: "node:sqlite" as const,
+			onDiagnostic: () => {
+				out.complete = false;
+			},
+			signal: AbortSignal.timeout(120_000),
+		};
+		context = reader.createSessionReadContext(options);
+		const config = { ...options, readContext: context };
+		let offset = 0;
+		while (true) {
+			const page = await reader.listSessionSummaries({
+				...config,
+				offset,
+				limit: 100,
+			});
+			for (const summary of page.data) {
+				stats.filesFound++;
+				if (summary.resolutionState === "ambiguous") {
+					out.complete = false;
+				}
+				try {
+					const session = await reader.getSession(summary.id, config);
+					if (
+						session.resolutionState !== "complete" ||
+						session.messages.some((m) => m.metadata?.corrupted)
+					)
+						out.complete = false;
+					const tokens = await readTokenEvidence(root, session);
+					out.sessions.push({ session, tokens });
+					stats.filesRead++;
+					onProgress?.(stats.filesRead);
+				} catch {
+					out.complete = false;
+					stats.filesUnreadable++;
+				} finally {
+					context.releaseSession(summary.id);
+				}
+			}
+			if (!page.pagination.hasMore) break;
+			if (page.data.length === 0 || offset >= 100_000) {
+				out.complete = false;
+				break;
+			}
+			offset += page.data.length;
+		}
+	} catch {
+		out.complete = false;
+		stats.filesUnreadable++;
+	} finally {
+		try {
+			await context?.dispose();
+		} catch {
+			out.complete = false;
+		}
+	}
+	if (before !== (await sourceStamp(root))) out.complete = false;
+	return out;
+}

--- a/packages/cli/src/harness/cursor/scan.test.ts
+++ b/packages/cli/src/harness/cursor/scan.test.ts
@@ -1,0 +1,215 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { buildUsageDays } from "../../usage/days.js";
+import { countsTotal, finalize } from "../shared/aggregate.js";
+import { emptyScanStats } from "../shared/window.js";
+import { loadCache } from "./cache.js";
+import { AT, session } from "./fixtures.js";
+import type { LocalRead } from "./local.js";
+import { type ScanOptions, scan } from "./scan.js";
+
+let dir: string;
+let options: ScanOptions;
+let local: LocalRead;
+beforeEach(async () => {
+	dir = await mkdtemp(path.join(tmpdir(), "cursor-scan-"));
+	local = {
+		sessions: [
+			{
+				session: session(),
+				tokens: new Map([
+					[
+						"reply",
+						{
+							input: 1000,
+							inputSource: "context",
+							output: 0,
+							outputSource: "reported",
+						},
+					],
+				]),
+			},
+		],
+		complete: true,
+		stats: emptyScanStats(),
+	};
+	options = {
+		root: path.join(dir, "root"),
+		cachePath: path.join(dir, "cache.json"),
+		now: AT + 2000,
+		sinceMs: AT - 86_400_000,
+		readLocalImpl: async () => local,
+		accountImpl: async () => null,
+	};
+});
+afterEach(async () => {
+	await rm(dir, { recursive: true, force: true });
+});
+const event = (overrides: Record<string, unknown> = {}) => ({
+	id: "event-1",
+	conversationId: "local-session",
+	timestamp: AT + 1000,
+	model: "claude-sonnet-4-6",
+	tokenUsage: { inputTokens: 800, outputTokens: 0 },
+	...overrides,
+});
+const fetcher = (events: unknown[]) =>
+	vi.fn<typeof fetch>().mockImplementation(async () =>
+		Response.json({
+			usageEventsDisplay: events,
+			totalUsageEventsCount: events.length,
+		}),
+	);
+const total = async () => finalize((await scan(options)).aggregate).totalTokens;
+
+it("publishes useful local-only counts then replaces them with matched API usage through shared days", async () => {
+	expect(await total()).toBe(1000);
+	options.accountImpl = async () => ({
+		scope: "account-a",
+		cookie: "not-persisted",
+	});
+	options.fetchImpl = fetcher([
+		event(),
+		event({ id: "other", conversationId: "unmatched" }),
+		event({ id: "cloud", cloudAgentId: "cloud" }),
+	]);
+	const reading = await scan(options);
+	expect(reading.scanComplete).toBe(true);
+	expect(finalize(reading.aggregate).totalTokens).toBe(800);
+	const days = buildUsageDays({
+		aggregate: reading.aggregate,
+		harness: "cursor",
+		publishCost: false,
+		projectWorkspaceId: () => "opaque-workspace",
+	});
+	expect(days.size).toBe(1);
+	const wire = JSON.stringify([...days.values()]);
+	expect(wire).toContain('"harness":"cursor"');
+	expect(wire).not.toContain("/synthetic");
+	expect(wire).not.toContain('"usd"');
+	const stored = await readFile(path.join(dir, "cache.json"), "utf8");
+	expect(stored).not.toContain("not-persisted");
+	expect(stored).not.toContain("abcdefgh");
+});
+it("preserves complete enrichment on a later-page failure and on missing login", async () => {
+	options.accountImpl = async () => ({ scope: "account-a", cookie: "cookie" });
+	options.fetchImpl = fetcher([event()]);
+	expect(await total()).toBe(800);
+	options.now = AT + 600_000;
+	const page = Array.from({ length: 100 }, (_, i) =>
+		event({ id: String(i), tokenUsage: { inputTokens: 1 } }),
+	);
+	options.fetchImpl = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(
+			Response.json({ usageEventsDisplay: page, totalUsageEventsCount: 101 }),
+		)
+		.mockResolvedValueOnce(new Response(null, { status: 401 }));
+	expect(await total()).toBe(800);
+	options.accountImpl = async () => null;
+	expect(await total()).toBe(800);
+});
+it("does not reuse another account's enrichment and keeps ID-less multiplicity across repeated refreshes", async () => {
+	options.accountImpl = async () => ({ scope: "account-a", cookie: "cookie" });
+	options.fetchImpl = fetcher([
+		event({ id: undefined }),
+		event({ id: undefined }),
+	]);
+	expect(await total()).toBe(1600);
+	options.now = AT + 600_000;
+	expect(await total()).toBe(1600);
+	options.accountImpl = async () => ({
+		scope: "account-b",
+		cookie: "different",
+	});
+	options.fetchImpl = vi
+		.fn<typeof fetch>()
+		.mockRejectedValue(new Error("offline"));
+	expect(await total()).toBe(1000);
+});
+it("keeps a temporarily missing source unsafe on repeated scans and never commits the partial cache", async () => {
+	await scan(options);
+	local.sessions = [];
+	expect((await scan(options)).scanComplete).toBe(false);
+	expect((await scan(options)).scanComplete).toBe(false);
+	expect(
+		(await loadCache(path.join(dir, "cache.json"))).value.sessions,
+	).toEqual(["local-session"]);
+});
+it("withholds replacement when a retained source or cache is malformed", async () => {
+	local.complete = false;
+	expect((await scan(options)).scanComplete).toBe(false);
+	local.complete = true;
+	await writeFile(path.join(dir, "cache.json"), "broken cache");
+	expect((await scan(options)).scanComplete).toBe(false);
+});
+it("returns both UTC dates when a refreshed native event moves to the next day", async () => {
+	const old = Date.UTC(2026, 8, 9, 23, 59);
+	options.sinceMs = Date.UTC(2026, 8, 9);
+	options.accountImpl = async () => ({ scope: "account-a", cookie: "cookie" });
+	options.fetchImpl = fetcher([event({ timestamp: old })]);
+	await scan(options);
+	options.now = AT + 600_000;
+	options.fetchImpl = fetcher([event({ timestamp: AT })]);
+	const reading = await scan(options);
+	expect(
+		[...(reading.sessionDates?.get("local-session") ?? [])].sort(),
+	).toEqual(["2026-09-09", "2026-09-10"]);
+	expect(reading.aggregate.usageDays.has("2026-09-09")).toBe(false);
+});
+it("attributes two equal-timestamp conversations separately", async () => {
+	local.sessions.push({
+		...local.sessions[0],
+		session: session({ id: "second" }),
+	});
+	options.accountImpl = async () => ({ scope: "account-a", cookie: "cookie" });
+	options.fetchImpl = fetcher([
+		event(),
+		event({ id: "event-2", conversationId: "second" }),
+	]);
+	const reading = await scan(options);
+	expect(reading.aggregate.sessions.size).toBe(2);
+	expect(countsTotal([...reading.aggregate.byModel.values()][0])).toBe(1600);
+});
+
+it("preserves copied native response prefixes once while counting newly performed child activity", async () => {
+	const parent = session();
+	parent.messages[1].identityOrigin = "composer-native";
+	const child = session({
+		id: "child",
+		messages: [
+			...parent.messages,
+			{
+				...parent.messages[1],
+				id: "child-new",
+				isSidechain: true,
+				content: "new text",
+			},
+		],
+	});
+	local.sessions = [
+		{ session: parent, tokens: new Map() },
+		{ session: child, tokens: new Map() },
+	];
+	const reading = await scan(options);
+	expect(reading.aggregate.distinctResponses).toBe(2);
+	expect(finalize(reading.aggregate).totalTokens).toBe(6);
+	expect(reading.aggregate.sidechainTokens).toBe(2);
+});
+it("does not replace usable local counts with a billing-only account event", async () => {
+	options.accountImpl = async () => ({ scope: "account", cookie: "cookie" });
+	options.fetchImpl = fetcher([event({ tokenUsage: { totalCents: 5 } })]);
+	expect(await total()).toBe(1000);
+});
+it("retains untimed model inventory without inventing a dated usage row", async () => {
+	local.sessions[0].session.createdAtSource = "epoch-unknown";
+	local.sessions[0].session.messages = local.sessions[0].session.messages.map(
+		(m) => ({ ...m, timestampSource: "unknown" }),
+	);
+	const reading = await scan(options);
+	expect(reading.aggregate.usageDays.size).toBe(0);
+	expect(reading.aggregate.byModel.has("claude-sonnet-4-6")).toBe(true);
+	expect(finalize(reading.aggregate).totalTokens).toBe(0);
+});

--- a/packages/cli/src/harness/cursor/scan.test.ts
+++ b/packages/cli/src/harness/cursor/scan.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { layeredPricer, setActivePricer } from "@aistack/pricing";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { detectMcpServers } from "../../mcp.js";
 import { scanLocal } from "../../scanner.js";
@@ -50,6 +51,7 @@ beforeEach(async () => {
 	};
 });
 afterEach(async () => {
+	setActivePricer(null);
 	await rm(dir, { recursive: true, force: true });
 });
 const event = (overrides: Record<string, unknown> = {}) => ({
@@ -428,4 +430,96 @@ it("reuses configured Cursor resources without claiming use and publishes only c
 		/private-tool|private-skill|private_docs|never-send|skill body|rule body/,
 	);
 	expect(wire).not.toContain(project);
+});
+
+it("values Cursor tokens at dated shared rates, never dashboard charges, and leaves Auto unpriced", async () => {
+	setActivePricer(
+		layeredPricer({
+			id: "cursor-test-table",
+			rows: [
+				{
+					modelSlug: "claude-sonnet-4-6",
+					from: 0,
+					input: 2,
+					output: 4,
+					cacheRead: 0.5,
+					cacheWrite5m: 3,
+					source: "old-period",
+				},
+				{
+					modelSlug: "claude-sonnet-4-6",
+					from: AT + 500,
+					input: 5,
+					output: 10,
+					cacheRead: 1,
+					cacheWrite5m: 6,
+					source: "new-period",
+				},
+			],
+		}),
+	);
+	options.accountImpl = async () => ({ scope: "account-a", cookie: "cookie" });
+	options.fetchImpl = fetcher([
+		event({ id: "old", timestamp: AT, tokenUsage: { inputTokens: 1000 } }),
+		event({
+			id: "new",
+			model: "claude-sonnet-4-6-20260910",
+			tokenUsage: {
+				inputTokens: 1000,
+				outputTokens: 100,
+				cacheReadTokens: 200,
+				cacheWriteTokens: 300,
+			},
+			chargedCents: 999999,
+		}),
+		event({
+			id: "auto",
+			model: "auto",
+			tokenUsage: { inputTokens: 500 },
+			chargedCents: 999999,
+		}),
+		event({
+			id: "vendor",
+			model: "anthropic:claude-sonnet-4-6",
+			tokenUsage: { inputTokens: 1000 },
+		}),
+		event({
+			id: "gateway",
+			model: "openrouter:claude-sonnet-4-6",
+			tokenUsage: { inputTokens: 300 },
+		}),
+		event({
+			id: "free",
+			model: "local:llama",
+			tokenUsage: { inputTokens: 200 },
+		}),
+	]);
+	const reading = await scan(options);
+	const build = (publishCost: boolean) =>
+		[
+			...buildUsageDays({
+				aggregate: reading.aggregate,
+				harness: "cursor",
+				publishCost,
+				projectWorkspaceId: () => "opaque-workspace",
+			}).values(),
+		][0];
+	const day = build(true);
+	expect(
+		day.models.find((m) => m.model === "claude-sonnet-4-6")?.usd,
+	).toBeCloseTo(0.01, 6);
+	expect(day.models.find((m) => m.model === "auto")?.usd).toBeUndefined();
+	expect(day.models.find((m) => m.model === "local:llama")).toMatchObject({
+		usd: 0,
+		pricingTable: "local-no-charge",
+	});
+	expect(
+		day.models.find((m) => m.model === "anthropic:claude-sonnet-4-6")?.usd,
+	).toBeCloseTo(0.005, 6);
+	expect(
+		day.models.find((m) => m.model === "openrouter:claude-sonnet-4-6")?.usd,
+	).toBeUndefined();
+	expect(day.excludedTokens.unpriced).toBe(800);
+	expect(JSON.stringify(build(false))).not.toContain('"usd"');
+	expect(JSON.stringify(build(false))).not.toContain('"pricingTable"');
 });

--- a/packages/cli/src/harness/cursor/scan.test.ts
+++ b/packages/cli/src/harness/cursor/scan.test.ts
@@ -1,10 +1,15 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { detectMcpServers } from "../../mcp.js";
+import { scanLocal } from "../../scanner.js";
 import { buildUsageDays } from "../../usage/days.js";
 import { countsTotal, finalize } from "../shared/aggregate.js";
+import { BUNDLED_SYNC_CONFIG } from "../shared/allowlist.js";
+import { buildPayload } from "../shared/payload.js";
 import { emptyScanStats } from "../shared/window.js";
+import { CURSOR_BUILTIN_TOOLS } from "./adapter.js";
 import { loadCache } from "./cache.js";
 import { AT, session } from "./fixtures.js";
 import type { LocalRead } from "./local.js";
@@ -212,4 +217,215 @@ it("retains untimed model inventory without inventing a dated usage row", async 
 	expect(reading.aggregate.usageDays.size).toBe(0);
 	expect(reading.aggregate.byModel.has("claude-sonnet-4-6")).toBe(true);
 	expect(finalize(reading.aggregate).totalTokens).toBe(0);
+});
+
+it("projects tools, questions and API routing through shared workflow while keeping accumulated Context absent", async () => {
+	const reply = local.sessions[0].session.messages[1];
+	reply.toolCalls = [
+		{ id: "read", name: "read_file_v2", status: "completed" },
+		{ id: "edit", name: "search_replace", status: "completed" },
+		{
+			id: "test",
+			name: "run_terminal_cmd",
+			status: "completed",
+			params: { command: "pnpm test" },
+		},
+		{ id: "search", name: "web_search", status: "completed" },
+		{ id: "ask", name: "ask_question", status: "completed" },
+		{
+			id: "skill",
+			name: "skill",
+			status: "completed",
+			params: { skill: "code-review" },
+		},
+		{ id: "mcp", name: "mcp__context7__query_docs", status: "completed" },
+	];
+	options.accountImpl = async () => ({ scope: "account", cookie: "cookie" });
+	options.fetchImpl = fetcher([event()]);
+	const reading = await scan(options);
+	const day = reading.workflow.days[0];
+	expect(day.sessions).toBe(1);
+	expect(day.startHours).toEqual([{ hourUtc: 12, sessions: 1 }]);
+	expect(day.questions).toEqual({ asked: 1, turns: 1 });
+	expect(day.webSearches).toBe(1);
+	expect(day.routing).toEqual({
+		main: [{ model: "claude-sonnet-4-6", tokens: 800 }],
+		subagents: [],
+	});
+	expect(day.phase?.phaseEvents).toEqual({
+		scout: 2,
+		build: 1,
+		verify: 2,
+		handoff: 1,
+		unknown: 1,
+	});
+	expect(day.activity.reduce((sum, cell) => sum + cell.events, 0)).toBe(7);
+	for (const field of ["context", "turnDurations", "thinking", "effort"])
+		expect(day).not.toHaveProperty(field);
+	expect(reading.workflowLocal.projectWorkspaces).toEqual(
+		new Set(["/synthetic/project"]),
+	);
+	expect(reading.workflowLocal.activeProjectDays.get("2026-09-10")).toEqual(
+		new Set(["/synthetic/project"]),
+	);
+	expect(reading.aggregate.skillCalls.get("code-review")).toBe(1);
+	expect(reading.aggregate.mcpServerCalls.get("context7")).toBe(1);
+	expect(reading.aggregate.toolCalls.get("search_replace")).toBe(1);
+	expect(JSON.stringify(reading.workflow)).not.toMatch(
+		/synthetic|pnpm test|local-session|abcdefgh|query_docs/,
+	);
+});
+
+it("deduplicates inherited native messages and tools and uses demonstrated sidechain parent references", async () => {
+	const parent = session();
+	for (const message of parent.messages)
+		message.identityOrigin = "composer-native";
+	parent.messages[1].toolCalls = [
+		{
+			id: "native-tool",
+			identityOrigin: "source-native",
+			name: "read_file",
+			status: "completed",
+		},
+	];
+	const child = session({
+		id: "child",
+		messages: [
+			...parent.messages,
+			{
+				...parent.messages[1],
+				id: "new-child",
+				parentMessageId: "reply",
+				isSidechain: true,
+				toolCalls: [
+					...parent.messages[1].toolCalls,
+					{
+						id: "new-tool",
+						identityOrigin: "source-native",
+						name: "edit_file",
+						status: "completed",
+					},
+				],
+			},
+		],
+	});
+	local.sessions = [
+		{ session: parent, tokens: new Map() },
+		{ session: child, tokens: new Map() },
+	];
+	const reading = await scan(options);
+	const day = reading.workflow.days[0];
+	expect(day.delegation).toEqual({
+		mainToolCalls: 1,
+		subagentToolCalls: 1,
+		widestFanOut: 1,
+		mostSubagents: 1,
+	});
+	expect(day.routing?.main[0].tokens).toBe(4);
+	expect(day.routing?.subagents[0].tokens).toBe(2);
+	expect(day.questions?.turns).toBe(2);
+	expect(reading.aggregate.toolCalls.get("read_file")).toBe(1);
+});
+
+it("skips Cursor workflow extraction with consent off while retaining observed inventory and usage", async () => {
+	options.publishWorkflow = false;
+	local.sessions[0].session.messages[1].toolCalls = [
+		{ name: "read_file", status: "completed" },
+	];
+	const reading = await scan(options);
+	expect(reading.workflow.days).toEqual([]);
+	expect(reading.workflowLocal.projectWorkspaces.size).toBe(0);
+	expect(reading.workflowLocal.activeProjectDays.size).toBe(0);
+	expect(reading.aggregate.toolCalls.get("read_file")).toBe(1);
+	expect(finalize(reading.aggregate).totalTokens).toBe(1000);
+});
+
+it("keeps undated tools in inventory without inventing workflow or a Git day", async () => {
+	const localSession = local.sessions[0].session;
+	localSession.createdAtSource = "epoch-unknown";
+	localSession.messages = localSession.messages.map((m) => ({
+		...m,
+		timestampSource: "unknown",
+	}));
+	localSession.messages[1].toolCalls = [
+		{ name: "read_file", status: "completed" },
+	];
+	const reading = await scan(options);
+	expect(reading.aggregate.toolCalls.get("read_file")).toBe(1);
+	expect(reading.workflow.days).toEqual([]);
+	expect(reading.workflowLocal.activeProjectDays.size).toBe(0);
+});
+
+it("reuses configured Cursor resources without claiming use and publishes only consented observed names", async () => {
+	const project = path.join(dir, "project");
+	await mkdir(path.join(project, ".cursor", "skills", "private-skill"), {
+		recursive: true,
+	});
+	await mkdir(path.join(project, ".cursor", "rules"), { recursive: true });
+	await writeFile(
+		path.join(project, ".cursor", "skills", "private-skill", "SKILL.md"),
+		"skill body",
+	);
+	await writeFile(
+		path.join(project, ".cursor", "rules", "project.mdc"),
+		"rule body",
+	);
+	await writeFile(
+		path.join(project, ".cursor", "mcp.json"),
+		JSON.stringify({
+			mcpServers: {
+				private_docs: {
+					command: "npx",
+					args: ["-y", "example-mcp"],
+					env: { TOKEN: "never-send" },
+				},
+				unused: { command: "npx", args: ["-y", "unused-mcp"] },
+			},
+		}),
+	);
+	const configured = detectMcpServers(project, dir);
+	expect(
+		configured.filter((r) => r.group === "cursor").map((r) => r.name),
+	).toEqual(["private_docs", "unused"]);
+	expect(JSON.stringify(configured)).not.toContain("never-send");
+	expect(scanLocal(project).map((r) => [r.type, r.group])).toEqual([
+		["rule", "cursor"],
+		["skill", "cursor"],
+	]);
+	local.sessions[0].session.canonicalWorkspacePath = project;
+	local.sessions[0].session.messages[1].toolCalls = [
+		{ name: "read_file", status: "completed" },
+		{ name: "private-tool", status: "completed" },
+		{ name: "skill", status: "completed", params: { skill: "private-skill" } },
+		{ name: "mcp_private_docs_search", status: "completed" },
+	];
+	const reading = await scan(options);
+	expect(reading.aggregate.mcpServerCalls).toEqual(
+		new Map([["private_docs", 1]]),
+	);
+	const projectId = vi.fn(() => "AAAAAAAAAAAAAAAAAAAAAA");
+	const built = buildPayload({
+		aggregate: reading.aggregate,
+		stats: reading.stats,
+		syncConfig: { ...BUNDLED_SYNC_CONFIG, publishCost: false },
+		now: AT + 2000,
+		windowDays: 30,
+		harnessName: "cursor",
+		builtinTools: CURSOR_BUILTIN_TOOLS,
+		projectWorkspaceId: projectId,
+	});
+	expect(projectId).toHaveBeenCalledWith(project);
+	expect(built.payload.activity.projectKeys).toEqual([
+		"AAAAAAAAAAAAAAAAAAAAAA",
+	]);
+	expect(
+		built.payload.inventory.builtinTools.map((tool) => tool.name),
+	).toContain("read_file");
+	expect(built.payload.inventory.mcpServers).toEqual([]);
+	expect(built.payload.inventory.skills).toEqual([]);
+	const wire = JSON.stringify(built.payload);
+	expect(wire).not.toMatch(
+		/private-tool|private-skill|private_docs|never-send|skill body|rule body/,
+	);
+	expect(wire).not.toContain(project);
 });

--- a/packages/cli/src/harness/cursor/scan.ts
+++ b/packages/cli/src/harness/cursor/scan.ts
@@ -153,6 +153,8 @@ export async function scan(options: ScanOptions): Promise<HarnessScan> {
 			cacheWrite1h: 0,
 			cacheWriteUnsplit: buckets.cacheWrite ?? 0,
 		};
+		// Value the reported model at shared API rates. Cursor account charges
+		// include plan accounting and never substitute for token valuation.
 		addModelUsage(
 			aggregate,
 			model,

--- a/packages/cli/src/harness/cursor/scan.ts
+++ b/packages/cli/src/harness/cursor/scan.ts
@@ -1,0 +1,176 @@
+import path from "node:path";
+import {
+	apiEquivalentCost,
+	normalizeModel,
+	type TokenCounts,
+} from "@aistack/pricing";
+import {
+	createHarnessWorkflowReducer,
+	createWorkflowLocalSources,
+} from "../../workflow/reducer.js";
+import {
+	addModelUsage,
+	countsTotal,
+	createAggregate,
+	emptyUsage,
+	noteProjectDay,
+	noteSessionStart,
+	utcDateOf,
+} from "../shared/aggregate.js";
+import type { HarnessScan, HarnessScanOptions } from "../types.js";
+import { type Account, existingAccount } from "./account.js";
+import {
+	cachedEvents,
+	cacheFile,
+	loadCache,
+	refreshAccount,
+	saveCache,
+} from "./cache.js";
+import { localContributions, messageTimes, reconcile } from "./evidence.js";
+import { dataPath, type LocalRead, readLocal, storeRoot } from "./local.js";
+
+export type ScanOptions = HarnessScanOptions & {
+	root?: string;
+	cachePath?: string;
+	now?: number;
+	readLocalImpl?: (
+		root: string,
+		onProgress?: (files: number) => void,
+	) => Promise<LocalRead>;
+	accountImpl?: (root: string) => Promise<Account | null>;
+	fetchImpl?: typeof fetch;
+};
+export async function scan(options: ScanOptions): Promise<HarnessScan> {
+	const root = options.root ?? dataPath();
+	const now = options.now ?? Date.now();
+	const file = options.cachePath ?? cacheFile(root, storeRoot());
+	const local = await (options.readLocalImpl ?? readLocal)(
+		root,
+		options.onProgress,
+	);
+	const loaded = await loadCache(file);
+	let complete = local.complete && loaded.complete;
+	const ids = new Set(local.sessions.map((s) => s.session.id));
+	// Disappearing local history cannot prove a full replacement, even when usage is cached.
+	if (
+		[
+			...loaded.value.local,
+			...Object.values(loaded.value.windows).flatMap((w) => w.events),
+		].some((row) => row.tsMs >= options.sinceMs && !ids.has(row.session))
+	)
+		complete = false;
+	const account = await (options.accountImpl ?? existingAccount)(root);
+	const cache = await refreshAccount({
+		cache: loaded.value,
+		account,
+		sinceMs: options.sinceMs,
+		now,
+		sessionIds: ids,
+		fetchImpl: options.fetchImpl,
+	});
+	const api = cachedEvents(cache, ids);
+	const native = new Set<string>();
+	const contributions = local.sessions
+		.flatMap((s) => localContributions(s, api))
+		.filter((row) => {
+			if (!row.nativeId) return true;
+			if (native.has(row.nativeId)) return false;
+			native.add(row.nativeId);
+			return true;
+		});
+	const dated = new Set(contributions.map((row) => row.session));
+	if (
+		loaded.value.local.some(
+			(row) => row.tsMs >= options.sinceMs && !dated.has(row.session),
+		)
+	)
+		complete = false;
+	const previousDates = new Map<string, Set<string>>();
+	for (const row of [
+		...loaded.value.local,
+		...cachedEvents(loaded.value, ids),
+	]) {
+		const dates = previousDates.get(row.session) ?? new Set();
+		dates.add(utcDateOf(row.tsMs));
+		previousDates.set(row.session, dates);
+	}
+	if (complete) {
+		cache.local = contributions;
+		cache.sessions = [...ids].sort();
+		try {
+			await saveCache(file, cache);
+		} catch {
+			complete = false;
+		}
+	}
+	const aggregate = createAggregate();
+	const workflowLocal = createWorkflowLocalSources();
+	const workflow = createHarnessWorkflowReducer("cursor", workflowLocal);
+	const sessions = new Map(local.sessions.map((s) => [s.session.id, s]));
+	const sessionDates = previousDates;
+	for (const { session } of local.sessions) {
+		for (const message of session.messages)
+			if (message.model) {
+				const model = normalizeModel(message.model);
+				if (!aggregate.byModel.has(model))
+					aggregate.byModel.set(model, emptyUsage());
+			}
+		const project = session.canonicalWorkspacePath;
+		if (project && path.isAbsolute(project)) aggregate.projectDirs.add(project);
+		if (session.metadata?.cursorVersion)
+			aggregate.ccVersions.add(session.metadata.cursorVersion);
+		const times = messageTimes(session, api).filter(
+			(t): t is number => t !== null && t >= options.sinceMs && t <= now,
+		);
+		if (times.length) {
+			aggregate.sessions.add(session.id);
+			noteSessionStart(aggregate, session.id, Math.min(...times));
+		}
+	}
+	for (const contribution of reconcile(contributions, api)) {
+		const { tsMs, buckets, session, sidechain } = contribution;
+		const dates = sessionDates.get(session) ?? new Set();
+		dates.add(utcDateOf(tsMs));
+		sessionDates.set(session, dates);
+		if (tsMs < options.sinceMs || tsMs > now) continue;
+		const model = normalizeModel(contribution.model);
+		const counts: TokenCounts = {
+			input: buckets.input ?? 0,
+			output: buckets.output ?? 0,
+			cacheRead: buckets.cacheRead ?? 0,
+			cacheWrite5m: 0,
+			cacheWrite1h: 0,
+			cacheWriteUnsplit: buckets.cacheWrite ?? 0,
+		};
+		addModelUsage(
+			aggregate,
+			model,
+			counts,
+			apiEquivalentCost(model, counts, tsMs),
+			1,
+			{ tsMs, sidechain },
+		);
+		aggregate.records++;
+		aggregate.assistantRecords++;
+		aggregate.distinctResponses++;
+		aggregate.sessions.add(session);
+		aggregate.activeDays.add(utcDateOf(tsMs));
+		aggregate.firstTs = Math.min(aggregate.firstTs ?? tsMs, tsMs);
+		aggregate.lastTs = Math.max(aggregate.lastTs ?? tsMs, tsMs);
+		if (sidechain) aggregate.sidechainTokens += countsTotal(counts);
+		else aggregate.mainTokens += countsTotal(counts);
+		noteSessionStart(aggregate, session, tsMs);
+		const project = sessions.get(session)?.session.canonicalWorkspacePath;
+		if (project && path.isAbsolute(project))
+			noteProjectDay(aggregate, project, tsMs);
+	}
+	aggregate.files = local.stats.filesRead;
+	return {
+		aggregate,
+		stats: local.stats,
+		workflow: workflow.finish(),
+		workflowLocal,
+		scanComplete: complete,
+		sessionDates,
+	};
+}

--- a/packages/cli/src/harness/cursor/scan.ts
+++ b/packages/cli/src/harness/cursor/scan.ts
@@ -28,6 +28,7 @@ import {
 } from "./cache.js";
 import { localContributions, messageTimes, reconcile } from "./evidence.js";
 import { dataPath, type LocalRead, readLocal, storeRoot } from "./local.js";
+import { projectHistory } from "./workflow.js";
 
 export type ScanOptions = HarnessScanOptions & {
 	root?: string;
@@ -127,7 +128,17 @@ export async function scan(options: ScanOptions): Promise<HarnessScan> {
 			noteSessionStart(aggregate, session.id, Math.min(...times));
 		}
 	}
-	for (const contribution of reconcile(contributions, api)) {
+	const usage = reconcile(contributions, api);
+	projectHistory({
+		locals: local.sessions,
+		api,
+		usage,
+		aggregate,
+		workflow: options.publishWorkflow === false ? undefined : workflow,
+		sinceMs: options.sinceMs,
+		now,
+	});
+	for (const contribution of usage) {
 		const { tsMs, buckets, session, sidechain } = contribution;
 		const dates = sessionDates.get(session) ?? new Set();
 		dates.add(utcDateOf(tsMs));

--- a/packages/cli/src/harness/cursor/workflow.ts
+++ b/packages/cli/src/harness/cursor/workflow.ts
@@ -1,0 +1,199 @@
+import path from "node:path";
+import { normalizeModel } from "@aistack/pricing";
+import type { Message } from "cursor-history";
+import { detectMcpServers } from "../../mcp.js";
+import type { HarnessWorkflowReducer } from "../../workflow/reducer.js";
+import { type Aggregate, asStr, bump } from "../shared/aggregate.js";
+import {
+	type Contribution,
+	type LocalSession,
+	messageTimes,
+} from "./evidence.js";
+
+/** Native names stay in inventory; only the reducer sees these established equivalents. */
+const TOOLS: Record<string, string> = {
+	read_file: "Read",
+	read_file_v2: "Read",
+	list_dir: "Glob",
+	glob_file_search: "Glob",
+	grep: "Grep",
+	search: "Grep",
+	codebase_search: "Grep",
+	edit_file: "Edit",
+	edit_file_v2: "Edit",
+	search_replace: "Edit",
+	write: "Write",
+	write_file: "Write",
+	delete_file: "Edit",
+	run_terminal_cmd: "Bash",
+	run_terminal_command: "Bash",
+	execute_command: "Bash",
+	web_search: "WebSearch",
+	web_fetch: "WebFetch",
+	ask_question: "ask_question",
+	todo_write: "TodoWrite",
+	task: "Task",
+	skill: "Skill",
+};
+export const CURSOR_BUILTIN_TOOLS: ReadonlySet<string> = new Set(
+	Object.keys(TOOLS),
+);
+
+/** Project retained history without treating an accumulated turn as a Context call. */
+export function projectHistory(options: {
+	locals: LocalSession[];
+	api: Contribution[];
+	usage: Contribution[];
+	aggregate: Aggregate;
+	workflow?: HarnessWorkflowReducer;
+	sinceMs: number;
+	now: number;
+}): void {
+	const { locals, api, usage, aggregate, workflow, sinceMs, now } = options;
+	const nativeOwners = new Map<string, string>();
+	for (const { session } of locals)
+		for (const message of session.messages)
+			if (
+				message.id &&
+				message.identityOrigin === "composer-native" &&
+				!message.isSidechain &&
+				!nativeOwners.has(message.id)
+			)
+				nativeOwners.set(message.id, session.id);
+	const seenMessages = new Set<string>();
+	const seenTools = new Set<string>();
+	const configuredServers = new Map<string, string[]>();
+	const scopes = new Map<
+		string,
+		{ session: string; sidechain?: boolean; parentSession?: string }
+	>();
+	const inWindow = (t: number | null): t is number =>
+		t !== null && t >= sinceMs && t <= now;
+	for (const { session } of locals) {
+		const projectWorkspace =
+			session.canonicalWorkspacePath &&
+			path.isAbsolute(session.canonicalWorkspacePath)
+				? session.canonicalWorkspacePath
+				: undefined;
+		const times = messageTimes(session, api);
+		const scopeOf = (message: Message) => {
+			// A sidechain bit establishes routing. Only an actual parent reference establishes fan-out.
+			const parent =
+				message.parentMessageId && nativeOwners.get(message.parentMessageId);
+			return message.isSidechain
+				? {
+						session: `${session.id}:sidechain`,
+						sidechain: true,
+						...(parent ? { parentSession: parent } : {}),
+					}
+				: { session: session.id };
+		};
+		for (const [index, message] of session.messages.entries()) {
+			const identity =
+				message.identityOrigin === "composer-native" && message.id
+					? `native:${message.id}`
+					: `${session.id}:${message.id ?? index}`;
+			if (seenMessages.has(identity)) continue;
+			seenMessages.add(identity);
+			const tsMs = times[index];
+			const scope = scopeOf(message);
+			if (message.id) scopes.set(`${session.id}:${message.id}`, scope);
+			if (tsMs !== null && !inWindow(tsMs)) continue;
+			const common = { ...scope, projectWorkspace, tsMs: tsMs ?? 0 };
+			if (message.role === "user") {
+				if (inWindow(tsMs))
+					workflow?.ingest({
+						...common,
+						type: "response",
+						responseId: `anchor:${message.id ?? index}`,
+					});
+				continue;
+			}
+			let questionBack = false;
+			for (const [toolIndex, call] of (message.toolCalls ?? []).entries()) {
+				const id =
+					call.identityOrigin === "source-native" && call.id
+						? `native:${call.id}`
+						: `${identity}:${call.id ?? toolIndex}`;
+				if (seenTools.has(id)) continue;
+				seenTools.add(id);
+				bump(aggregate.toolCalls, call.name);
+				const tool = TOOLS[call.name] ?? call.name;
+				const arg =
+					asStr(call.params?.command) ??
+					asStr(call.params?.cmd) ??
+					asStr(call.params?.skill) ??
+					asStr(call.params?.subagent_type) ??
+					"";
+				if (tool === "WebSearch") aggregate.webSearchRequests++;
+				if (tool === "WebFetch") aggregate.webFetchRequests++;
+				if (tool === "Skill" && arg) bump(aggregate.skillCalls, arg);
+				if (tool === "Task") bump(aggregate.subagentCalls, arg || "(unknown)");
+				const mcp = /^mcp__(.+?)__(.+)$/.exec(call.name);
+				let server = mcp?.[1];
+				if (!server && call.name.startsWith("mcp_")) {
+					const directory = projectWorkspace ?? process.cwd();
+					let names = configuredServers.get(directory);
+					if (!names) {
+						names = detectMcpServers(directory)
+							.filter((r) => r.group === "cursor")
+							.map((r) => r.name)
+							.sort((a, b) => b.length - a.length);
+						configuredServers.set(directory, names);
+					}
+					server = names.find((name) => call.name.startsWith(`mcp_${name}_`));
+				}
+				if (server) {
+					bump(aggregate.mcpServerCalls, server);
+					bump(aggregate.mcpToolCalls, call.name);
+				}
+				questionBack ||= tool === "ask_question";
+				if (inWindow(tsMs))
+					workflow?.ingest({
+						...common,
+						type: "event",
+						tool,
+						arg,
+						batchId: id,
+					});
+			}
+			if (inWindow(tsMs))
+				workflow?.ingest({
+					...common,
+					type: "turn",
+					turnId: message.id ?? `assistant:${index}`,
+					questionBack,
+				});
+		}
+	}
+	if (!workflow) return;
+	const projects = new Map(
+		locals.map(({ session }) => [session.id, session.canonicalWorkspacePath]),
+	);
+	for (const [index, row] of usage.entries()) {
+		if (!inWindow(row.tsMs)) continue;
+		const project = projects.get(row.session);
+		const scope =
+			row.id && row.source === "local"
+				? scopes.get(`${row.session}:${row.id}`)
+				: undefined;
+		workflow.ingest({
+			...(scope ?? {
+				session: row.sidechain ? `${row.session}:sidechain` : row.session,
+				sidechain: row.sidechain,
+			}),
+			...(project && path.isAbsolute(project)
+				? { projectWorkspace: project }
+				: {}),
+			type: "response",
+			tsMs: row.tsMs,
+			responseId: `${row.source}:${row.id ?? index}`,
+			model: normalizeModel(row.model),
+			routingTokens:
+				(row.buckets.input ?? 0) +
+				(row.buckets.output ?? 0) +
+				(row.buckets.cacheRead ?? 0) +
+				(row.buckets.cacheWrite ?? 0),
+		});
+	}
+}

--- a/packages/cli/src/harness/detect.test.ts
+++ b/packages/cli/src/harness/detect.test.ts
@@ -29,6 +29,8 @@ const SINCE = detectionSinceMs(NOW);
 
 let dir: string;
 const savedEnv = {
+	CURSOR_DATA_PATH: process.env.CURSOR_DATA_PATH,
+	CURSOR_STORE_ROOT: process.env.CURSOR_STORE_ROOT,
 	CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
 	CODEX_HOME: process.env.CODEX_HOME,
 	GROK_HOME: process.env.GROK_HOME,
@@ -42,6 +44,8 @@ beforeEach(() => {
 	dir = mkdtempSync(join(tmpdir(), "aistack-detect-"));
 	// Point every harness at the temp dir so the machine running the tests
 	// never leaks its own installs into `detectedAdapters`.
+	process.env.CURSOR_DATA_PATH = join(dir, "cursor-workspaces");
+	process.env.CURSOR_STORE_ROOT = join(dir, "cursor-store");
 	process.env.XDG_DATA_HOME = join(dir, "xdg-data");
 	process.env.GROK_HOME = join(dir, "grok-home");
 	delete process.env.OPENCODE_DB;

--- a/packages/cli/src/harness/index.ts
+++ b/packages/cli/src/harness/index.ts
@@ -23,6 +23,7 @@
 
 import { CLAUDE_HARNESS_NAME, claudeAdapter } from "./claude/adapter.js";
 import { CODEX_HARNESS_NAME, codexAdapter } from "./codex/adapter.js";
+import { CURSOR_HARNESS_NAME, cursorAdapter } from "./cursor/adapter.js";
 import { GROK_HARNESS_NAME, grokAdapter } from "./grok/adapter.js";
 import { OPENCODE_HARNESS_NAME, opencodeAdapter } from "./opencode/adapter.js";
 import { PI_HARNESS_NAME, piAdapter } from "./pi/adapter.js";
@@ -62,6 +63,7 @@ export {
 } from "./claude/analyzer.js";
 export { type ScanOptions, scan, transcriptRoots } from "./claude/scan.js";
 export { CODEX_HARNESS_NAME, codexAdapter } from "./codex/adapter.js";
+export { CURSOR_HARNESS_NAME, cursorAdapter } from "./cursor/adapter.js";
 export { GROK_HARNESS_NAME, grokAdapter } from "./grok/adapter.js";
 export {
 	OPENCODE_BUILTIN_TOOLS,
@@ -140,6 +142,7 @@ export const HARNESS_ADAPTERS: readonly HarnessAdapter[] = [
 	claudeAdapter,
 	codexAdapter,
 	grokAdapter,
+	cursorAdapter,
 	opencodeAdapter,
 	piAdapter,
 ];
@@ -148,6 +151,7 @@ export const HARNESS_ADAPTERS: readonly HarnessAdapter[] = [
 export function harnessLabel(name: string): string {
 	if (name === CLAUDE_HARNESS_NAME) return "Claude Code";
 	if (name === CODEX_HARNESS_NAME) return "Codex";
+	if (name === CURSOR_HARNESS_NAME) return "Cursor";
 	if (name === GROK_HARNESS_NAME) return "Grok Build";
 	// opencode spells itself lowercase, so its discriminator IS the label -
 	// but it is an explicit row, so a rename cannot leak a raw slug.

--- a/packages/cli/src/harness/types.ts
+++ b/packages/cli/src/harness/types.ts
@@ -28,6 +28,8 @@ export type HarnessScan = {
 };
 
 export type HarnessScanOptions = {
+	/** Skip optional workflow extraction when the stack has disabled publication. */
+	publishWorkflow?: boolean;
 	/** Only count records with a timestamp at or after this epoch ms. */
 	sinceMs: number;
 	onProgress?: (files: number) => void;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -52,7 +52,7 @@ program
 	.description("Scan, preview, and publish measured usage (rolling 30 days)")
 	.option(
 		"--auto [state]",
-		"silent background sync; 'on' asks your stack for the permission and installs the SessionStart hooks, 'off' revokes both",
+		"silent background sync; 'on' asks your stack for the permission and installs harness hooks, 'off' revokes both",
 	)
 	.option(
 		"--every <hours>",

--- a/packages/cli/src/sync/stage.test.ts
+++ b/packages/cli/src/sync/stage.test.ts
@@ -425,3 +425,38 @@ describe("stageSync", () => {
 		expect(none.prices?.origin).toBe("bundled");
 	});
 });
+
+test("Cursor corrections rebuild a former date and incomplete reads withhold the machine day block", async () => {
+	let complete = true;
+	const adapter: HarnessAdapter = {
+		...FAKE_CLAUDE_ADAPTER,
+		name: "cursor",
+		async scan(options) {
+			return {
+				...(await FAKE_CLAUDE_ADAPTER.scan(options)),
+				scanComplete: complete,
+				sessionDates: new Map([
+					["synthetic-cursor-session", new Set(["2026-07-19", "2026-07-20"])],
+				]),
+			};
+		},
+	};
+	const input = deps({
+		baseUrl: "https://cursor-date-test.invalid",
+		adaptersImpl: async () => [adapter],
+		config: {
+			config: { ...FETCHED, publishWorkflow: false },
+			source: "fetched",
+		},
+	});
+	const staged = await stageSync(input);
+	expect(staged.body.measuredDays?.days.map((day) => day.date)).toContain(
+		"2026-07-19",
+	);
+	expect(
+		staged.body.measuredDays?.days.find((day) => day.date === "2026-07-19")
+			?.usage,
+	).toBeUndefined();
+	complete = false;
+	expect((await stageSync(input)).body.measuredDays).toBeUndefined();
+});

--- a/packages/cli/src/sync/stage.ts
+++ b/packages/cli/src/sync/stage.ts
@@ -243,7 +243,7 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 	const active = await adapters(sinceMs);
 	const historical = await adapters(daysSinceMs);
 	let dayScansComplete = true;
-	let grokCurrentDates: Map<string, Set<string>> | null = null;
+	const sessionDatesByHarness = new Map<string, Map<string, Set<string>>>();
 	for (const adapter of active) {
 		progress(`Scanning recent ${adapter.name} usage`);
 		const { aggregate, stats } = await adapter.scan({
@@ -274,8 +274,8 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 					progress(`Reading historical ${adapter.name} days · ${files} files`),
 			});
 		if (scanComplete === false) dayScansComplete = false;
-		if (adapter.name === "grok-build")
-			grokCurrentDates = sessionDates ?? new Map();
+		if (adapter.name === "grok-build" || adapter.name === "cursor")
+			sessionDatesByHarness.set(adapter.name, sessionDates ?? new Map());
 		workflowScans.push({ aggregate: workflow, local: workflowLocal });
 		usageScans.push(
 			buildUsageDays({
@@ -322,19 +322,29 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 	// against the manifest. Today always resends.
 	const correctionDates = new Set<string>();
 	let acknowledgePublish: (() => void) | undefined;
-	if (grokCurrentDates && token && config.stack) {
-		const scope = grokCacheScope(deps.baseUrl, config.stack.slug, token);
+	const acknowledgements: Array<() => void> = [];
+	for (const [harness, currentDates] of sessionDatesByHarness) {
+		if (!token || !config.stack) continue;
+		const scope = grokCacheScope(
+			harness === "grok-build" ? deps.baseUrl : `${deps.baseUrl}\0${harness}`,
+			config.stack.slug,
+			token,
+		);
 		const floor = utcDate(daysSinceMs);
 		const previous = loadGrokDateHints(scope);
-		const current = mapToHints(grokCurrentDates, floor);
+		const current = mapToHints(currentDates, floor);
 		for (const dates of Object.values(previous))
 			for (const date of dates) correctionDates.add(date);
 		for (const dates of Object.values(current))
 			for (const date of dates) correctionDates.add(date);
 		if (Object.keys(previous).some((id) => !(id in current)))
 			dayScansComplete = false;
-		acknowledgePublish = () => saveGrokDateHints(scope, current);
+		acknowledgements.push(() => saveGrokDateHints(scope, current));
 	}
+	if (acknowledgements.length)
+		acknowledgePublish = () => {
+			for (const acknowledge of acknowledgements) acknowledge();
+		};
 	const localDays: MeasuredDay[] = applyDayConsent(
 		buildMeasuredDays({
 			usage: mergeUsageDays(usageScans),

--- a/packages/cli/src/sync/stage.ts
+++ b/packages/cli/src/sync/stage.ts
@@ -248,6 +248,7 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 		progress(`Scanning recent ${adapter.name} usage`);
 		const { aggregate, stats } = await adapter.scan({
 			sinceMs,
+			publishWorkflow: false,
 			onProgress: (files) =>
 				progress(`Scanning recent ${adapter.name} usage · ${files} files`),
 		});
@@ -270,6 +271,7 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 		const { aggregate, workflow, workflowLocal, scanComplete, sessionDates } =
 			await adapter.scan({
 				sinceMs: daysSinceMs,
+				publishWorkflow: config.publishWorkflow,
 				onProgress: (files) =>
 					progress(`Reading historical ${adapter.name} days · ${files} files`),
 			});

--- a/packages/cli/src/sync/summary.test.ts
+++ b/packages/cli/src/sync/summary.test.ts
@@ -352,7 +352,7 @@ describe("beat one - the summary", () => {
 		const lines = summary.split("\n");
 		const toIdx = lines.findIndex((l) => l.startsWith("to        "));
 		expect(lines[toIdx + 1]).toBe(
-			"searched  claude code, codex, grok build, opencode, pi",
+			"searched  claude code, codex, grok build, cursor, opencode, pi",
 		);
 	});
 

--- a/packages/cli/src/workflow/reducer.ts
+++ b/packages/cli/src/workflow/reducer.ts
@@ -686,7 +686,8 @@ export function createHarnessWorkflowReducer(
 			const routesModels =
 				harness === "claude-code" ||
 				harness === "opencode" ||
-				harness === "grok-build";
+				harness === "grok-build" ||
+				harness === "cursor";
 
 			const asRows = (map: Map<string, number>) => {
 				const safe = new Map<string, number>();

--- a/packages/workflow-rules/src/phaseRules.ts
+++ b/packages/workflow-rules/src/phaseRules.ts
@@ -40,6 +40,7 @@ export const HANDOFF_MARKERS: Record<HarnessName, readonly string[]> = {
 		"mcp__curia__request_review",
 	],
 	codex: ["request_user_input"],
+	cursor: [],
 	"grok-build": ["ask_user_question", "request_user_input"],
 	opencode: ["question"],
 	"pi-mono": [],

--- a/packages/workflow-rules/src/phaseRules.ts
+++ b/packages/workflow-rules/src/phaseRules.ts
@@ -40,7 +40,7 @@ export const HANDOFF_MARKERS: Record<HarnessName, readonly string[]> = {
 		"mcp__curia__request_review",
 	],
 	codex: ["request_user_input"],
-	cursor: [],
+	cursor: ["ask_question"],
 	"grok-build": ["ask_user_question", "request_user_input"],
 	opencode: ["question"],
 	"pi-mono": [],

--- a/packages/workflow-rules/src/types.ts
+++ b/packages/workflow-rules/src/types.ts
@@ -9,6 +9,7 @@
 export type HarnessName =
 	| "claude-code"
 	| "codex"
+	| "cursor"
 	| "grok-build"
 	| "opencode"
 	| "pi-mono";
@@ -16,6 +17,7 @@ export type HarnessName =
 export const HARNESS_NAMES: readonly HarnessName[] = [
 	"claude-code",
 	"codex",
+	"cursor",
 	"grok-build",
 	"opencode",
 	"pi-mono",
@@ -31,6 +33,8 @@ export function harnessLabel(name: HarnessName): string {
 	switch (name) {
 		case "claude-code":
 			return "Claude Code";
+		case "cursor":
+			return "Cursor";
 		case "codex":
 			return "Codex";
 		case "grok-build":

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,6 +339,9 @@ importers:
       commander:
         specifier: ^13.1.0
         version: 13.1.0
+      cursor-history:
+        specifier: 0.18.0
+        version: 0.18.0
       ignore:
         specifier: ^7.0.0
         version: 7.0.5
@@ -5444,6 +5447,155 @@ packages:
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cursor-history@0.18.0:
+    resolution: {integrity: sha512-GbUABlmdzKi9smUxUVp+2SJv2bZIRdVtaRdPflw0zr4iay3GUPy5hzRDZ4pKpNhieauILzbQ5oDUPvfCHFT3vQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
+    hasBin: true
+
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  jszip@3.10.2:
+    resolution: {integrity: sha512-3l+rb15IOWtUhU0H5MFqES/T6Kh7abYwjosBey/vD6hDt8zoEffkSC5Ws5SGtgVw3gBx2NEbhTeSW1+kWkpyTQ==}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  node-abi@3.96.0:
+    resolution: {integrity: sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==}
+    engines: {node: '>=10'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+
 snapshots:
 
   '@acemir/cssom@0.9.30': {}
@@ -10477,3 +10629,175 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.3)
 
   zwitch@2.0.4: {}
+
+  better-sqlite3@12.11.1:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  chownr@1.1.4: {}
+
+  commander@14.0.3: {}
+
+  core-util-is@1.0.3: {}
+
+  cursor-history@0.18.0:
+    dependencies:
+      better-sqlite3: 12.11.1
+      commander: 14.0.3
+      jszip: 3.10.2
+      picocolors: 1.1.1
+
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  expand-template@2.0.3: {}
+
+  file-uri-to-path@1.0.0: {}
+
+  fs-constants@1.0.0: {}
+
+  github-from-package@0.0.0: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
+
+  isarray@1.0.0: {}
+
+  jszip@3.10.2:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
+  mimic-response@3.1.0: {}
+
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
+
+  napi-build-utils@2.0.0: {}
+
+  node-abi@3.96.0:
+    dependencies:
+      semver: 7.7.3
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.96.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.5
+      tunnel-agent: 0.6.0
+
+  process-nextick-args@2.0.1: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  safe-buffer@5.1.2: {}
+
+  safe-buffer@5.2.1: {}
+
+  setimmediate@1.0.5: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-json-comments@2.0.1: {}
+
+  tar-fs@2.1.5:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  util-deprecate@1.0.2: {}
+
+  wrappy@1.0.2: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - "packages/*"
 
 allowBuilds:
+  better-sqlite3: false
   core-js: false
   esbuild: false
   sharp: false

--- a/scripts/verify-cursor-package.mjs
+++ b/scripts/verify-cursor-package.mjs
@@ -1,0 +1,59 @@
+// Exercise the actual built CLI's read-only MCP preview with synthetic sources.
+// The loader redirects os.homedir() only inside this child. No owner config,
+// native credential, external request, interactive sync or publish is involved.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const repo = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const temporary = await mkdtemp(path.join(tmpdir(), 'cursor-package-'));
+try {
+  const root = path.join(temporary, 'Cursor', 'User', 'workspaceStorage');
+  const workspace = path.join(root, 'synthetic');
+  const global = path.join(temporary, 'Cursor', 'User', 'globalStorage');
+  await mkdir(workspace, {recursive: true});
+  await mkdir(global, {recursive: true});
+  const project = path.join(temporary, 'project');
+  await writeFile(path.join(workspace, 'workspace.json'), JSON.stringify({folder: pathToFileURL(project).href}));
+  const rows = JSON.parse(await readFile(path.join(repo, 'packages/cli/src/harness/cursor/fixtures/composer-rows.json'), 'utf8'));
+  const db = new DatabaseSync(path.join(global, 'state.vscdb'));
+  const wdb = new DatabaseSync(path.join(workspace, 'state.vscdb'));
+  db.exec('CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT); CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)');
+  wdb.exec('CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)');
+  for (const row of rows) {
+    if (row.value.createdAt) row.value.createdAt = Date.now() - 10_000;
+    if (row.value.timingInfo) {
+      row.value.timingInfo = {clientRpcSendTime: Date.now()-5000, clientStartTime: Date.now()-5000, clientEndTime: Date.now()-4000};
+      row.value.tokenCount = {inputTokens: 100, outputTokens: 20};
+    }
+    (row.table === 'cursorDiskKV' ? db : wdb).prepare(`INSERT INTO ${row.table} VALUES (?, ?)`).run(row.key, JSON.stringify(row.value));
+  }
+  db.close(); wdb.close();
+  const shim = path.join(temporary, 'os.mjs');
+  const loader = path.join(temporary, 'loader.mjs');
+  const preload = path.join(temporary, 'preload.mjs');
+  await writeFile(shim, `export * from 'node:os'; import * as os from 'node:os'; export const homedir = () => ${JSON.stringify(temporary)}; export default {...os, homedir};`);
+  await writeFile(loader, `const shim = ${JSON.stringify(pathToFileURL(shim).href)}; export async function resolve(specifier, context, next) { if ((specifier === 'node:os' || specifier === 'os') && context.parentURL !== shim) return {url: shim, shortCircuit: true}; return next(specifier, context); }`);
+  await writeFile(preload, `globalThis.fetch = async () => { throw new Error('offline synthetic preview'); };`);
+  const output = execFileSync(process.execPath, ['--experimental-loader', pathToFileURL(loader).href, '--import', pathToFileURL(preload).href, path.join(repo, 'packages/cli/dist/index.js'), 'mcp'], {
+    cwd: temporary,
+    env: {PATH: process.env.PATH, CURSOR_DATA_PATH: root, CURSOR_STORE_ROOT: path.join(temporary, 'store'), AISTACK_URL: 'http://127.0.0.1:1'},
+    input: JSON.stringify({jsonrpc: '2.0', id: 1, method: 'tools/call', params: {name: 'sync_preview'}})+'\n',
+    encoding: 'utf8', timeout: 30_000, stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  assert.match(output, /not linked|not authenticated/i);
+  const cacheDir = path.join(temporary, '.config', 'aistack', 'cursor');
+  const files = (await readdir(cacheDir)).filter(file => file.endsWith('.json'));
+  assert.equal(files.length, 1);
+  const cache = JSON.parse(await readFile(path.join(cacheDir, files[0]), 'utf8'));
+  assert.equal(cache.local.length, 1);
+  assert.equal(cache.local[0].buckets.input, 100);
+  assert.equal(cache.local[0].buckets.output, 20);
+  console.log(`Cursor packaged CLI preview passed on Node ${process.versions.node}`);
+} finally {
+  await rm(temporary, {recursive: true, force: true});
+}

--- a/src/features/activity/__tests__/feed.test.ts
+++ b/src/features/activity/__tests__/feed.test.ts
@@ -59,6 +59,7 @@ describe("a sync row", () => {
 		expect(harnessList(["claude-code"])).toBe("Claude Code");
 		expect(harnessList(["grok-build"])).toBe("Grok Build");
 		expect(harnessList(["claude-code", "codex"])).toBe("Claude Code + Codex");
-		expect(harnessList(["cursor"])).toBe("cursor");
+		expect(harnessList(["cursor"])).toBe("Cursor");
+		expect(harnessList(["future-harness"])).toBe("future-harness");
 	});
 });

--- a/src/features/activity/feed.ts
+++ b/src/features/activity/feed.ts
@@ -62,6 +62,7 @@ export function dayBucket(at: number, now: number): string {
 const HARNESS_LABELS: Record<string, string> = {
 	"claude-code": "Claude Code",
 	codex: "Codex",
+	cursor: "Cursor",
 	"grok-build": "Grok Build",
 	// Lowercase brands: the wire name is the label, but each is an explicit
 	// row so a rename cannot silently leak a raw slug (#130).

--- a/src/features/leaderboard/__tests__/leaderboard-page.test.tsx
+++ b/src/features/leaderboard/__tests__/leaderboard-page.test.tsx
@@ -22,6 +22,7 @@ function setup(b = board()) {
 describe("the trend", () => {
 	it("names Grok Build", () => {
 		expect(harnessLabel("grok-build")).toBe("Grok Build");
+		expect(harnessLabel("cursor")).toBe("Cursor");
 	});
 	it("is null below two readings - one dot is not a trend", () => {
 		expect(trendOf([{ at: 1, tokens: 100 }])).toBeNull();

--- a/src/features/leaderboard/board.ts
+++ b/src/features/leaderboard/board.ts
@@ -46,6 +46,7 @@ export function trendWords(
 const HARNESS_LABELS: Record<string, string> = {
 	"claude-code": "Claude Code",
 	codex: "Codex",
+	cursor: "Cursor",
 	"grok-build": "Grok Build",
 	// Lowercase brands: the wire name is the label, but each is an explicit
 	// row so a rename cannot silently leak a raw slug (#130).

--- a/src/features/usage/HarnessShareRows.tsx
+++ b/src/features/usage/HarnessShareRows.tsx
@@ -10,6 +10,7 @@ export const SOURCE_PAINTS = [
 export const HARNESS_LABELS: Record<string, string> = {
 	"claude-code": "Claude Code",
 	codex: "Codex",
+	cursor: "Cursor",
 	"grok-build": "Grok Build",
 	opencode: "opencode",
 	"pi-mono": "Pi",

--- a/src/features/usage/__tests__/harness-label.test.ts
+++ b/src/features/usage/__tests__/harness-label.test.ts
@@ -4,5 +4,6 @@ import { harnessLabel } from "../HarnessShareRows";
 describe("usage harness labels", () => {
 	it("names Grok Build", () => {
 		expect(harnessLabel("grok-build")).toBe("Grok Build");
+		expect(harnessLabel("cursor")).toBe("Cursor");
 	});
 });

--- a/src/features/workflow/__tests__/harness-label.test.ts
+++ b/src/features/workflow/__tests__/harness-label.test.ts
@@ -4,5 +4,6 @@ import { harnessLabelOf } from "../copy";
 describe("workflow harness labels", () => {
 	it("names Grok Build", () => {
 		expect(harnessLabelOf("grok-build")).toBe("Grok Build");
+		expect(harnessLabelOf("cursor")).toBe("Cursor");
 	});
 });

--- a/src/features/workflow/copy.ts
+++ b/src/features/workflow/copy.ts
@@ -153,6 +153,7 @@ export function fmtRowValue(row: Pick<WorkflowRow, "unit" | "value">): string {
 export const HARNESS_LABELS: Record<string, string> = {
 	"claude-code": "Claude Code",
 	codex: "Codex",
+	cursor: "Cursor",
 	"grok-build": "Grok Build",
 	opencode: "opencode",
 	"pi-mono": "Pi",


### PR DESCRIPTION
Cursor history now flows through normal sync, pricing, measured statistics, workflow metrics and machine inventory. Existing-login enrichment joins retained conversations, preserves complete days on source failures, and uses the shared pricing and consent rules. Automatic sync uses Cursor's user-level stop hook and the existing opt-in, throttle and removal lifecycle.

Validation: 880 integrated tests passed, CLI typecheck/build and production web build passed, and the production CLI bundle passed an isolated synthetic SQLite/MCP preview on Node 22.13 and 24.15. Reviewed the release diff against current main; no integration drift or migration is required. The owner approved release with native manual sync, account-login reuse and native hooks deferred to post-release validation; their status remains UNRUN in the validation report.

Backend deployment must succeed before merging the Release Please CLI release PR. Release tracking: https://github.com/alp82/aistack/issues/394
