### PR TITLE
feat(cli): collect Grok context maps from retained inference logs

### DIFF
--- a/convex/lib/workflow.ts
+++ b/convex/lib/workflow.ts
@@ -97,12 +97,15 @@ export function contextReadingsOf(
 	const readings: ContextReading[] = []
 	for (const harness of section.harnesses) {
 		const context = harness.context
-		if (!context) continue
+		if (!context || !context.calls.main.some((row) => row.calls > 0)) continue
 		let window: number | null = context.window ?? null
 		if (window === null) {
 			const model = topModelOf(harness, rows)
 			const known = model === null ? null : contextWindowOf(catalog, model)
-			window = inferContextWindow(known, context.maxContext)
+			// Claude tiers cannot establish the window of a Grok model.
+			window = harness.harness === 'grok-build'
+				? (known !== null && known >= context.maxContext ? known : null)
+				: inferContextWindow(known, context.maxContext)
 		}
 		readings.push(readContextReading(harness.harness, context, window))
 	}

--- a/convex/workflow.test.ts
+++ b/convex/workflow.test.ts
@@ -705,6 +705,48 @@ describe('the Context reading (#358)', () => {
     expect(over?.context?.harnesses[0]?.window).toBe(1_000_000)
   })
 
+  test('Grok uses its catalog window without inventing Claude tiers and discloses retained coverage', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, slug } = await seedStack(t)
+    const harness: Harness = {
+      ...(day().harnesses[0] as Harness),
+      harness: 'grok-build',
+      routing: { main: [{ model: 'grok-4.6-build', tokens: 100 }], subagents: [] },
+      context: context({ firstCallCount: 0, firstCallHarnessTokens: 0, firstCallInstructionsTokens: 0 }),
+    }
+    await publish(t, stackId, {
+      machine: 'laptop',
+      workflow: wire([day({ harnesses: [harness] })], { aggregateVersion: 'workflow-aggregates/v3' }),
+    })
+    const read = () => t.query(api.workflow.getWorkflowByStackSlug, { slug })
+    expect((await read())?.context?.harnesses[0]).toMatchObject({
+      harness: 'grok-build', window: null, retainedCallsOnly: true, breakdownAvailable: false,
+    })
+    await seedModel(t, 'grok-4.6-build', 256_000)
+    expect((await read())?.context?.harnesses[0]?.window).toBe(256_000)
+    await publish(t, stackId, {
+      machine: 'laptop',
+      workflow: wire([day({ harnesses: [{ ...harness, context: context({ maxContext: 300_000 }) }] })], { aggregateVersion: 'workflow-aggregates/v3' }),
+    })
+    expect((await read())?.context?.harnesses[0]?.window).toBeNull()
+    await t.run(async (ctx) => ctx.db.patch(stackId, { publishWorkflow: false }))
+    expect(await read()).toBeNull()
+  })
+
+  test('compaction-only Grok evidence cannot fabricate a zero-call map', async () => {
+    const t = convexTest(schema, modules)
+    const { stackId, slug } = await seedStack(t)
+    const harness: Harness = {
+      ...(day().harnesses[0] as Harness), harness: 'grok-build',
+      context: context({ calls: { main: [], subagents: [] } }),
+    }
+    await publish(t, stackId, {
+      machine: 'laptop',
+      workflow: wire([day({ harnesses: [harness] })], { aggregateVersion: 'workflow-aggregates/v3' }),
+    })
+    expect((await t.query(api.workflow.getWorkflowByStackSlug, { slug }))?.context).toBeNull()
+  })
+
   test('the workflow switch off hides the reading with the rest', async () => {
     const t = convexTest(schema, modules)
     const { stackId, slug } = await seedStack(t)

--- a/convex/workflow.ts
+++ b/convex/workflow.ts
@@ -190,6 +190,8 @@ const ContextHarness = v.object({
 	/** `max(0, p90Call - harnessTokens - instructionsTokens)`. */
 	longChat: v.number(),
 	compactions: v.number(),
+	breakdownAvailable: v.optional(v.boolean()),
+	retainedCallsOnly: v.optional(v.boolean()),
 })
 
 const WorkflowView = v.object({

--- a/docs/grok-context.md
+++ b/docs/grok-context.md
@@ -1,0 +1,49 @@
+# Grok context measurements
+
+The CLI reads `shell.turn.inference_done` entries from
+`$GROK_HOME/logs/unified.jsonl` (default `~/.grok/logs/unified.jsonl`). Each
+entry reports one inference's `prompt_tokens`, including its cached tokens.
+Turn totals in `usage.json` still own usage and cost accounting.
+
+This source supplements the historical adapter. The earlier Grok investigation
+correctly identified that `ResponseCompleted` notifications are not persisted,
+but missed the separate numeric inference log.
+
+Only entries for discovered local sessions are collected. AI Stack retains a
+numeric projection under `~/.config/aistack/grok-context/<root-hash>/`, in dated
+append files: a deduplication ID, session ID, timestamp, and prompt token count.
+No log text, prompts, URLs, or response content is copied into this cache or
+published. Duplicate entries fold once. Captures expire after 400 days; scanning
+a shorter display window does not shorten that retention. Cache read/write
+failures defer measured-day publication through the existing incomplete-scan gate.
+
+Grok trims its unified log at 5 MiB. The page therefore labels these as retained
+calls and says some calls may be missing. Calls that rotated out before an AI
+Stack scan cannot be recovered. Removing the local AI Stack cache also removes
+its retained history. This is a sample of recorded calls, not proof of complete
+session coverage.
+
+The log does not establish a first-call harness/instructions split. The map shows
+the median and p90 total call sizes and labels the split unavailable. Its window
+comes from the measured model's catalog row. If no catalog window is known, or
+a call exceeds that window, the page shows the numeric reading without a grid.
+Grok never inherits Claude Code's window tiers. The existing `publishWorkflow`
+gate continues to control publication and public reads.
+
+Deploy the backend and web changes before releasing the CLI. After updating the
+CLI, the owner runs an ordinary sync. No new hook, launcher, API credential,
+upstream patch, or schema migration is required. The map needs at least one
+retained main-session inference entry; older Grok versions without that log
+entry still show no reading.
+
+## Evidence
+
+Verified against xAI's source revision
+`37949780c144e37df692e3d669051a21fec24f20`:
+
+- [Per-call inference log producer](https://github.com/xai-org/grok-build/blob/37949780c144e37df692e3d669051a21fec24f20/crates/codegen/xai-grok-shell/src/session/acp_session_impl/turn.rs#L3140).
+- [Local log envelope, path, and rotation](https://github.com/xai-org/grok-build/blob/37949780c144e37df692e3d669051a21fec24f20/crates/codegen/xai-grok-telemetry/src/unified_log.rs).
+
+Validation uses source-shaped log fixtures through the real scanner and reducer,
+backend query tests, and the rendered context component. A live Grok sync with
+the updated CLI remains an owner-run release check.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -103,3 +103,5 @@ node packages/cli/dist/index.js sync
 ```
 
 Set `AISTACK_URL=http://localhost:3019` to test against local dev server.
+
+Grok Build's context map uses per-call measurements retained from its local diagnostic log. Some calls may be missing because Grok rotates that log. AI Stack preserves the numeric measurements it has captured for 400 days. The map shows total call sizes; Grok's harness/instructions breakdown is unavailable. An ordinary sync collects these measurements when the log contains them.

--- a/packages/cli/src/harness/grok/context.test.ts
+++ b/packages/cli/src/harness/grok/context.test.ts
@@ -1,0 +1,115 @@
+import { mkdir, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import { contextCall, retainedContextCalls } from "./context.js";
+
+const now = Date.parse("2026-09-10T12:00:00Z");
+const entry = (ctx: Record<string, unknown> = {}) => ({
+	ts: "2026-09-10T10:00:00Z",
+	src: "shell",
+	pid: 12,
+	sid: "session",
+	msg: "shell.turn.inference_done",
+	ctx: {
+		loop_index: 0,
+		prompt_tokens: 40000,
+		cached_prompt_tokens: 10000,
+		...ctx,
+	},
+});
+async function fixture() {
+	const home = await mkdtemp(path.join(tmpdir(), "grok-context-log-"));
+	await mkdir(path.join(home, "logs"));
+	return {
+		root: path.join(home, "sessions"),
+		cache: path.join(home, "cache"),
+		log: path.join(home, "logs", "unified.jsonl"),
+	};
+}
+
+describe("Grok numeric context capture", () => {
+	test("uses total prompt tokens without adding the cached subset again", () => {
+		expect(contextCall(entry())?.tokens).toBe(40000);
+		expect(contextCall(entry({ prompt_tokens: 0 }))?.tokens).toBe(0);
+		for (const prompt_tokens of [
+			undefined,
+			null,
+			"40000",
+			-1,
+			1.5,
+			Infinity,
+			Number.MAX_SAFE_INTEGER + 1,
+		]) {
+			expect(contextCall(entry({ prompt_tokens }))).toBeNull();
+		}
+		expect(contextCall({ ...entry(), ts: "invalid" })).toBeNull();
+		expect(contextCall({ ...entry(), src: "grok-pager" })).toBeNull();
+		expect(contextCall({ ...entry(), msg: "other" })).toBeNull();
+	});
+
+	test("retains only numeric projections for known sessions and deduplicates overlapping captures", async () => {
+		const f = await fixture();
+		const sessions = new Set(["session"]);
+		const raw = JSON.stringify(
+			entry({ secret: "private conversation", url: "https://private.example" }),
+		);
+		await writeFile(
+			f.log,
+			`${raw}\n${raw}\n${JSON.stringify({ ...entry(), sid: "unknown" })}\n`,
+		);
+		const first = await retainedContextCalls(f.root, sessions, f.cache, now);
+		expect(first).toHaveLength(1);
+		await retainedContextCalls(f.root, sessions, f.cache, now);
+		expect(await readdir(f.cache)).toEqual(["2026-09-10.jsonl"]);
+		const cache = await readFile(
+			path.join(f.cache, "2026-09-10.jsonl"),
+			"utf8",
+		);
+		expect(cache.trim().split("\n")).toHaveLength(1);
+		expect(Object.keys(JSON.parse(cache))).toEqual([
+			"id",
+			"session",
+			"tsMs",
+			"tokens",
+		]);
+		expect(cache).not.toContain("private");
+		await writeFile(f.log, "");
+		expect(await retainedContextCalls(f.root, sessions, f.cache, now)).toEqual(
+			first,
+		);
+	});
+
+	test("ignores unfinished live log lines, but rejects damaged retained data", async () => {
+		const f = await fixture();
+		const sessions = new Set(["session"]);
+		await writeFile(f.log, `${JSON.stringify(entry())}\n{"unfinished":`);
+		expect(
+			await retainedContextCalls(f.root, sessions, f.cache, now),
+		).toHaveLength(1);
+		await writeFile(path.join(f.cache, "2026-09-10.jsonl"), '{"unfinished":');
+		await expect(
+			retainedContextCalls(f.root, sessions, f.cache, now),
+		).rejects.toThrow("Incomplete Grok context cache");
+	});
+
+	test("expires captured calls after 400 days, and missing logs need no cache", async () => {
+		const f = await fixture();
+		const sessions = new Set(["session"]);
+		expect(await retainedContextCalls(f.root, sessions, f.cache, now)).toEqual(
+			[],
+		);
+		await expect(readdir(f.cache)).rejects.toMatchObject({ code: "ENOENT" });
+		await writeFile(f.log, `${JSON.stringify(entry())}\n`);
+		await retainedContextCalls(f.root, sessions, f.cache, now);
+		expect(
+			await retainedContextCalls(
+				f.root,
+				sessions,
+				f.cache,
+				now + 401 * 86400000,
+			),
+		).toEqual([]);
+		expect(await readdir(f.cache)).toEqual([]);
+	});
+});

--- a/packages/cli/src/harness/grok/context.ts
+++ b/packages/cli/src/harness/grok/context.ts
@@ -1,0 +1,164 @@
+import { createHash } from "node:crypto";
+import { appendFile, mkdir, readdir, readFile, unlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import { asObj, asStr } from "../shared/aggregate.js";
+
+const DAY_MS = 86_400_000;
+const hash = (value: string) =>
+	createHash("sha256").update(value).digest("hex");
+
+export type ContextCall = {
+	id: string;
+	session: string;
+	tsMs: number;
+	tokens: number;
+};
+
+/** Numeric projection of Grok's local inference log. Prompt tokens include caches. */
+export function contextCall(value: unknown): ContextCall | null {
+	const row = asObj(value);
+	if (row?.src !== "shell" || row.msg !== "shell.turn.inference_done")
+		return null;
+	const session = asStr(row.sid);
+	const ts = asStr(row.ts);
+	const ctx = asObj(row.ctx);
+	const tokens = ctx?.prompt_tokens;
+	const loop = ctx?.loop_index;
+	const tsMs = ts ? Date.parse(ts) : NaN;
+	if (
+		!session ||
+		!Number.isFinite(tsMs) ||
+		typeof tokens !== "number" ||
+		!Number.isSafeInteger(tokens) ||
+		tokens < 0 ||
+		typeof loop !== "number" ||
+		!Number.isSafeInteger(loop) ||
+		loop < 0
+	)
+		return null;
+	return {
+		id: hash(JSON.stringify([session, tsMs, row.pid ?? null, loop, tokens])),
+		session,
+		tsMs,
+		tokens,
+	};
+}
+
+export function contextCacheDirectory(root: string): string {
+	return path.join(
+		homedir(),
+		".config",
+		"aistack",
+		"grok-context",
+		hash(path.resolve(root)),
+	);
+}
+
+async function optionalRead(file: string): Promise<string> {
+	try {
+		return await readFile(file, "utf8");
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return "";
+		throw error;
+	}
+}
+
+/**
+ * Preserve only observed numeric calls, never raw log lines. Daily append files
+ * tolerate concurrent readers appending the same call: the id deduplicates it.
+ * Retention is independent of the requested display window. A short scan must
+ * not erase calls that the next full sync needs after Grok rotates its log.
+ */
+export async function retainedContextCalls(
+	root: string,
+	sessions: ReadonlySet<string>,
+	cacheDir = contextCacheDirectory(root),
+	now = Date.now(),
+): Promise<ContextCall[]> {
+	const cutoff = now - 400 * DAY_MS;
+	const calls = new Map<string, ContextCall>();
+	let files: string[] = [];
+	try {
+		files = await readdir(cacheDir);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+	for (const file of files) {
+		if (!/^\d{4}-\d{2}-\d{2}\.jsonl$/.test(file)) continue;
+		if (Date.parse(file.slice(0, 10)) + DAY_MS < cutoff) {
+			await unlink(path.join(cacheDir, file)).catch(
+				(error: NodeJS.ErrnoException) => {
+					if (error.code !== "ENOENT") throw error;
+				},
+			);
+			continue;
+		}
+		const raw = await optionalRead(path.join(cacheDir, file));
+		// A partial cache write cannot silently replace a previously published day.
+		if (raw && !raw.endsWith("\n"))
+			throw new Error("Incomplete Grok context cache");
+		for (const line of raw.split("\n").filter(Boolean)) {
+			const call = asObj(JSON.parse(line));
+			if (
+				!call ||
+				typeof call.id !== "string" ||
+				!/^[a-f0-9]{64}$/.test(call.id) ||
+				typeof call.session !== "string" ||
+				typeof call.tsMs !== "number" ||
+				!Number.isFinite(call.tsMs) ||
+				typeof call.tokens !== "number" ||
+				!Number.isSafeInteger(call.tokens) ||
+				call.tokens < 0
+			)
+				throw new Error("Invalid Grok context cache");
+			if (call.tsMs >= cutoff && call.tsMs <= now)
+				calls.set(call.id, {
+					id: call.id,
+					session: call.session,
+					tsMs: call.tsMs,
+					tokens: call.tokens,
+				});
+		}
+	}
+	const raw = await optionalRead(
+		path.join(root, "..", "logs", "unified.jsonl"),
+	);
+	const additions = new Map<string, string[]>();
+	// Grok can be appending a line while we read. Pick it up on the next sync.
+	for (const line of raw.slice(0, raw.lastIndexOf("\n") + 1).split("\n")) {
+		let value: unknown;
+		try {
+			value = JSON.parse(line);
+		} catch {
+			continue;
+		}
+		const call = contextCall(value);
+		if (
+			!call ||
+			!sessions.has(call.session) ||
+			call.tsMs < cutoff ||
+			call.tsMs > now ||
+			calls.has(call.id)
+		)
+			continue;
+		calls.set(call.id, call);
+		const date = new Date(call.tsMs).toISOString().slice(0, 10);
+		const lines = additions.get(date) ?? [];
+		lines.push(JSON.stringify(call));
+		additions.set(date, lines);
+	}
+	if (additions.size) {
+		await mkdir(cacheDir, { recursive: true, mode: 0o700 });
+		for (const [date, lines] of additions) {
+			await appendFile(
+				path.join(cacheDir, `${date}.jsonl`),
+				`${lines.join("\n")}\n`,
+				{ mode: 0o600 },
+			);
+		}
+	}
+	return [...calls.values()]
+		.filter((call) => sessions.has(call.session))
+		.sort((a, b) => a.tsMs - b.tsMs || a.id.localeCompare(b.id));
+}

--- a/packages/cli/src/harness/grok/scan.test.ts
+++ b/packages/cli/src/harness/grok/scan.test.ts
@@ -170,3 +170,92 @@ describe("Grok Build scanner", () => {
 		);
 	});
 });
+
+describe("Grok retained per-call context", () => {
+	test("reads individual inference calls, preserves them after log rotation, and leaves usage totals alone", async () => {
+		const home = await mkdtemp(path.join(tmpdir(), "grok-context-"));
+		const root = path.join(home, "sessions");
+		const session = path.join(root, "workspace", "s");
+		await mkdir(session, { recursive: true });
+		await mkdir(path.join(home, "logs"));
+		const ts = new Date().toISOString();
+		await writeFile(
+			path.join(session, "summary.json"),
+			JSON.stringify({ sessionId: "s", cwd: "/private/project" }),
+		);
+		await writeFile(
+			path.join(session, "usage.json"),
+			JSON.stringify({
+				sessionId: "s",
+				turns: [
+					{
+						endedAt: ts,
+						primaryModelId: "grok-4.6-build",
+						inputTokens: 120000,
+						outputTokens: 100,
+					},
+				],
+			}),
+		);
+		const log = (tokens: number, loop: number, sid = "s") =>
+			JSON.stringify({
+				ts,
+				src: "shell",
+				pid: 42,
+				sid,
+				msg: "shell.turn.inference_done",
+				ctx: {
+					loop_index: loop,
+					prompt_tokens: tokens,
+					cached_prompt_tokens: 10000,
+					completion_tokens: 50,
+					private_extra: "never retain me",
+				},
+			});
+		await writeFile(
+			path.join(home, "logs", "unified.jsonl"),
+			[log(40000, 0), log(80000, 1), log(999999, 2, "unknown")].join("\n") +
+				"\n",
+		);
+		const first = createAggregate();
+		expect(
+			(
+				await scan(first, {
+					roots: [root],
+					contextCacheDir: path.join(home, "cache"),
+				})
+			).complete,
+		).toBe(true);
+		const context = first.workflow.finish().days[0]?.context;
+		expect(context?.calls.main.reduce((sum, row) => sum + row.calls, 0)).toBe(
+			2,
+		);
+		expect(context?.maxContext).toBe(80000);
+		expect(context?.firstCallCount).toBe(0);
+		expect(first.byModel.get("grok-4.6-build")?.input).toBe(120000);
+		await writeFile(
+			path.join(home, "logs", "unified.jsonl"),
+			`${log(80000, 1)}\n`,
+		);
+		const second = createAggregate();
+		expect(
+			(
+				await scan(second, {
+					roots: [root],
+					contextCacheDir: path.join(home, "cache"),
+				})
+			).complete,
+		).toBe(true);
+		expect(second.workflow.finish().days[0]?.context).toEqual(context);
+		await writeFile(
+			path.join(home, "cache", `${ts.slice(0, 10)}.jsonl`),
+			'{"partial":',
+		);
+		const damaged = await scan(createAggregate(), {
+			roots: [root],
+			contextCacheDir: path.join(home, "cache"),
+		});
+		expect(damaged.complete).toBe(false);
+		expect(damaged.stats.filesUnreadable).toBeGreaterThan(0);
+	});
+});

--- a/packages/cli/src/harness/grok/scan.ts
+++ b/packages/cli/src/harness/grok/scan.ts
@@ -16,6 +16,7 @@ import {
 	terminalContribution,
 	type UsageContribution,
 } from "./analyzer.js";
+import { retainedContextCalls } from "./context.js";
 
 export function sessionRoots(): string[] {
 	return [
@@ -122,6 +123,7 @@ export async function scan(
 		sinceMs?: number;
 		roots?: string[];
 		onProgress?: (files: number) => void;
+		contextCacheDir?: string;
 	} = {},
 ): Promise<{
 	stats: ScanStats;
@@ -137,6 +139,10 @@ export async function scan(
 	let complete = true;
 	for (const root of opts.roots ?? sessionRoots()) {
 		const aliases = await modelAliasesForRoot(root);
+		const contextSessions = new Map<
+			string,
+			{ projectDir: string; parentSession?: string }
+		>();
 		const dirs = await directories(root);
 		if (dirs === null) {
 			complete = false;
@@ -183,6 +189,7 @@ export async function scan(
 					undefined;
 				child = parentSession !== undefined;
 			}
+			contextSessions.set(sessionFallback, { projectDir, parentSession });
 			let rows = [] as ReturnType<typeof sidecarContributions>;
 			let precedence = 0;
 			const usage = files.get("usage.json");
@@ -196,7 +203,11 @@ export async function scan(
 				}
 				stats.filesRead++;
 				rows = sidecarContributions(read.json, projectDir);
-				if (rows.length > 0) precedence = 2;
+				if (rows.length > 0) {
+					precedence = 2;
+					for (const row of rows)
+						contextSessions.set(row.sessionId, { projectDir, parentSession });
+				}
 			}
 			if (child) {
 				rows = [];
@@ -275,6 +286,32 @@ export async function scan(
 					candidates.set(sessionId, { precedence, rows });
 			}
 			opts.onProgress?.(stats.filesFound);
+		}
+		try {
+			const calls = await retainedContextCalls(
+				root,
+				new Set(contextSessions.keys()),
+				opts.contextCacheDir,
+			);
+			for (const call of calls) {
+				if (opts.sinceMs !== undefined && call.tsMs < opts.sinceMs) continue;
+				const source = contextSessions.get(call.session);
+				agg.workflow.ingest({
+					type: "response",
+					session: call.session,
+					projectWorkspace: source?.projectDir,
+					parentSession: source?.parentSession,
+					tsMs: call.tsMs,
+					responseId: `context:${call.id}`,
+					contextTokens: call.tokens,
+				});
+				const dates = sessionDates.get(call.session) ?? new Set<string>();
+				dates.add(new Date(call.tsMs).toISOString().slice(0, 10));
+				sessionDates.set(call.session, dates);
+			}
+		} catch {
+			complete = false;
+			stats.filesUnreadable++;
 		}
 	}
 	for (const { rows } of candidates.values()) {

--- a/packages/workflow-rules/src/context.test.ts
+++ b/packages/workflow-rules/src/context.test.ts
@@ -94,3 +94,17 @@ describe("readContextReading", () => {
 		});
 	});
 });
+
+test("Grok calls disclose partial log coverage and an unavailable first-call split", () => {
+	const reading = readContextReading(
+		"grok-build",
+		contextDay({
+			firstCallCount: 0,
+			firstCallHarnessTokens: 0,
+			firstCallInstructionsTokens: 0,
+		}),
+		256000,
+	);
+	expect(reading.retainedCallsOnly).toBe(true);
+	expect(reading.breakdownAvailable).toBe(false);
+});

--- a/packages/workflow-rules/src/context.ts
+++ b/packages/workflow-rules/src/context.ts
@@ -65,6 +65,10 @@ export type ContextReading = {
 	/** `max(0, p90Call - harnessTokens - instructionsTokens)`. */
 	longChat: number;
 	compactions: number;
+	/** False when no first-call split was measured. */
+	breakdownAvailable?: boolean;
+	/** Grok diagnostic logs retain only a subset of calls. */
+	retainedCallsOnly?: boolean;
 };
 
 const asCounts = (
@@ -97,6 +101,8 @@ export function readContextReading(
 	const fixed = harnessTokens + instructionsTokens;
 	return {
 		harness,
+		...(context.firstCallCount === 0 ? { breakdownAvailable: false } : {}),
+		...(harness === "grok-build" ? { retainedCallsOnly: true } : {}),
 		window: context.window ?? window,
 		calls,
 		medianCall,

--- a/src/features/usage/ContextRow.tsx
+++ b/src/features/usage/ContextRow.tsx
@@ -40,7 +40,7 @@ export function ContextSummary({
 				<b className="font-mono text-accent-lime">
 					{fmtTokens(first.medianCall)}
 				</b>{" "}
-				median call
+				{first.retainedCallsOnly ? "median retained call" : "median call"}
 			</span>
 			{context.harnesses.map((h) =>
 				h.window === null ? null : (
@@ -89,9 +89,20 @@ function HarnessBlock({ h }: { h: ContextHarness }) {
 							{fmtWholeShare(h.medianCall / h.window)} full ·{" "}
 						</>
 					)}
-					{h.calls.toLocaleString("en-US")} calls
+					{h.calls.toLocaleString("en-US")}{" "}
+					{h.retainedCallsOnly ? "retained calls" : "calls"}
 				</span>
 			</p>
+			{h.retainedCallsOnly && (
+				<p className="mb-3 text-xs text-fg-muted">
+					Based on retained local logs. Some calls may be missing.
+				</p>
+			)}
+			{h.breakdownAvailable === false && (
+				<p className="mb-3 text-xs text-fg-muted">
+					Harness and instructions breakdown unavailable.
+				</p>
+			)}
 			{h.window === null ? (
 				<Legend h={h} window={null} />
 			) : (
@@ -138,7 +149,11 @@ function Waffle({
 					key={i}
 					data-cell={cell}
 					className="block aspect-square w-full"
-					style={CELL_STYLE[cell]}
+					style={
+						cell === "usualChat" && h.breakdownAvailable === false
+							? { background: "var(--accent-lime)" }
+							: CELL_STYLE[cell]
+					}
 				/>
 			))}
 		</div>
@@ -150,32 +165,48 @@ function Legend({ h, window }: { h: ContextHarness; window: number | null }) {
 		window === null ? null : fmtShare(tokens / window);
 	return (
 		<div data-testid="context-legend">
+			{h.breakdownAvailable !== false && (
+				<>
+					<LegendRow
+						label="harness"
+						tokens={h.harnessTokens}
+						share={share(h.harnessTokens)}
+						title={CONTEXT_HINT.harness}
+						swatch={CELL_STYLE.harness}
+					/>
+					<LegendRow
+						label="instructions"
+						tokens={h.instructionsTokens}
+						share={share(h.instructionsTokens)}
+						title={CONTEXT_HINT.instructions}
+						swatch={CELL_STYLE.instructions}
+					/>
+				</>
+			)}
 			<LegendRow
-				label="harness"
-				tokens={h.harnessTokens}
-				share={share(h.harnessTokens)}
-				title={CONTEXT_HINT.harness}
-				swatch={CELL_STYLE.harness}
-			/>
-			<LegendRow
-				label="instructions"
-				tokens={h.instructionsTokens}
-				share={share(h.instructionsTokens)}
-				title={CONTEXT_HINT.instructions}
-				swatch={CELL_STYLE.instructions}
-			/>
-			<LegendRow
-				label="usual chat"
+				label={h.breakdownAvailable === false ? "median call" : "usual chat"}
 				tokens={h.usualChat}
 				share={share(h.usualChat)}
-				title={CONTEXT_HINT.usualChat}
-				swatch={CELL_STYLE.usualChat}
+				title={
+					h.breakdownAvailable === false
+						? "the median recorded call"
+						: CONTEXT_HINT.usualChat
+				}
+				swatch={
+					h.breakdownAvailable === false
+						? { background: "var(--accent-lime)" }
+						: CELL_STYLE.usualChat
+				}
 			/>
 			<LegendRow
-				label="long chat"
+				label={h.breakdownAvailable === false ? "p90 call" : "long chat"}
 				tokens={h.longChat}
 				share={share(h.longChat)}
-				title={CONTEXT_HINT.longChat}
+				title={
+					h.breakdownAvailable === false
+						? "1 in 10 recorded calls exceed this size"
+						: CONTEXT_HINT.longChat
+				}
 				swatch={CELL_STYLE.longChat}
 				className="mt-1.5"
 			/>

--- a/src/features/usage/__tests__/context-row.test.tsx
+++ b/src/features/usage/__tests__/context-row.test.tsx
@@ -224,3 +224,26 @@ describe("the Context row", () => {
 		expect(topics()[0].textContent).toMatch(/^Time/);
 	});
 });
+
+it("renders Grok's retained-call map without claiming an unmeasured split", () => {
+	const h = {
+		...contextReading().harnesses[0],
+		harness: "grok-build",
+		window: 256000,
+		breakdownAvailable: false,
+		retainedCallsOnly: true,
+		harnessTokens: 0,
+		instructionsTokens: 0,
+	};
+	render(<ContextBody context={{ harnesses: [h] }} />);
+	expect(screen.getByTestId("context-waffle").children).toHaveLength(200);
+	expect(screen.getByText("Grok Build")).toBeTruthy();
+	expect(screen.getByText(/Some calls may be missing/)).toBeTruthy();
+	expect(
+		screen.getByText("Harness and instructions breakdown unavailable."),
+	).toBeTruthy();
+	const legend = within(screen.getByTestId("context-legend"));
+	expect(legend.queryByText("harness")).toBeNull();
+	expect(legend.queryByText("instructions")).toBeNull();
+	expect(legend.getByText("median call")).toBeTruthy();
+});


### PR DESCRIPTION
Grok Build stacks had no context map because the adapter only read turn-level usage. Collect per-call prompt counts from Grok's existing local inference log and retain numeric measurements for 400 days so log rotation does not erase captured calls.

The map identifies retained-call coverage and unavailable harness/instructions breakdowns. Grok uses its catalog context window without inheriting Claude tiers. Usage/cost accounting and workflow consent remain on their existing paths. No database migration or additional hook is needed.

Validation: 692 tests pass, including the full CLI suite and context scanner, cache, backend and rendering tests. CLI typecheck and build pass. Full-repository typechecking reports errors in unchanged prototype/test files. Live Grok sync remains an owner-run check after updating the CLI.

Deploy backend/web before merging the Release Please CLI release.
