### PR TITLE
fix(cli): bound sync startup requests and clarify progress

### DIFF
--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -3,6 +3,10 @@ import { CLI_VERSION } from "./version.js";
 
 export const BASE_URL = process.env.AISTACK_URL || "https://aistack.to";
 
+// Optional startup reads must reach their fallback even if the server stalls.
+// Keep the deadline active while consuming the response body too.
+const STARTUP_READ_TIMEOUT_MS = 5_000;
+
 async function request(
 	path: string,
 	options: RequestInit = {},
@@ -210,6 +214,7 @@ export async function fetchDayManifest(
 	days: { date: string; fingerprint: string }[];
 } | null> {
 	const res = await fetch(`${baseUrl}/api/cli/sync-manifest`, {
+		signal: AbortSignal.timeout(STARTUP_READ_TIMEOUT_MS),
 		headers: { "Content-Type": "application/json", ...authHeaders(token) },
 	});
 	if (res.status === 404) return null;
@@ -257,6 +262,7 @@ export async function fetchPriceTable(
 	baseUrl: string,
 ): Promise<PriceTable | null> {
 	const res = await fetch(`${baseUrl}/api/prices`, {
+		signal: AbortSignal.timeout(STARTUP_READ_TIMEOUT_MS),
 		headers: { Accept: "application/json" },
 	});
 	if (res.status === 404) return null;

--- a/packages/cli/src/sync/stage-network.test.ts
+++ b/packages/cli/src/sync/stage-network.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { BUNDLED_SYNC_CONFIG } from "../harness/shared/allowlist.js";
+import { stageSync } from "./stage.js";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+	vi.useRealTimers();
+});
+
+describe("sync startup with a stalled server", () => {
+	test.each([
+		["/api/prices", "headers"],
+		["/api/prices", "body"],
+		["/api/sync-config", "headers"],
+		["/api/sync-config", "body"],
+		["/api/cli/sync-manifest", "headers"],
+		["/api/cli/sync-manifest", "body"],
+	])("leaves startup when %s stalls at %s", async (path, phase) => {
+		vi.useFakeTimers();
+		// Node's native AbortSignal timeout uses an internal clock. Connect it
+		// to the test clock while preserving cancellation of headers and body.
+		vi.spyOn(AbortSignal, "timeout").mockImplementation((ms) => {
+			const controller = new AbortController();
+			setTimeout(
+				() => controller.abort(new DOMException("Timed out", "TimeoutError")),
+				ms,
+			);
+			return controller.signal;
+		});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (url: string, init?: RequestInit) => {
+				if (!url.endsWith(path)) {
+					return new Response(
+						JSON.stringify({
+							...BUNDLED_SYNC_CONFIG,
+							stack: { name: "Test", slug: "test" },
+						}),
+						{ status: url.endsWith("/api/sync-config") ? 200 : 404 },
+					);
+				}
+				if (phase === "headers") {
+					return new Promise<Response>((_, reject) => {
+						init?.signal?.addEventListener(
+							"abort",
+							() => reject(init.signal?.reason),
+							{ once: true },
+						);
+					});
+				}
+				return new Response(
+					new ReadableStream({
+						start(controller) {
+							controller.enqueue(new TextEncoder().encode("{"));
+							init?.signal?.addEventListener(
+								"abort",
+								() => controller.error(init.signal?.reason),
+								{ once: true },
+							);
+						},
+					}),
+				);
+			}),
+		);
+		const adapters = vi.fn(async () => []);
+		const staging = stageSync({
+			baseUrl: "https://sync.test",
+			getTokenImpl: () => "test-token",
+			getSettingsImpl: () => ({}),
+			adaptersImpl: adapters,
+		});
+		await vi.advanceTimersByTimeAsync(5_001);
+		expect(
+			adapters,
+			"sync must leave network startup within its read deadline",
+		).toHaveBeenCalled();
+		const staged = await staging;
+		if (path === "/api/prices") expect(staged.prices?.origin).toBe("bundled");
+		if (path === "/api/sync-config") {
+			expect(staged.config.stack).toBeNull();
+			expect(staged.blockedReason).not.toBeNull();
+		}
+	});
+});

--- a/packages/cli/src/sync/stage.ts
+++ b/packages/cli/src/sync/stage.ts
@@ -188,7 +188,7 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 		id: BUNDLED_PRICE_TABLE_ID,
 		origin: "bundled",
 	};
-	progress("Checking prices and stack settings");
+	progress("Checking prices");
 	try {
 		const table = await fetchPrices(deps.baseUrl);
 		if (table) {
@@ -201,6 +201,7 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 		setActivePricer(null);
 	}
 
+	progress("Checking stack settings");
 	const { config, source } = await loadConfig({
 		baseUrl: deps.baseUrl,
 		...(token ? { token } : {}),
@@ -213,6 +214,7 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 	// far back the day scan reaches.
 	let manifest: DayManifest | null = null;
 	if (token) {
+		progress("Checking previously synced days");
 		try {
 			manifest = await fetchManifest(deps.baseUrl, token);
 		} catch {
@@ -240,6 +242,7 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 	// date the server would keep. Two scans over the same files; the second is
 	// the one the days and the workflow blocks come from.
 	const daysSinceMs = windowStartMs(now, retentionDays);
+	progress("Detecting local harnesses");
 	const active = await adapters(sinceMs);
 	const historical = await adapters(daysSinceMs);
 	let dayScansComplete = true;


### PR DESCRIPTION
Sync could remain at “Checking prices and stack settings” when the price or day-manifest response stalled. Both reads now have a five-second deadline covering headers and body, allowing the existing bundled-price and full-window fallbacks to run. Separate progress messages identify prices, settings, synced days, and local harness detection.

Validation: 657 tests passed, including six stalled-response regression cases; CLI build and Biome checks passed. The tests reproduced four hangs before the fix. The affected users' specific network failure has not been confirmed.
