### PR TITLE
fix(cli): add sync --verbose and read Cursor history once per sync

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -22,6 +22,17 @@ On an unlinked machine, `sync` starts the login flow inline - your browser opens
 
 After a manual sync, the CLI offers auto-sync with three choices: Enable, Maybe later, and Never ask again. Maybe later asks again after your next manual sync. Existing declines from older CLI versions are treated as Maybe later.
 
+#### A sync that looks stuck
+
+The scan runs on this machine and can take a few minutes when a harness keeps a large history. Cursor is the usual case: its global `state.vscdb` grows past a gigabyte, and the session listing walks all of it before the first result. The spinner text can lag behind the running step while that happens. To see each phase as it starts, with its duration, run with `--verbose`:
+
+```sh
+npx @use-aistack/cli sync --verbose
+AISTACK_DEBUG=1 npx @use-aistack/cli sync   # the same, for a hook or a script
+```
+
+The lines go to stderr and hold counts and durations only: no paths, prompts, or database values. Paste them into a bug report.
+
 ### `npx @use-aistack/cli sync --auto on` / `off`
 
 Optional: keep your stack fresh without manual syncs. `on` asks your stack for permission, then writes hooks for the harnesses you actually use. The `SessionStart` paths are: `~/.claude/settings.json` for Claude Code, `~/.codex/hooks.json` for Codex, and `$GROK_HOME/hooks/aistack.json` (default `~/.grok/hooks/aistack.json`) for Grok Build. Cursor uses a user-level `stop` hook in `~/.cursor/hooks.json` and reloads that configuration automatically. Its trigger runs when the agent finishes a turn. The other hooks run when a session starts. All triggers share one silent sync throttle, at most once every 6 hours. Existing user hooks are preserved. Grok Build needs a new session or hook reload after installation. `off` disables local publication first, removes the owned hooks, then takes the remote permission back. If removal fails, the disabled local gate still prevents publication and the next interactive sync can retry reconciliation.

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -36,6 +36,12 @@ import {
 	outroError,
 	yellow,
 } from "../theme.js";
+import {
+	enableTrace,
+	traceEnvironment,
+	traceRequestedByEnv,
+} from "../trace.js";
+import { CLI_VERSION } from "../version.js";
 import { offerConnectUpsell } from "./connect.js";
 import { performLogin } from "./login.js";
 
@@ -44,9 +50,29 @@ export interface SyncOptions {
 	auto?: boolean | string;
 	/** `--every <hours>`, applied with `--auto on`. */
 	every?: string;
+	/** `--verbose`: print every phase with its duration to stderr. */
+	verbose?: boolean;
 }
 
+/**
+ * The clack spinner repaints on an interval of this length. A phase message
+ * set right before work that blocks the event loop is never drawn unless the
+ * caller waits one frame first, and the stale text then names the wrong step
+ * for as long as the block lasts (minutes on a large Cursor database).
+ */
+const SPINNER_FRAME_MS = 90;
+const paintFrame = () =>
+	new Promise<void>((resolve) => setTimeout(resolve, SPINNER_FRAME_MS));
+
 export async function syncCommand(options: SyncOptions = {}): Promise<void> {
+	if (options.verbose || traceRequestedByEnv()) {
+		enableTrace();
+		traceEnvironment({
+			cliVersion: CLI_VERSION,
+			baseUrl: BASE_URL,
+			trigger: options.auto === true ? "auto" : "manual",
+		});
+	}
 	// The silent path (#62): no TTY, no prompts, no upsells. Publishes only
 	// under the standing opt-in and always exits 0 - the hook command's `||`
 	// offline fallback must never fire on a mere sync failure.
@@ -180,7 +206,10 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
 			baseUrl: BASE_URL,
 			getTokenImpl: () => destinationToken,
 			loadConfigImpl: async () => destinationConfig,
-			onProgress: (message) => s.message(message),
+			onProgress: async (message) => {
+				s.message(message);
+				await paintFrame();
+			},
 		});
 	} catch (e) {
 		s.stop("Scan failed");

--- a/packages/cli/src/harness/cursor/local.test.ts
+++ b/packages/cli/src/harness/cursor/local.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import rows from "./fixtures/composer-rows.json";
-import { dataPath, readLocal } from "./local.js";
+import { dataPath, forgetLocalReads, readLocal } from "./local.js";
 
 let dir: string;
 let root: string;
@@ -13,6 +13,7 @@ beforeEach(async () => {
 	root = path.join(dir, "User", "workspaceStorage");
 	vi.stubEnv("CURSOR_DATA_PATH", root);
 	vi.stubEnv("CURSOR_STORE_ROOT", path.join(dir, "store"));
+	forgetLocalReads();
 });
 afterEach(async () => {
 	vi.unstubAllEnvs();
@@ -64,6 +65,26 @@ it("resolves the qualified Composer fixture with the packaged node:sqlite reader
 		"read_file",
 	);
 });
+// A sync asks the adapter four times (detect twice, scan twice). Each read
+// walks the whole global database on the main thread, so the second, third
+// and fourth must be the first one's result, until the source changes.
+it("reads a root once per process while its source is unchanged", async () => {
+	await createSource();
+	const first = await readLocal(root);
+	expect(first.sessions).toHaveLength(1);
+	expect(await readLocal(root)).toBe(first);
+	const global = new DatabaseSync(
+		path.join(dir, "User", "globalStorage", "state.vscdb"),
+	);
+	global
+		.prepare("INSERT INTO cursorDiskKV VALUES (?, ?)")
+		.run("aistack:changed", JSON.stringify({ padding: "x".repeat(8192) }));
+	global.close();
+	const again = await readLocal(root);
+	expect(again).not.toBe(first);
+	expect(again.sessions).toHaveLength(1);
+});
+
 it("reconciles a transcript copy once and retains explicit-zero raw token evidence", async () => {
 	await createSource();
 	const id = "11111111-1111-4111-8111-111111111111";

--- a/packages/cli/src/harness/cursor/local.ts
+++ b/packages/cli/src/harness/cursor/local.ts
@@ -2,6 +2,7 @@ import { stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import type { Session, SessionReadContext } from "cursor-history";
+import { trace, traceTimer } from "../../trace.js";
 import { asObj, asStr } from "../shared/aggregate.js";
 import { emptyScanStats, type ScanStats } from "../shared/window.js";
 import {
@@ -125,15 +126,56 @@ export type LocalRead = {
 	complete: boolean;
 	stats: ScanStats;
 };
+/**
+ * One read per root per process while the source is unchanged.
+ *
+ * A sync asks this adapter four times (detect twice, scan twice), and every
+ * read walks the whole global database on the main thread: on a 1.6 GB
+ * `state.vscdb` the session listing alone costs tens of seconds of CPU, during
+ * which the spinner cannot repaint. Four walks read as a hang; one is a wait.
+ * The memo is keyed by the source stamp, so a database that changes between
+ * two calls in the same run is read again, and the stamp check that marks a
+ * read incomplete when the source moved under it still applies to each read.
+ */
+const localReads = new Map<
+	string,
+	{ stamp: string; read: Promise<LocalRead> }
+>();
+
+/** Tests only: forget the reads this process made. */
+export function forgetLocalReads(): void {
+	localReads.clear();
+}
+
 /** Errors never escape with paths, prompts or database values. */
 export async function readLocal(
 	root = dataPath(),
 	onProgress?: (files: number) => void,
 ): Promise<LocalRead> {
+	const stamp = await sourceStamp(root);
+	const held = localReads.get(root);
+	if (held && held.stamp === stamp) {
+		trace("cursor · reusing this run's history read");
+		return held.read;
+	}
+	const read = readLocalOnce(root, stamp, onProgress);
+	localReads.set(root, { stamp, read });
+	return read;
+}
+
+async function readLocalOnce(
+	root: string,
+	before: string,
+	onProgress?: (files: number) => void,
+): Promise<LocalRead> {
 	const stats = emptyScanStats();
 	const out: LocalRead = { sessions: [], complete: true, stats };
-	if (!(await hasLocalSource(root))) return out;
-	const before = await sourceStamp(root);
+	if (!(await hasLocalSource(root))) {
+		trace("cursor · no local source");
+		return out;
+	}
+	trace(`cursor · global database ${await globalDbSize(root)}`);
+	const readDone = traceTimer("cursor history read");
 	let context: SessionReadContext | undefined;
 	try {
 		const reader = await import("cursor-history");
@@ -149,11 +191,17 @@ export async function readLocal(
 		const config = { ...options, readContext: context };
 		let offset = 0;
 		while (true) {
+			// The first page carries the whole workspace discovery, which walks
+			// every bubble key in the global database before it returns.
+			const pageDone = traceTimer(
+				offset === 0 ? "cursor session listing" : "cursor session page",
+			);
 			const page = await reader.listSessionSummaries({
 				...config,
 				offset,
 				limit: 100,
 			});
+			pageDone(`${page.data.length} sessions`);
 			for (const summary of page.data) {
 				stats.filesFound++;
 				if (summary.resolutionState === "ambiguous") {
@@ -195,5 +243,17 @@ export async function readLocal(
 		}
 	}
 	if (before !== (await sourceStamp(root))) out.complete = false;
+	readDone(
+		`${stats.filesRead}/${stats.filesFound} sessions read, ${stats.filesUnreadable} unreadable${out.complete ? "" : ", incomplete"}`,
+	);
 	return out;
+}
+
+async function globalDbSize(root: string): Promise<string> {
+	try {
+		const info = await stat(globalDb(root));
+		return `${(info.size / 1_048_576).toFixed(0)} MB`;
+	} catch {
+		return "absent";
+	}
 }

--- a/packages/cli/src/harness/index.ts
+++ b/packages/cli/src/harness/index.ts
@@ -21,6 +21,7 @@
 //     });
 //   }
 
+import { traceTimer } from "../trace.js";
 import { CLAUDE_HARNESS_NAME, claudeAdapter } from "./claude/adapter.js";
 import { CODEX_HARNESS_NAME, codexAdapter } from "./codex/adapter.js";
 import { CURSOR_HARNESS_NAME, cursorAdapter } from "./cursor/adapter.js";
@@ -182,10 +183,23 @@ export function detectionSinceMs(now: number = Date.now()): number {
  */
 export async function detectedAdapters(
 	sinceMs: number = detectionSinceMs(),
+	hooks: {
+		/**
+		 * Called before each adapter's detect and awaited, so a caller with a
+		 * spinner can name the harness about to be checked. A detect can block
+		 * the event loop for a while (Cursor reads its SQLite history here), and
+		 * the name on screen must be the one doing the work.
+		 */
+		onAdapter?: (adapter: HarnessAdapter) => void | Promise<void>;
+	} = {},
 ): Promise<HarnessAdapter[]> {
 	const out: HarnessAdapter[] = [];
 	for (const adapter of HARNESS_ADAPTERS) {
-		if (await adapter.detect({ sinceMs })) out.push(adapter);
+		await hooks.onAdapter?.(adapter);
+		const done = traceTimer(`detect ${adapter.name}`);
+		const present = await adapter.detect({ sinceMs });
+		done(present ? "found" : "nothing in window");
+		if (present) out.push(adapter);
 	}
 	return out;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -58,6 +58,10 @@ program
 		"--every <hours>",
 		"with --auto on: hours between auto-syncs (default 6)",
 	)
+	.option(
+		"--verbose",
+		"print every phase with its duration to stderr, for a sync that looks stuck (same as AISTACK_DEBUG=1)",
+	)
 	.action((options) => syncCommand(options));
 
 program

--- a/packages/cli/src/sync/stage.test.ts
+++ b/packages/cli/src/sync/stage.test.ts
@@ -113,6 +113,41 @@ describe("stageSync", () => {
 		expect(staged.bodyJson).not.toContain("-home-u-p");
 	});
 
+	// A phase message is the only thing a user sees while a step blocks the
+	// event loop, so the stage names the step first and waits for the terminal
+	// to show it. Detection names each harness through the adapters hook.
+	test("names each phase before its work and waits for the terminal to show it", async () => {
+		const seen: string[] = [];
+		let pending = 0;
+		const staged = await stageSync(
+			deps({
+				adaptersImpl: async (_sinceMs, hooks) => {
+					await hooks?.onAdapter?.(FAKE_CLAUDE_ADAPTER);
+					return [FAKE_CLAUDE_ADAPTER];
+				},
+				onProgress: async (message) => {
+					// Every earlier phase's promise settled before the next one started.
+					expect(pending).toBe(0);
+					pending++;
+					seen.push(message);
+					await new Promise((resolve) => setTimeout(resolve, 1));
+					pending--;
+				},
+			}),
+		);
+		expect(staged.blockedReason).toBeNull();
+		expect(seen).toEqual([
+			"Checking prices",
+			"Checking stack settings",
+			"Checking previously synced days",
+			"Checking for Claude Code history",
+			"Scanning recent Claude Code usage",
+			"Reading historical Claude Code days",
+			"Reading Git history",
+			"Preparing review",
+		]);
+	});
+
 	test("bodyJson is the exact serialization and the id derives from it", async () => {
 		const staged = await stageSync(deps({}));
 		expect(staged.bodyJson).toBe(JSON.stringify(staged.body));

--- a/packages/cli/src/sync/stage.ts
+++ b/packages/cli/src/sync/stage.ts
@@ -33,7 +33,7 @@ import {
 	getToken,
 	type Settings,
 } from "../config.js";
-import { detectedAdapters } from "../harness/index.js";
+import { detectedAdapters, harnessLabel } from "../harness/index.js";
 import {
 	type KeptPrivateAtom,
 	type LoadedSyncConfig,
@@ -56,6 +56,7 @@ import {
 	windowStartMs,
 } from "../harness/shared/window.js";
 import type { HarnessAdapter } from "../harness/types.js";
+import { trace, traceTimer } from "../trace.js";
 import {
 	buildMeasuredDays,
 	buildUsageDays,
@@ -136,7 +137,12 @@ export type StageDeps = {
 		token?: string;
 	}) => Promise<LoadedSyncConfig>;
 	/** Override the adapter set. Tests only. */
-	adaptersImpl?: (sinceMs: number) => Promise<HarnessAdapter[]>;
+	adaptersImpl?: (
+		sinceMs: number,
+		hooks?: {
+			onAdapter?: (adapter: HarnessAdapter) => void | Promise<void>;
+		},
+	) => Promise<HarnessAdapter[]>;
 	/** Override the Git reader the workflow extraction shells out to. Tests only. */
 	gitRunnerImpl?: GitWorkflowRunner;
 	/**
@@ -159,8 +165,15 @@ export type StageDeps = {
 	 * the background run has a human at the keyboard.
 	 */
 	trigger?: SyncTrigger;
-	/** Human-facing phase updates for the interactive terminal. */
-	onProgress?: (message: string) => void;
+	/**
+	 * Human-facing phase updates for the interactive terminal. A phase change
+	 * is AWAITED before the work it names starts: the spinner repaints on a
+	 * timer, and a phase that blocks the event loop (Cursor's SQLite walk) would
+	 * otherwise leave the previous phase's text on screen for minutes and read
+	 * as a hang at the wrong step. File-count updates inside a scan are not
+	 * awaited; they are frequent and the scan yields on its own.
+	 */
+	onProgress?: (message: string) => void | Promise<void>;
 };
 
 export function stageId(bodyJson: string): string {
@@ -177,7 +190,15 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 		deps.getProjectWorkspaceIdImpl ?? getProjectWorkspaceId;
 	const fetchManifest = deps.fetchManifestImpl ?? fetchDayManifest;
 	const fetchPrices = deps.fetchPricesImpl ?? fetchPriceTable;
-	const progress = deps.onProgress ?? (() => {});
+	// `phase` names the step that is about to run and waits for the terminal to
+	// show it; `note` refreshes a count inside a running step and returns at once.
+	const phase = async (message: string) => {
+		trace(message);
+		await deps.onProgress?.(message);
+	};
+	const note = (message: string) => {
+		void deps.onProgress?.(message);
+	};
 
 	// The price table comes from the server BEFORE any adapter prices a
 	// response (#336): the adapters call the module-level pricing functions,
@@ -188,24 +209,32 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 		id: BUNDLED_PRICE_TABLE_ID,
 		origin: "bundled",
 	};
-	progress("Checking prices");
+	await phase("Checking prices");
+	const pricesDone = traceTimer("prices");
 	try {
 		const table = await fetchPrices(deps.baseUrl);
 		if (table) {
 			setActivePricer(layeredPricer(table));
 			prices = { id: table.id, origin: "served" };
+			pricesDone(`served ${table.id}`);
 		} else {
 			setActivePricer(null);
+			pricesDone("server has no price route, bundled table");
 		}
-	} catch {
+	} catch (error) {
 		setActivePricer(null);
+		pricesDone(`fetch failed (${describeError(error)}), bundled table`);
 	}
 
-	progress("Checking stack settings");
+	await phase("Checking stack settings");
+	const settingsDone = traceTimer("stack settings");
 	const { config, source } = await loadConfig({
 		baseUrl: deps.baseUrl,
 		...(token ? { token } : {}),
 	});
+	settingsDone(
+		`${source}${config.stack ? ", stack resolved" : ", no stack"}, publishWorkflow ${config.publishWorkflow}, publishCost ${config.publishCost}`,
+	);
 
 	// The server's day manifest (#307, ADR-0010): which dates it holds and with
 	// what fingerprint. Missing (an old server) or failing (network) reads as
@@ -214,12 +243,21 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 	// far back the day scan reaches.
 	let manifest: DayManifest | null = null;
 	if (token) {
-		progress("Checking previously synced days");
+		await phase("Checking previously synced days");
+		const manifestDone = traceTimer("day manifest");
 		try {
 			manifest = await fetchManifest(deps.baseUrl, token);
-		} catch {
+			manifestDone(
+				manifest
+					? `${manifest.days.length} days held, retention ${manifest.retentionDays}`
+					: "server has no manifest route, whole window goes",
+			);
+		} catch (error) {
 			manifest = null;
+			manifestDone(`fetch failed (${describeError(error)}), whole window goes`);
 		}
+	} else {
+		trace("day manifest · skipped, this machine holds no token");
 	}
 	const retentionDays = Math.max(
 		1,
@@ -242,19 +280,34 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 	// date the server would keep. Two scans over the same files; the second is
 	// the one the days and the workflow blocks come from.
 	const daysSinceMs = windowStartMs(now, retentionDays);
-	progress("Detecting local harnesses");
-	const active = await adapters(sinceMs);
+	// One phase per harness, so a detect that blocks the event loop (Cursor's
+	// history read) shows its own name on the spinner instead of the previous
+	// phase's. The historical pass repeats the same checks over a longer window
+	// and reuses the reads the first pass made where an adapter memoizes them.
+	const active = await adapters(sinceMs, {
+		onAdapter: (adapter) =>
+			phase(`Checking for ${harnessLabel(adapter.name)} history`),
+	});
+	trace(
+		`active harnesses (${windowDays} days): ${active.map((a) => a.name).join(", ") || "none"}`,
+	);
 	const historical = await adapters(daysSinceMs);
+	trace(
+		`historical harnesses (${retentionDays} days): ${historical.map((a) => a.name).join(", ") || "none"}`,
+	);
 	let dayScansComplete = true;
 	const sessionDatesByHarness = new Map<string, Map<string, Set<string>>>();
 	for (const adapter of active) {
-		progress(`Scanning recent ${adapter.name} usage`);
+		const label = harnessLabel(adapter.name);
+		await phase(`Scanning recent ${label} usage`);
+		const scanDone = traceTimer(`scan ${adapter.name} (recent)`);
 		const { aggregate, stats } = await adapter.scan({
 			sinceMs,
 			publishWorkflow: false,
 			onProgress: (files) =>
-				progress(`Scanning recent ${adapter.name} usage · ${files} files`),
+				note(`Scanning recent ${label} usage · ${files} files`),
 		});
+		scanDone(describeScan(stats));
 		scanStats[adapter.name] = stats;
 		built.push(
 			buildPayload({
@@ -270,14 +323,25 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 		);
 	}
 	for (const adapter of historical) {
-		progress(`Reading historical ${adapter.name} days`);
-		const { aggregate, workflow, workflowLocal, scanComplete, sessionDates } =
-			await adapter.scan({
-				sinceMs: daysSinceMs,
-				publishWorkflow: config.publishWorkflow,
-				onProgress: (files) =>
-					progress(`Reading historical ${adapter.name} days · ${files} files`),
-			});
+		const label = harnessLabel(adapter.name);
+		await phase(`Reading historical ${label} days`);
+		const scanDone = traceTimer(`scan ${adapter.name} (historical)`);
+		const {
+			aggregate,
+			stats,
+			workflow,
+			workflowLocal,
+			scanComplete,
+			sessionDates,
+		} = await adapter.scan({
+			sinceMs: daysSinceMs,
+			publishWorkflow: config.publishWorkflow,
+			onProgress: (files) =>
+				note(`Reading historical ${label} days · ${files} files`),
+		});
+		scanDone(
+			`${describeScan(stats)}${scanComplete === false ? ", incomplete" : ""}`,
+		);
 		if (scanComplete === false) dayScansComplete = false;
 		if (adapter.name === "grok-build" || adapter.name === "cursor")
 			sessionDatesByHarness.set(adapter.name, sessionDates ?? new Map());
@@ -307,7 +371,8 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 	// would be the one visible cost of a preference that is supposed to be free.
 	let workflow: WorkflowExtraction | undefined;
 	if (workflowScans.length > 0 && config.publishWorkflow) {
-		progress("Reading Git history");
+		await phase("Reading Git history");
+		const gitDone = traceTimer("git history");
 		workflow = deps.gitRunnerImpl
 			? extractLocalWorkflow({
 					harnesses: workflowScans,
@@ -320,6 +385,11 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 					fromMs: daysSinceMs,
 					toMs: now,
 				});
+		gitDone(`${workflow.days.length} days`);
+	} else {
+		trace(
+			`git history · skipped (${config.publishWorkflow ? "no harness scanned" : "publishWorkflow off"})`,
+		);
 	}
 
 	// The day rows (#307): usage and workflow joined by date, consent applied
@@ -381,8 +451,12 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 			: undefined,
 		CLI_VERSION,
 	);
-	progress("Preparing review");
+	await phase("Preparing review");
 	const bodyJson = JSON.stringify(body);
+	trace(
+		`days · ${days.mode}, ${days.send.length} to send${dayScansComplete ? "" : " (a scan was incomplete, no day rows go)"}`,
+	);
+	trace(`body · ${bodyJson.length} bytes, ${built.length} harness payloads`);
 	const keptPrivate = mergeKeptPrivate(built.map((b) => b.keptPrivate));
 
 	const ctx = {
@@ -427,4 +501,15 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 		prices,
 		...(acknowledgePublish ? { acknowledgePublish } : {}),
 	};
+}
+
+function describeError(error: unknown): string {
+	if (error instanceof Error) {
+		return error.name === "TimeoutError" ? "timed out" : error.message;
+	}
+	return String(error);
+}
+
+function describeScan(stats: ScanStats): string {
+	return `${stats.filesRead}/${stats.filesFound} files read, ${stats.filesUnreadable} unreadable`;
 }

--- a/packages/cli/src/trace.test.ts
+++ b/packages/cli/src/trace.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, test } from "vitest";
+import {
+	disableTrace,
+	enableTrace,
+	trace,
+	traceEnabled,
+	traceRequestedByEnv,
+	traceTimer,
+} from "./trace.js";
+
+afterEach(() => disableTrace());
+
+describe("trace", () => {
+	test("prints nothing until enabled, then stamps each line with the elapsed time", () => {
+		const lines: string[] = [];
+		trace("silent");
+		expect(traceEnabled()).toBe(false);
+		enableTrace((line) => lines.push(line));
+		trace("Checking prices");
+		expect(lines).toHaveLength(1);
+		expect(lines[0]).toMatch(/^\[aistack +\+\d+\.\d+s\] Checking prices$/);
+	});
+
+	test("a timer reports its label, the duration and the note", () => {
+		const lines: string[] = [];
+		enableTrace((line) => lines.push(line));
+		const done = traceTimer("detect cursor");
+		done("yes");
+		expect(lines[0]).toMatch(/detect cursor · \d+ ms · yes$/);
+	});
+
+	test("a timer taken while tracing is off stays a no-op", () => {
+		const lines: string[] = [];
+		const done = traceTimer("never");
+		enableTrace((line) => lines.push(line));
+		done("late");
+		expect(lines).toEqual([]);
+	});
+
+	test("AISTACK_DEBUG turns tracing on without a flag", () => {
+		expect(traceRequestedByEnv({ AISTACK_DEBUG: "1" })).toBe(true);
+		expect(traceRequestedByEnv({ AISTACK_DEBUG: "true" })).toBe(true);
+		expect(traceRequestedByEnv({ AISTACK_DEBUG: "0" })).toBe(false);
+		expect(traceRequestedByEnv({})).toBe(false);
+	});
+});

--- a/packages/cli/src/trace.ts
+++ b/packages/cli/src/trace.ts
@@ -1,0 +1,76 @@
+// Verbose diagnostics for a sync that looks stuck.
+//
+// The interactive spinner repaints on a timer, so a phase that blocks the event
+// loop (a synchronous SQLite walk, a large transcript parse) leaves the LAST
+// message on screen and reads as a hang at the wrong step. A user who reports
+// "it hangs at X" is then pointing at the phase that finished. This sink prints
+// every phase as it starts, with the seconds since the command began, so the
+// report names the phase that is actually running and how long it took.
+//
+// Enabled by `sync --verbose` or `AISTACK_DEBUG=1`. Every line goes to stderr,
+// so the MCP server's stdout protocol and a piped summary stay clean. Nothing
+// here prints a path, a prompt, or a database value: counts and durations only.
+
+let sink: ((line: string) => void) | null = null;
+let startedAtMs = 0;
+
+const stderrSink = (line: string) => {
+	process.stderr.write(`${line}\n`);
+};
+
+/** True when the environment asks for diagnostics without a flag. */
+export function traceRequestedByEnv(env = process.env): boolean {
+	const value = env.AISTACK_DEBUG?.trim().toLowerCase();
+	return value === "1" || value === "true" || value === "yes";
+}
+
+export function enableTrace(
+	write: (line: string) => void = stderrSink,
+	now: () => number = () => performance.now(),
+): void {
+	sink = write;
+	startedAtMs = now();
+}
+
+export function disableTrace(): void {
+	sink = null;
+}
+
+export function traceEnabled(): boolean {
+	return sink !== null;
+}
+
+function elapsedLabel(): string {
+	const seconds = (performance.now() - startedAtMs) / 1000;
+	return `+${seconds.toFixed(seconds < 10 ? 2 : 1)}s`;
+}
+
+/** One diagnostic line. A no-op unless tracing is on, so callers never guard. */
+export function trace(message: string): void {
+	if (!sink) return;
+	sink(`[aistack ${elapsedLabel().padStart(7)}] ${message}`);
+}
+
+/**
+ * Time one step. Returns a function that prints `label · N ms` plus an optional
+ * result note, so a caller writes `const done = traceTimer("x"); ...; done("ok")`.
+ */
+export function traceTimer(label: string): (note?: string) => void {
+	if (!sink) return () => {};
+	const started = performance.now();
+	return (note) => {
+		const ms = Math.round(performance.now() - started);
+		trace(`${label} · ${ms} ms${note ? ` · ${note}` : ""}`);
+	};
+}
+
+/** The facts a bug report needs first, printed once when tracing starts. */
+export function traceEnvironment(facts: {
+	cliVersion: string;
+	baseUrl: string;
+	trigger?: string;
+}): void {
+	trace(
+		`aistack ${facts.cliVersion} · node ${process.versions.node} · ${process.platform}-${process.arch} · ${facts.baseUrl}${facts.trigger ? ` · trigger ${facts.trigger}` : ""}`,
+	);
+}


### PR DESCRIPTION
## Why

Users reported `npx @use-aistack/cli sync` hanging at "Checking previously synced days" (and earlier at "Checking prices and stack settings"). Reproduced locally: the process burned 99% CPU for about 4.5 minutes inside cursor-history's session listing over a 1.5 GB `state.vscdb`, on the main thread. One sync ran that full read four times (detect twice, scan twice). The clack spinner repaints on a timer, so the stale text named the phase that had finished, not the one running.

## What

- `sync --verbose` (also `AISTACK_DEBUG=1`): each phase to stderr with elapsed time, network read results, per-harness detect and scan timings, file counts, Cursor database size. Counts and durations only.
- Cursor history read once per process (`readLocal` memoized by source stamp).
- Phases await one spinner frame before their work, and detection names each harness, so the spinner shows the running step.
- README note for a sync that looks stuck.

Traced run on the reporter's machine: about 5 minutes before, 73 seconds after (one Cursor read of 60 s instead of four).

## Follow-ups

- Move the remaining Cursor listing into a worker thread so the spinner keeps animating.
- One unreadable Cursor session marks the scan incomplete and drops every day row for all harnesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aUJHeza9TjhnoKECY3FhB
