### PR TITLE
fix(cli): scan every harness at once and draw a live board with progress bars

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,7 +24,7 @@ After a manual sync, the CLI offers auto-sync with three choices: Enable, Maybe 
 
 #### A sync that looks stuck
 
-The scan runs on this machine and can take a few minutes when a harness keeps a large history. Cursor is the usual case: its global `state.vscdb` grows past a gigabyte, and the session listing walks all of it before the first result. The spinner text can lag behind the running step while that happens. To see each phase as it starts, with its duration, run with `--verbose`:
+The scan runs on this machine and can take a few minutes when a harness keeps a large history. Cursor is the usual case: its global `state.vscdb` grows past a gigabyte, and the session listing walks all of it before the first result. Every harness is checked at the same time and gets its own row with a progress bar, so one slow harness shows as one slow row while the others finish. To see each step as it starts, with its duration, run with `--verbose`:
 
 ```sh
 npx @use-aistack/cli sync --verbose

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -24,6 +24,7 @@ import {
 import { runAutoSync } from "../autosync/run.js";
 import { DEFAULT_FREQUENCY_HOURS, getSettings, getToken } from "../config.js";
 import { loadSyncConfig } from "../harness/shared/allowlist.js";
+import { createBoard } from "../sync/board.js";
 import { stageSync } from "../sync/stage.js";
 import { fmtReceivedAt } from "../sync/summary.js";
 import {
@@ -38,6 +39,7 @@ import {
 } from "../theme.js";
 import {
 	enableTrace,
+	traceEnabled,
 	traceEnvironment,
 	traceRequestedByEnv,
 } from "../trace.js";
@@ -53,16 +55,6 @@ export interface SyncOptions {
 	/** `--verbose`: print every phase with its duration to stderr. */
 	verbose?: boolean;
 }
-
-/**
- * The clack spinner repaints on an interval of this length. A phase message
- * set right before work that blocks the event loop is never drawn unless the
- * caller waits one frame first, and the stale text then names the wrong step
- * for as long as the block lasts (minutes on a large Cursor database).
- */
-const SPINNER_FRAME_MS = 90;
-const paintFrame = () =>
-	new Promise<void>((resolve) => setTimeout(resolve, SPINNER_FRAME_MS));
 
 export async function syncCommand(options: SyncOptions = {}): Promise<void> {
 	if (options.verbose || traceRequestedByEnv()) {
@@ -198,26 +190,31 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
 	const destinationToken = token;
 	const destinationConfig = loaded;
 
-	const s = p.spinner();
-	s.start("Scanning local agent transcripts");
+	// The scan board (#420): every step runs at once and gets its own row, so
+	// a slow harness shows as one slow row instead of a frozen spinner. With
+	// tracing on the rows are not animated: the trace lines on stderr would
+	// interleave with the redraws.
+	p.log.step("Scanning local history");
+	const board = createBoard({
+		write: (text) => process.stdout.write(text),
+		interactive: !traceEnabled(),
+	});
 	let staged: Awaited<ReturnType<typeof stageSync>>;
 	try {
 		staged = await stageSync({
 			baseUrl: BASE_URL,
 			getTokenImpl: () => destinationToken,
 			loadConfigImpl: async () => destinationConfig,
-			onProgress: async (message) => {
-				s.message(message);
-				await paintFrame();
-			},
+			onEvent: board.handle,
 		});
 	} catch (e) {
-		s.stop("Scan failed");
+		board.stop();
 		outroError(e instanceof Error ? e.message : String(e));
 		process.exitCode = 1;
 		return;
 	}
-	s.stop("Scan complete");
+	board.stop();
+	const s = p.spinner();
 
 	// Beat one - the same full summary the MCP preview returns, verbatim,
 	// printed behind the clack bar so it reads as one flow. The text is the

--- a/packages/cli/src/harness/claude/scan.test.ts
+++ b/packages/cli/src/harness/claude/scan.test.ts
@@ -182,12 +182,12 @@ describe("scan", () => {
 	});
 
 	it("reports progress on the caller's cadence without leaking paths", async () => {
-		for (let i = 0; i < 401; i++) {
+		for (let i = 0; i < 41; i++) {
 			writeTranscript(`proj/s-${i}.jsonl`, [assistant({})]);
 		}
 		const agg = createAggregate();
 		const seen: number[] = [];
 		await scan(agg, { roots: [root], onProgress: (n) => seen.push(n) });
-		expect(seen).toEqual([200, 400]);
+		expect(seen).toEqual([20, 40]);
 	});
 });

--- a/packages/cli/src/harness/claude/scan.ts
+++ b/packages/cli/src/harness/claude/scan.ts
@@ -143,7 +143,7 @@ export async function scan(
 			const projectDir = rel.split(path.sep)[0] ?? "(root)";
 			agg.files++;
 			stats.filesRead++;
-			if (opts.onProgress && agg.files % 200 === 0) opts.onProgress(agg.files);
+			if (opts.onProgress && agg.files % 20 === 0) opts.onProgress(agg.files);
 			try {
 				await ingestFile(
 					agg,

--- a/packages/cli/src/harness/codex/scan.ts
+++ b/packages/cli/src/harness/codex/scan.ts
@@ -136,7 +136,7 @@ export async function scan(
 
 			agg.files++;
 			stats.filesRead++;
-			if (opts.onProgress && agg.files % 200 === 0) opts.onProgress(agg.files);
+			if (opts.onProgress && agg.files % 20 === 0) opts.onProgress(agg.files);
 			const outcome = ingestWithRetry(agg, file, opts);
 			if (!outcome.ok) {
 				// Never rethrown: the error object carries the absolute path. The

--- a/packages/cli/src/harness/cursor/local.test.ts
+++ b/packages/cli/src/harness/cursor/local.test.ts
@@ -66,13 +66,13 @@ it("resolves the qualified Composer fixture with the packaged node:sqlite reader
 	);
 });
 // A sync asks the adapter four times (detect twice, scan twice). Each read
-// walks the whole global database on the main thread, so the second, third
-// and fourth must be the first one's result, until the source changes.
-it("reads a root once per process while its source is unchanged", async () => {
+// walks the whole global database, so the later three must be the first one's
+// result, even after the source moved: an open Cursor appends to its
+// write-ahead log the whole time, and a stamp check would defeat the memo.
+it("reads a root once per process, even when the source moves", async () => {
 	await createSource();
 	const first = await readLocal(root);
 	expect(first.sessions).toHaveLength(1);
-	expect(await readLocal(root)).toBe(first);
 	const global = new DatabaseSync(
 		path.join(dir, "User", "globalStorage", "state.vscdb"),
 	);
@@ -80,9 +80,9 @@ it("reads a root once per process while its source is unchanged", async () => {
 		.prepare("INSERT INTO cursorDiskKV VALUES (?, ?)")
 		.run("aistack:changed", JSON.stringify({ padding: "x".repeat(8192) }));
 	global.close();
-	const again = await readLocal(root);
-	expect(again).not.toBe(first);
-	expect(again.sessions).toHaveLength(1);
+	expect(await readLocal(root)).toBe(first);
+	forgetLocalReads();
+	expect(await readLocal(root)).not.toBe(first);
 });
 
 it("reconciles a transcript copy once and retains explicit-zero raw token evidence", async () => {

--- a/packages/cli/src/harness/cursor/local.ts
+++ b/packages/cli/src/harness/cursor/local.ts
@@ -1,8 +1,10 @@
+import { existsSync } from "node:fs";
 import { stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
+import { Worker } from "node:worker_threads";
 import type { Session, SessionReadContext } from "cursor-history";
-import { trace, traceTimer } from "../../trace.js";
+import { trace, traceEnabled, traceTimer } from "../../trace.js";
 import { asObj, asStr } from "../shared/aggregate.js";
 import { emptyScanStats, type ScanStats } from "../shared/window.js";
 import {
@@ -127,15 +129,16 @@ export type LocalRead = {
 	stats: ScanStats;
 };
 /**
- * One read per root per process while the source is unchanged.
+ * One read per root per process.
  *
  * A sync asks this adapter four times (detect twice, scan twice), and every
- * read walks the whole global database on the main thread: on a 1.6 GB
- * `state.vscdb` the session listing alone costs tens of seconds of CPU, during
- * which the spinner cannot repaint. Four walks read as a hang; one is a wait.
- * The memo is keyed by the source stamp, so a database that changes between
- * two calls in the same run is read again, and the stamp check that marks a
- * read incomplete when the source moved under it still applies to each read.
+ * read walks the whole global database: on a 1.6 GB `state.vscdb` the session
+ * listing alone costs tens of seconds of CPU. Four walks read as a hang; one is
+ * a wait. The memo is keyed by root alone, not by the source stamp: while
+ * Cursor is open it appends to the write-ahead log continuously, so a stamp
+ * taken after the first read never matches and the read would repeat. A sync
+ * is one moment, and the read itself marks its result incomplete when the
+ * source moved under it (see `readLocalOnce`).
  */
 const localReads = new Map<
 	string,
@@ -150,23 +153,89 @@ export function forgetLocalReads(): void {
 /** Errors never escape with paths, prompts or database values. */
 export async function readLocal(
 	root = dataPath(),
-	onProgress?: (files: number) => void,
+	onProgress?: (files: number, total?: number) => void,
 ): Promise<LocalRead> {
-	const stamp = await sourceStamp(root);
 	const held = localReads.get(root);
-	if (held && held.stamp === stamp) {
+	if (held) {
 		trace("cursor · reusing this run's history read");
 		return held.read;
 	}
-	const read = readLocalOnce(root, stamp, onProgress);
+	// Nothing to walk, nothing to remember: an install that appears later in
+	// the same process (tests do this) must still be read.
+	if (!(await hasLocalSource(root))) {
+		trace("cursor · no local source");
+		return { sessions: [], complete: true, stats: emptyScanStats() };
+	}
+	const stamp = await sourceStamp(root);
+	const read = readLocalOffThread(root, stamp, onProgress);
 	localReads.set(root, { stamp, read });
 	return read;
 }
 
-async function readLocalOnce(
+/**
+ * The bundled worker next to the CLI entry (`tsup` emits `cursor-worker.js`
+ * beside `index.js`). Absent when running from source, where the read stays
+ * inline; `AISTACK_CURSOR_INLINE=1` forces inline in a build too.
+ */
+function workerFile(): URL | null {
+	if (process.env.AISTACK_CURSOR_INLINE === "1") return null;
+	const url = new URL("./cursor-worker.js", import.meta.url);
+	return existsSync(url) ? url : null;
+}
+
+/**
+ * The read walks the whole global database synchronously: cursor-history's
+ * session listing alone is tens of seconds of CPU on a database past a
+ * gigabyte. On the main thread that freezes the terminal; in a worker the
+ * board keeps drawing and the other harnesses keep scanning (#420). The
+ * worker returns the same `LocalRead` (sessions are plain data, token
+ * evidence is a Map), so the caller cannot tell which thread read it.
+ */
+async function readLocalOffThread(
 	root: string,
 	before: string,
-	onProgress?: (files: number) => void,
+	onProgress?: (files: number, total?: number) => void,
+): Promise<LocalRead> {
+	const file = workerFile();
+	if (!file) return readLocalOnce(root, before, onProgress);
+	return new Promise<LocalRead>((resolve) => {
+		const fallback = () => resolve(readLocalOnce(root, before, onProgress));
+		let settled = false;
+		const settle = (fn: () => void) => {
+			if (settled) return;
+			settled = true;
+			fn();
+		};
+		const worker = new Worker(file, {
+			workerData: { root, before, trace: traceEnabled() },
+		});
+		worker.on("message", (message: CursorWorkerMessage) => {
+			if (message.kind === "progress")
+				onProgress?.(message.files, message.total);
+			else if (message.kind === "result") settle(() => resolve(message.read));
+			else
+				settle(() => {
+					trace("cursor · worker failed, reading inline");
+					fallback();
+				});
+		});
+		worker.on("error", () => settle(fallback));
+		worker.on("exit", (code) => {
+			if (code !== 0) settle(fallback);
+		});
+	});
+}
+
+export type CursorWorkerMessage =
+	| { kind: "progress"; files: number; total?: number }
+	| { kind: "result"; read: LocalRead }
+	| { kind: "error" };
+
+/** The read itself, on whichever thread called it. */
+export async function readLocalOnce(
+	root: string,
+	before: string,
+	onProgress?: (files: number, total?: number) => void,
 ): Promise<LocalRead> {
 	const stats = emptyScanStats();
 	const out: LocalRead = { sessions: [], complete: true, stats };
@@ -201,7 +270,8 @@ async function readLocalOnce(
 				offset,
 				limit: 100,
 			});
-			pageDone(`${page.data.length} sessions`);
+			pageDone(`${page.data.length} of ${page.pagination.total} sessions`);
+			if (offset === 0) onProgress?.(0, page.pagination.total);
 			for (const summary of page.data) {
 				stats.filesFound++;
 				if (summary.resolutionState === "ambiguous") {
@@ -217,7 +287,7 @@ async function readLocalOnce(
 					const tokens = await readTokenEvidence(root, session);
 					out.sessions.push({ session, tokens });
 					stats.filesRead++;
-					onProgress?.(stats.filesRead);
+					onProgress?.(stats.filesRead, page.pagination.total);
 				} catch {
 					out.complete = false;
 					stats.filesUnreadable++;

--- a/packages/cli/src/harness/cursor/worker.ts
+++ b/packages/cli/src/harness/cursor/worker.ts
@@ -1,0 +1,21 @@
+// The Cursor history read, off the main thread (#420). See
+// `readLocalOffThread` in local.ts for why: cursor-history walks the whole
+// global database synchronously, and on the main thread that freezes the
+// terminal for as long as the walk takes.
+
+import { parentPort, workerData } from "node:worker_threads";
+import { enableTrace } from "../../trace.js";
+import { type CursorWorkerMessage, readLocalOnce } from "./local.js";
+
+const port = parentPort;
+if (!port) throw new Error("cursor worker started without a parent port");
+const post = (message: CursorWorkerMessage) => port.postMessage(message);
+const input = workerData as { root: string; before: string; trace: boolean };
+if (input.trace) enableTrace();
+
+readLocalOnce(input.root, input.before, (files, total) =>
+	post({ kind: "progress", files, ...(total !== undefined ? { total } : {}) }),
+).then(
+	(read) => post({ kind: "result", read }),
+	() => post({ kind: "error" }),
+);

--- a/packages/cli/src/harness/index.ts
+++ b/packages/cli/src/harness/index.ts
@@ -183,19 +183,9 @@ export function detectionSinceMs(now: number = Date.now()): number {
  */
 export async function detectedAdapters(
 	sinceMs: number = detectionSinceMs(),
-	hooks: {
-		/**
-		 * Called before each adapter's detect and awaited, so a caller with a
-		 * spinner can name the harness about to be checked. A detect can block
-		 * the event loop for a while (Cursor reads its SQLite history here), and
-		 * the name on screen must be the one doing the work.
-		 */
-		onAdapter?: (adapter: HarnessAdapter) => void | Promise<void>;
-	} = {},
 ): Promise<HarnessAdapter[]> {
 	const out: HarnessAdapter[] = [];
 	for (const adapter of HARNESS_ADAPTERS) {
-		await hooks.onAdapter?.(adapter);
 		const done = traceTimer(`detect ${adapter.name}`);
 		const present = await adapter.detect({ sinceMs });
 		done(present ? "found" : "nothing in window");

--- a/packages/cli/src/harness/pi/scan.ts
+++ b/packages/cli/src/harness/pi/scan.ts
@@ -137,7 +137,7 @@ export async function scan(
 
 			agg.files++;
 			stats.filesRead++;
-			if (opts.onProgress && agg.files % 200 === 0) opts.onProgress(agg.files);
+			if (opts.onProgress && agg.files % 20 === 0) opts.onProgress(agg.files);
 			try {
 				const verdict = await ingestFile(agg, fold, file, opts.sinceMs);
 				if (verdict === "foreign") {

--- a/packages/cli/src/harness/types.ts
+++ b/packages/cli/src/harness/types.ts
@@ -32,7 +32,8 @@ export type HarnessScanOptions = {
 	publishWorkflow?: boolean;
 	/** Only count records with a timestamp at or after this epoch ms. */
 	sinceMs: number;
-	onProgress?: (files: number) => void;
+	/** Files (or sessions) read so far, and the total when the scan knows it. */
+	onProgress?: (files: number, total?: number) => void;
 };
 
 export type HarnessDetectOptions = {

--- a/packages/cli/src/sync/board.test.ts
+++ b/packages/cli/src/sync/board.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from "vitest";
+import {
+	applyEvent,
+	BAR_CELLS,
+	type BoardRow,
+	bar,
+	createBoard,
+	renderRows,
+} from "./board.js";
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes
+const plain = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+describe("board", () => {
+	test("folds step and progress events into one row per id", () => {
+		const rows = new Map<string, BoardRow>();
+		applyEvent(
+			rows,
+			{ kind: "step", id: "harness:cursor", label: "Cursor", state: "waiting" },
+			0,
+		);
+		applyEvent(
+			rows,
+			{
+				kind: "step",
+				id: "harness:cursor",
+				label: "Cursor",
+				state: "running",
+				note: "checking history",
+			},
+			1000,
+		);
+		applyEvent(
+			rows,
+			{
+				kind: "progress",
+				id: "harness:cursor",
+				done: 40,
+				total: 327,
+				unit: "files",
+			},
+			2000,
+		);
+		const row = rows.get("harness:cursor");
+		expect(row).toMatchObject({
+			state: "running",
+			done: 40,
+			total: 327,
+			startedAt: 1000,
+		});
+		applyEvent(
+			rows,
+			{
+				kind: "step",
+				id: "harness:cursor",
+				label: "Cursor",
+				state: "done",
+				note: "327 files · 61.0 s",
+			},
+			62000,
+		);
+		expect(rows.get("harness:cursor")).toMatchObject({
+			state: "done",
+			endedAt: 62000,
+		});
+		expect(rows.size).toBe(1);
+	});
+
+	test("draws a filled bar for a known total and a sweeping block for an unknown one", () => {
+		expect(plain(bar(6, 12, 0))).toBe("██████░░░░░░");
+		expect(plain(bar(12, 12, 0))).toBe("█".repeat(BAR_CELLS));
+		expect(plain(bar(0, 12, 0))).toBe("░".repeat(BAR_CELLS));
+		const a = plain(bar(5, undefined, 0));
+		const b = plain(bar(5, undefined, 4));
+		expect(a).toHaveLength(BAR_CELLS);
+		expect(a).not.toBe(b);
+		expect(a.split("█")).toHaveLength(4);
+	});
+
+	test("renders every state on its own line, labels aligned, cut to the width", () => {
+		const rows: BoardRow[] = [
+			{ id: "prices", label: "Prices", state: "done", note: "current" },
+			{
+				id: "harness:claude-code",
+				label: "Claude Code",
+				state: "running",
+				note: "history",
+				done: 312,
+				unit: "files",
+				startedAt: 0,
+			},
+			{
+				id: "harness:cursor",
+				label: "Cursor",
+				state: "running",
+				note: "recent usage",
+				done: 40,
+				total: 327,
+				unit: "files",
+				startedAt: 500,
+			},
+			{
+				id: "harness:pi-mono",
+				label: "Pi",
+				state: "skipped",
+				note: "nothing in window",
+			},
+			{ id: "git", label: "Git history", state: "waiting" },
+			{ id: "x", label: "Broken", state: "failed", note: "boom" },
+		];
+		const lines = renderRows(rows, { now: 4200, width: 80, frame: 0 }).map(
+			plain,
+		);
+		expect(lines).toEqual([
+			"│  ● Prices       current",
+			"│  ◐ Claude Code  ███░░░░░░░░░  312 files  history  4.2 s",
+			"│  ◐ Cursor       █░░░░░░░░░░░  40/327 files  recent usage  3.7 s",
+			"│  ○ Pi           nothing in window",
+			"│  ○ Git history  waiting",
+			"│  ✗ Broken       boom",
+		]);
+		const narrow = renderRows(rows, { now: 4200, width: 30, frame: 0 }).map(
+			plain,
+		);
+		for (const line of narrow) expect([...line].length).toBeLessThan(30);
+	});
+
+	test("a live board repaints in place and paints the final frame at stop", () => {
+		const out: string[] = [];
+		let t = 0;
+		const board = createBoard({
+			write: (text) => out.push(text),
+			interactive: true,
+			columns: () => 80,
+			now: () => t,
+			frameMs: 1_000_000,
+		});
+		board.handle({
+			kind: "step",
+			id: "prices",
+			label: "Prices",
+			state: "running",
+		});
+		board.handle({
+			kind: "step",
+			id: "settings",
+			label: "Stack settings",
+			state: "running",
+		});
+		t = 300;
+		board.handle({
+			kind: "step",
+			id: "prices",
+			label: "Prices",
+			state: "done",
+			note: "current",
+		});
+		board.stop();
+		expect(out).toHaveLength(1);
+		const text = plain(out[0] ?? "");
+		expect(text).toContain("● Prices          current");
+		expect(text).toContain("◐ Stack settings");
+		expect(out[0]).not.toContain("\x1b[2A");
+		board.stop();
+		expect(out).toHaveLength(1);
+	});
+
+	test("a board on a pipe prints the rows once, at stop", () => {
+		const out: string[] = [];
+		const board = createBoard({
+			write: (text) => out.push(text),
+			interactive: false,
+			columns: () => 80,
+			now: () => 0,
+		});
+		board.handle({
+			kind: "step",
+			id: "prices",
+			label: "Prices",
+			state: "done",
+			note: "current",
+		});
+		board.stop();
+		expect(out.map(plain)).toEqual(["│  ● Prices  current\n"]);
+	});
+});

--- a/packages/cli/src/sync/board.ts
+++ b/packages/cli/src/sync/board.ts
@@ -1,0 +1,204 @@
+// The scan board (#420): one row per unit of stage work, redrawn in place
+// while the steps run concurrently, the way a status bar lists subagents.
+//
+// The stage emits `StageEvent`s; `applyEvent` folds them into rows and
+// `renderRows` turns rows into lines. Both are pure, so the drawing is tested
+// without a terminal. `createBoard` owns the timer and the cursor movement: it
+// paints every frame, moves the cursor back up, and paints again, so a step
+// that stalls only stalls its own row. On a pipe it prints the finished rows
+// once, at stop.
+
+import { dim, lime, red } from "../theme.js";
+import type { StageEvent } from "./stage.js";
+
+export type BoardRow = {
+	id: string;
+	label: string;
+	state: "waiting" | "running" | "done" | "skipped" | "failed";
+	note?: string;
+	done?: number;
+	total?: number;
+	unit?: string;
+	startedAt?: number;
+	endedAt?: number;
+};
+
+export const BAR_CELLS = 12;
+const FILLED = "█";
+const EMPTY = "░";
+const PREFIX = "│  ";
+
+export function applyEvent(
+	rows: Map<string, BoardRow>,
+	event: StageEvent,
+	now: number,
+): void {
+	const row: BoardRow = rows.get(event.id) ?? {
+		id: event.id,
+		label: event.kind === "step" ? event.label : event.id,
+		state: "waiting",
+	};
+	if (event.kind === "step") {
+		row.label = event.label;
+		row.state = event.state;
+		row.note = event.note;
+		if (event.state === "running" && row.startedAt === undefined)
+			row.startedAt = now;
+		if (event.state === "done" || event.state === "failed") row.endedAt = now;
+		if (event.state === "running" && row.note !== undefined) {
+			// A new running note is a new sub-step; its count starts over.
+			row.done = undefined;
+			row.total = undefined;
+		}
+	} else {
+		row.done = event.done;
+		row.total = event.total;
+		row.unit = event.unit;
+		if (event.note !== undefined) row.note = event.note;
+		if (row.state === "waiting") row.state = "running";
+		if (row.startedAt === undefined) row.startedAt = now;
+	}
+	rows.set(event.id, row);
+}
+
+/** A determinate bar, or the moving block of an activity bar when `total` is unknown. */
+export function bar(
+	done: number,
+	total: number | undefined,
+	frame: number,
+): string {
+	if (total !== undefined && total > 0) {
+		const filled = Math.max(
+			0,
+			Math.min(BAR_CELLS, Math.round((done / total) * BAR_CELLS)),
+		);
+		return `${lime(FILLED.repeat(filled))}${dim(EMPTY.repeat(BAR_CELLS - filled))}`;
+	}
+	// A three-cell block sweeping back and forth: work is happening, size unknown.
+	const span = BAR_CELLS - 3;
+	const at = frame % (span * 2);
+	const start = at < span ? at : span * 2 - at;
+	return [...Array(BAR_CELLS).keys()]
+		.map((i) => (i >= start && i < start + 3 ? lime(FILLED) : dim(EMPTY)))
+		.join("");
+}
+
+const seconds = (ms: number) => `${(ms / 1000).toFixed(1)} s`;
+
+export function renderRows(
+	rows: readonly BoardRow[],
+	opts: { now: number; width: number; frame: number },
+): string[] {
+	const labelWidth = Math.max(0, ...rows.map((r) => r.label.length));
+	return rows.map((row) => {
+		const label = row.label.padEnd(labelWidth);
+		let icon: string;
+		let body: string;
+		switch (row.state) {
+			case "waiting":
+				icon = dim("○");
+				body = dim("waiting");
+				break;
+			case "running": {
+				icon = lime("◐");
+				const parts: string[] = [bar(row.done ?? 0, row.total, opts.frame)];
+				if (row.done !== undefined) {
+					parts.push(
+						row.total !== undefined
+							? `${row.done}/${row.total} ${row.unit ?? ""}`.trimEnd()
+							: `${row.done} ${row.unit ?? ""}`.trimEnd(),
+					);
+				}
+				if (row.note) parts.push(dim(row.note));
+				if (row.startedAt !== undefined)
+					parts.push(dim(seconds(opts.now - row.startedAt)));
+				body = parts.join("  ");
+				break;
+			}
+			case "done":
+				icon = lime("●");
+				body = dim(row.note ?? "done");
+				break;
+			case "skipped":
+				icon = dim("○");
+				body = dim(row.note ?? "skipped");
+				break;
+			case "failed":
+				icon = red("✗");
+				body = red(row.note ?? "failed");
+				break;
+		}
+		return fit(`${dim(PREFIX)}${icon} ${label}  ${body}`, opts.width);
+	});
+}
+
+/** Cut a line to the terminal width, counting visible characters only. */
+function fit(line: string, width: number): string {
+	if (width <= 0) return line;
+	let visible = 0;
+	let out = "";
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes
+	for (const part of line.split(/(\x1b\[[0-9;]*m)/)) {
+		if (part.startsWith("\x1b[")) {
+			out += part;
+			continue;
+		}
+		const room = width - 1 - visible;
+		if (room <= 0) break;
+		const slice = [...part].slice(0, room).join("");
+		out += slice;
+		visible += [...slice].length;
+	}
+	return `${out}\x1b[0m`;
+}
+
+export type Board = {
+	handle: (event: StageEvent) => void;
+	/** Paint the final frame and release the lines. */
+	stop: () => void;
+};
+
+export function createBoard(opts: {
+	write: (text: string) => void;
+	interactive: boolean;
+	columns?: () => number;
+	now?: () => number;
+	frameMs?: number;
+}): Board {
+	const rows = new Map<string, BoardRow>();
+	const now = opts.now ?? (() => Date.now());
+	const columns = opts.columns ?? (() => process.stdout.columns ?? 80);
+	let painted = 0;
+	let frame = 0;
+	let stopped = false;
+	const paint = () => {
+		const lines = renderRows([...rows.values()], {
+			now: now(),
+			width: columns(),
+			frame,
+		});
+		frame++;
+		const up = painted > 0 ? `\x1b[${painted}A` : "";
+		opts.write(`${up}${lines.map((line) => `\x1b[2K\r${line}`).join("\n")}\n`);
+		painted = lines.length;
+	};
+	const timer = opts.interactive
+		? setInterval(paint, opts.frameMs ?? 80)
+		: null;
+	return {
+		handle: (event) => {
+			if (stopped) return;
+			applyEvent(rows, event, now());
+		},
+		stop: () => {
+			if (stopped) return;
+			stopped = true;
+			if (timer) clearInterval(timer);
+			if (opts.interactive) paint();
+			else
+				opts.write(
+					`${renderRows([...rows.values()], { now: now(), width: columns(), frame: 0 }).join("\n")}\n`,
+				);
+		},
+	};
+}

--- a/packages/cli/src/sync/stage.test.ts
+++ b/packages/cli/src/sync/stage.test.ts
@@ -113,39 +113,33 @@ describe("stageSync", () => {
 		expect(staged.bodyJson).not.toContain("-home-u-p");
 	});
 
-	// A phase message is the only thing a user sees while a step blocks the
-	// event loop, so the stage names the step first and waits for the terminal
-	// to show it. Detection names each harness through the adapters hook.
-	test("names each phase before its work and waits for the terminal to show it", async () => {
-		const seen: string[] = [];
-		let pending = 0;
+	// The terminal draws one row per step from these events (#420). Every
+	// harness gets a waiting row before any is checked, each network read is
+	// its own step, and a harness ends done with its file count.
+	test("emits one step per unit of work, in the order the board draws them", async () => {
+		const events: string[] = [];
 		const staged = await stageSync(
 			deps({
-				adaptersImpl: async (_sinceMs, hooks) => {
-					await hooks?.onAdapter?.(FAKE_CLAUDE_ADAPTER);
-					return [FAKE_CLAUDE_ADAPTER];
-				},
-				onProgress: async (message) => {
-					// Every earlier phase's promise settled before the next one started.
-					expect(pending).toBe(0);
-					pending++;
-					seen.push(message);
-					await new Promise((resolve) => setTimeout(resolve, 1));
-					pending--;
+				onEvent: (event) => {
+					events.push(
+						event.kind === "step"
+							? `${event.id} ${event.state}`
+							: `${event.id} ${event.done}/${event.total ?? "?"}`,
+					);
 				},
 			}),
 		);
 		expect(staged.blockedReason).toBeNull();
-		expect(seen).toEqual([
-			"Checking prices",
-			"Checking stack settings",
-			"Checking previously synced days",
-			"Checking for Claude Code history",
-			"Scanning recent Claude Code usage",
-			"Reading historical Claude Code days",
-			"Reading Git history",
-			"Preparing review",
+		expect(events.slice(0, 3)).toEqual([
+			"prices running",
+			"settings running",
+			"manifest running",
 		]);
+		expect(events).toContain("harness:claude-code waiting");
+		expect(
+			events.filter((e) => e.startsWith("harness:claude-code")).at(-1),
+		).toBe("harness:claude-code done");
+		expect(events.at(-1)).toBe("review done");
 	});
 
 	test("bodyJson is the exact serialization and the id derives from it", async () => {
@@ -248,24 +242,24 @@ describe("stageSync", () => {
 		const scanSince: number[] = [];
 		await stageSync(
 			deps({
-				adaptersImpl: async (sinceMs) => {
-					detectSince.push(sinceMs);
-					return [
-						{
-							...FAKE_CLAUDE_ADAPTER,
-							scan: async (opts) => {
-								scanSince.push(opts.sinceMs);
-								return FAKE_CLAUDE_ADAPTER.scan(opts);
-							},
+				adaptersImpl: () => [
+					{
+						...FAKE_CLAUDE_ADAPTER,
+						detect: async (opts) => {
+							detectSince.push(opts.sinceMs);
+							return true;
 						},
-					];
-				},
+						scan: async (opts) => {
+							scanSince.push(opts.sinceMs);
+							return FAKE_CLAUDE_ADAPTER.scan(opts);
+						},
+					},
+				],
 			}),
 		);
-		expect(detectSince).toEqual([
-			windowStartMs(NOW, DEFAULT_WINDOW_DAYS),
-			windowStartMs(NOW, 400),
-		]);
+		// A harness active in the snapshot window is historical by inclusion,
+		// so the second detect is skipped.
+		expect(detectSince).toEqual([windowStartMs(NOW, DEFAULT_WINDOW_DAYS)]);
 		// The snapshot scan reads the 30-day window; the day scan (#307) reads
 		// the whole retention, 400 days when no manifest names one.
 		expect(scanSince).toEqual([

--- a/packages/cli/src/sync/stage.ts
+++ b/packages/cli/src/sync/stage.ts
@@ -33,7 +33,7 @@ import {
 	getToken,
 	type Settings,
 } from "../config.js";
-import { detectedAdapters, harnessLabel } from "../harness/index.js";
+import { HARNESS_ADAPTERS, harnessLabel } from "../harness/index.js";
 import {
 	type KeptPrivateAtom,
 	type LoadedSyncConfig,
@@ -55,7 +55,7 @@ import {
 	type ScanStats,
 	windowStartMs,
 } from "../harness/shared/window.js";
-import type { HarnessAdapter } from "../harness/types.js";
+import type { HarnessAdapter, HarnessScan } from "../harness/types.js";
 import { trace, traceTimer } from "../trace.js";
 import {
 	buildMeasuredDays,
@@ -127,6 +127,29 @@ export type PriceTableUsed = {
 	origin: "served" | "bundled";
 };
 
+/**
+ * One unit of stage work, as the terminal sees it. `id` is stable per step
+ * (`prices`, `settings`, `manifest`, `harness:<name>`, `git`, `review`);
+ * `label` is what to print. A `progress` carries the count done so far and the
+ * total when the step knows it.
+ */
+export type StageEvent =
+	| {
+			kind: "step";
+			id: string;
+			label: string;
+			state: "waiting" | "running" | "done" | "skipped" | "failed";
+			note?: string;
+	  }
+	| {
+			kind: "progress";
+			id: string;
+			done: number;
+			total?: number;
+			unit: string;
+			note?: string;
+	  };
+
 export type StageDeps = {
 	baseUrl: string;
 	now?: () => number;
@@ -136,13 +159,10 @@ export type StageDeps = {
 		baseUrl: string;
 		token?: string;
 	}) => Promise<LoadedSyncConfig>;
-	/** Override the adapter set. Tests only. */
-	adaptersImpl?: (
-		sinceMs: number,
-		hooks?: {
-			onAdapter?: (adapter: HarnessAdapter) => void | Promise<void>;
-		},
-	) => Promise<HarnessAdapter[]>;
+	/** Override the candidate adapters (every harness this build can read). Tests only. */
+	adaptersImpl?: () =>
+		| readonly HarnessAdapter[]
+		| Promise<readonly HarnessAdapter[]>;
 	/** Override the Git reader the workflow extraction shells out to. Tests only. */
 	gitRunnerImpl?: GitWorkflowRunner;
 	/**
@@ -166,14 +186,12 @@ export type StageDeps = {
 	 */
 	trigger?: SyncTrigger;
 	/**
-	 * Human-facing phase updates for the interactive terminal. A phase change
-	 * is AWAITED before the work it names starts: the spinner repaints on a
-	 * timer, and a phase that blocks the event loop (Cursor's SQLite walk) would
-	 * otherwise leave the previous phase's text on screen for minutes and read
-	 * as a hang at the wrong step. File-count updates inside a scan are not
-	 * awaited; they are frequent and the scan yields on its own.
+	 * Structured progress for the interactive terminal (#420). Steps run
+	 * concurrently, so a listener gets one `step` per unit of work and redraws
+	 * a board; nothing here is awaited, and a step that blocks the event loop
+	 * (a synchronous SQLite walk) stalls only its own row's updates.
 	 */
-	onProgress?: (message: string) => void | Promise<void>;
+	onEvent?: (event: StageEvent) => void;
 };
 
 export function stageId(bodyJson: string): string {
@@ -184,81 +202,112 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 	const now = (deps.now ?? Date.now)();
 	const token = (deps.getTokenImpl ?? getToken)();
 	const loadConfig = deps.loadConfigImpl ?? loadSyncConfig;
-	const adapters = deps.adaptersImpl ?? detectedAdapters;
+	const adapters = deps.adaptersImpl ?? (() => HARNESS_ADAPTERS);
 	const windowDays = deps.windowDays ?? DEFAULT_WINDOW_DAYS;
 	const projectWorkspaceId =
 		deps.getProjectWorkspaceIdImpl ?? getProjectWorkspaceId;
 	const fetchManifest = deps.fetchManifestImpl ?? fetchDayManifest;
 	const fetchPrices = deps.fetchPricesImpl ?? fetchPriceTable;
-	// `phase` names the step that is about to run and waits for the terminal to
-	// show it; `note` refreshes a count inside a running step and returns at once.
-	const phase = async (message: string) => {
-		trace(message);
-		await deps.onProgress?.(message);
-	};
-	const note = (message: string) => {
-		void deps.onProgress?.(message);
+	const emit = (event: StageEvent) => deps.onEvent?.(event);
+	const step = (
+		id: string,
+		label: string,
+		state: "waiting" | "running" | "done" | "skipped" | "failed",
+		note?: string,
+	) => {
+		if (state !== "waiting")
+			trace(`${label} · ${state}${note ? ` · ${note}` : ""}`);
+		emit({ kind: "step", id, label, state, ...(note ? { note } : {}) });
 	};
 
-	// The price table comes from the server BEFORE any adapter prices a
-	// response (#336): the adapters call the module-level pricing functions,
-	// which read whichever pricer is active. Served rows win per key; the
-	// bundled constants fill what the server does not hold. Unreachable reads
-	// as bundled, and the gate says which one it was.
+	// The three startup reads are independent, so they go out together (#420).
+	// The price table must be active before any adapter prices a response
+	// (#336): the adapters call the module-level pricing functions, which read
+	// whichever pricer is active. Served rows win per key; the bundled constants
+	// fill what the server does not hold. Unreachable reads as bundled, and the
+	// gate says which one it was.
 	let prices: PriceTableUsed = {
 		id: BUNDLED_PRICE_TABLE_ID,
 		origin: "bundled",
 	};
-	await phase("Checking prices");
-	const pricesDone = traceTimer("prices");
-	try {
-		const table = await fetchPrices(deps.baseUrl);
-		if (table) {
-			setActivePricer(layeredPricer(table));
-			prices = { id: table.id, origin: "served" };
-			pricesDone(`served ${table.id}`);
-		} else {
+	step("prices", "Prices", "running");
+	step("settings", "Stack settings", "running");
+	if (token) step("manifest", "Synced days", "running");
+	const readPrices = async () => {
+		const done = traceTimer("prices");
+		try {
+			const table = await fetchPrices(deps.baseUrl);
+			if (table) {
+				setActivePricer(layeredPricer(table));
+				prices = { id: table.id, origin: "served" };
+				done(`served ${table.id}`);
+				step("prices", "Prices", "done", "current");
+			} else {
+				setActivePricer(null);
+				done("server has no price route, bundled table");
+				step("prices", "Prices", "done", "bundled table");
+			}
+		} catch (error) {
 			setActivePricer(null);
-			pricesDone("server has no price route, bundled table");
+			done(`fetch failed (${describeError(error)}), bundled table`);
+			step("prices", "Prices", "done", "unreachable, bundled table");
 		}
-	} catch (error) {
-		setActivePricer(null);
-		pricesDone(`fetch failed (${describeError(error)}), bundled table`);
-	}
-
-	await phase("Checking stack settings");
-	const settingsDone = traceTimer("stack settings");
-	const { config, source } = await loadConfig({
-		baseUrl: deps.baseUrl,
-		...(token ? { token } : {}),
-	});
-	settingsDone(
-		`${source}${config.stack ? ", stack resolved" : ", no stack"}, publishWorkflow ${config.publishWorkflow}, publishCost ${config.publishCost}`,
-	);
-
+	};
+	const readSettings = async () => {
+		const done = traceTimer("stack settings");
+		const loaded = await loadConfig({
+			baseUrl: deps.baseUrl,
+			...(token ? { token } : {}),
+		});
+		done(
+			`${loaded.source}${loaded.config.stack ? ", stack resolved" : ", no stack"}, publishWorkflow ${loaded.config.publishWorkflow}, publishCost ${loaded.config.publishCost}`,
+		);
+		step(
+			"settings",
+			"Stack settings",
+			"done",
+			loaded.source === "fetched"
+				? (loaded.config.stack?.name ?? "no stack")
+				: "unreachable",
+		);
+		return loaded;
+	};
 	// The server's day manifest (#307, ADR-0010): which dates it holds and with
 	// what fingerprint. Missing (an old server) or failing (network) reads as
 	// "send the whole window"; a publish that repeats a held date is correct,
 	// only wasteful. The manifest also names the retention, which bounds how
 	// far back the day scan reaches.
-	let manifest: DayManifest | null = null;
-	if (token) {
-		await phase("Checking previously synced days");
-		const manifestDone = traceTimer("day manifest");
+	const readManifest = async (): Promise<DayManifest | null> => {
+		if (!token) {
+			trace("day manifest · skipped, this machine holds no token");
+			return null;
+		}
+		const done = traceTimer("day manifest");
 		try {
-			manifest = await fetchManifest(deps.baseUrl, token);
-			manifestDone(
+			const manifest = await fetchManifest(deps.baseUrl, token);
+			done(
 				manifest
 					? `${manifest.days.length} days held, retention ${manifest.retentionDays}`
 					: "server has no manifest route, whole window goes",
 			);
+			step(
+				"manifest",
+				"Synced days",
+				"done",
+				manifest ? `${manifest.days.length} held` : "none",
+			);
+			return manifest;
 		} catch (error) {
-			manifest = null;
-			manifestDone(`fetch failed (${describeError(error)}), whole window goes`);
+			done(`fetch failed (${describeError(error)}), whole window goes`);
+			step("manifest", "Synced days", "done", "unreachable, whole window");
+			return null;
 		}
-	} else {
-		trace("day manifest · skipped, this machine holds no token");
-	}
+	};
+	const [, { config, source }, manifest] = await Promise.all([
+		readPrices(),
+		readSettings(),
+		readManifest(),
+	]);
 	const retentionDays = Math.max(
 		1,
 		Math.min(manifest?.retentionDays ?? MAX_DAY_WINDOW, MAX_DAY_WINDOW),
@@ -280,34 +329,94 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 	// date the server would keep. Two scans over the same files; the second is
 	// the one the days and the workflow blocks come from.
 	const daysSinceMs = windowStartMs(now, retentionDays);
-	// One phase per harness, so a detect that blocks the event loop (Cursor's
-	// history read) shows its own name on the spinner instead of the previous
-	// phase's. The historical pass repeats the same checks over a longer window
-	// and reuses the reads the first pass made where an adapter memoizes them.
-	const active = await adapters(sinceMs, {
-		onAdapter: (adapter) =>
-			phase(`Checking for ${harnessLabel(adapter.name)} history`),
-	});
+	// Every harness is checked and scanned at once (#420): the adapters are
+	// independent, the transcript readers are asynchronous, and Cursor's
+	// synchronous SQLite walk runs in a worker thread, so the board keeps
+	// drawing while the slowest one works. Results are assembled afterwards in
+	// registration order, which is display order at the gate.
+	const candidates = await adapters();
+	for (const adapter of candidates)
+		step(`harness:${adapter.name}`, harnessLabel(adapter.name), "waiting");
+	const readings = await Promise.all(
+		candidates.map((adapter) => readHarness(adapter)),
+	);
+	async function readHarness(adapter: HarnessAdapter): Promise<HarnessReading> {
+		const id = `harness:${adapter.name}`;
+		const label = harnessLabel(adapter.name);
+		const started = performance.now();
+		const elapsed = () =>
+			`${((performance.now() - started) / 1000).toFixed(1)} s`;
+		step(id, label, "running", "checking history");
+		const detectDone = traceTimer(`detect ${adapter.name}`);
+		const active = await adapter.detect({ sinceMs });
+		const historical =
+			active || (await adapter.detect({ sinceMs: daysSinceMs }));
+		detectDone(
+			active
+				? "found"
+				: historical
+					? "found (older than the window)"
+					: "nothing in window",
+		);
+		const reading: HarnessReading = { adapter, active, historical };
+		if (!historical) {
+			step(id, label, "skipped", "nothing in window");
+			return reading;
+		}
+		let seen = 0;
+		const progress = (phase: string) => (files: number, total?: number) => {
+			seen = files;
+			emit({
+				kind: "progress",
+				id,
+				done: files,
+				...(total !== undefined ? { total } : {}),
+				unit: "files",
+				note: phase,
+			});
+		};
+		if (active) {
+			step(id, label, "running", "recent usage");
+			const scanDone = traceTimer(`scan ${adapter.name} (recent)`);
+			reading.recent = await adapter.scan({
+				sinceMs,
+				publishWorkflow: false,
+				onProgress: progress("recent usage"),
+			});
+			scanDone(describeScan(reading.recent.stats));
+		}
+		step(id, label, "running", "history");
+		const scanDone = traceTimer(`scan ${adapter.name} (historical)`);
+		reading.history = await adapter.scan({
+			sinceMs: daysSinceMs,
+			publishWorkflow: config.publishWorkflow,
+			onProgress: progress("history"),
+		});
+		scanDone(
+			`${describeScan(reading.history.stats)}${reading.history.scanComplete === false ? ", incomplete" : ""}`,
+		);
+		const files = Math.max(seen, reading.history.stats.filesRead);
+		step(
+			id,
+			label,
+			"done",
+			`${files} ${files === 1 ? "file" : "files"} · ${elapsed()}`,
+		);
+		return reading;
+	}
+	const active = readings.filter((r) => r.active).map((r) => r.adapter);
+	const historical = readings.filter((r) => r.historical).map((r) => r.adapter);
 	trace(
 		`active harnesses (${windowDays} days): ${active.map((a) => a.name).join(", ") || "none"}`,
 	);
-	const historical = await adapters(daysSinceMs);
 	trace(
 		`historical harnesses (${retentionDays} days): ${historical.map((a) => a.name).join(", ") || "none"}`,
 	);
 	let dayScansComplete = true;
 	const sessionDatesByHarness = new Map<string, Map<string, Set<string>>>();
-	for (const adapter of active) {
-		const label = harnessLabel(adapter.name);
-		await phase(`Scanning recent ${label} usage`);
-		const scanDone = traceTimer(`scan ${adapter.name} (recent)`);
-		const { aggregate, stats } = await adapter.scan({
-			sinceMs,
-			publishWorkflow: false,
-			onProgress: (files) =>
-				note(`Scanning recent ${label} usage · ${files} files`),
-		});
-		scanDone(describeScan(stats));
+	for (const { adapter, recent } of readings) {
+		if (!recent) continue;
+		const { aggregate, stats } = recent;
 		scanStats[adapter.name] = stats;
 		built.push(
 			buildPayload({
@@ -322,26 +431,10 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 			}),
 		);
 	}
-	for (const adapter of historical) {
-		const label = harnessLabel(adapter.name);
-		await phase(`Reading historical ${label} days`);
-		const scanDone = traceTimer(`scan ${adapter.name} (historical)`);
-		const {
-			aggregate,
-			stats,
-			workflow,
-			workflowLocal,
-			scanComplete,
-			sessionDates,
-		} = await adapter.scan({
-			sinceMs: daysSinceMs,
-			publishWorkflow: config.publishWorkflow,
-			onProgress: (files) =>
-				note(`Reading historical ${label} days · ${files} files`),
-		});
-		scanDone(
-			`${describeScan(stats)}${scanComplete === false ? ", incomplete" : ""}`,
-		);
+	for (const { adapter, history } of readings) {
+		if (!history) continue;
+		const { aggregate, workflow, workflowLocal, scanComplete, sessionDates } =
+			history;
 		if (scanComplete === false) dayScansComplete = false;
 		if (adapter.name === "grok-build" || adapter.name === "cursor")
 			sessionDatesByHarness.set(adapter.name, sessionDates ?? new Map());
@@ -371,7 +464,7 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 	// would be the one visible cost of a preference that is supposed to be free.
 	let workflow: WorkflowExtraction | undefined;
 	if (workflowScans.length > 0 && config.publishWorkflow) {
-		await phase("Reading Git history");
+		step("git", "Git history", "running");
 		const gitDone = traceTimer("git history");
 		workflow = deps.gitRunnerImpl
 			? extractLocalWorkflow({
@@ -386,6 +479,7 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 					toMs: now,
 				});
 		gitDone(`${workflow.days.length} days`);
+		step("git", "Git history", "done", `${workflow.days.length} days`);
 	} else {
 		trace(
 			`git history · skipped (${config.publishWorkflow ? "no harness scanned" : "publishWorkflow off"})`,
@@ -451,12 +545,13 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 			: undefined,
 		CLI_VERSION,
 	);
-	await phase("Preparing review");
+	step("review", "Review", "running");
 	const bodyJson = JSON.stringify(body);
 	trace(
 		`days · ${days.mode}, ${days.send.length} to send${dayScansComplete ? "" : " (a scan was incomplete, no day rows go)"}`,
 	);
 	trace(`body · ${bodyJson.length} bytes, ${built.length} harness payloads`);
+	step("review", "Review", "done", `${days.send.length} days to send`);
 	const keptPrivate = mergeKeptPrivate(built.map((b) => b.keptPrivate));
 
 	const ctx = {
@@ -502,6 +597,16 @@ export async function stageSync(deps: StageDeps): Promise<StagedSend> {
 		...(acknowledgePublish ? { acknowledgePublish } : {}),
 	};
 }
+
+type HarnessReading = {
+	adapter: HarnessAdapter;
+	/** Wrote a transcript inside the snapshot window (#101). */
+	active: boolean;
+	/** Wrote a transcript inside the retention the day rows cover (#307). */
+	historical: boolean;
+	recent?: HarnessScan;
+	history?: HarnessScan;
+};
 
 function describeError(error: unknown): string {
 	if (error instanceof Error) {

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -2,7 +2,10 @@ import { defineConfig } from 'tsup'
 import pkg from './package.json' with { type: 'json' }
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  // The Cursor read runs in a worker thread (#420); it is its own entry so
+  // `new Worker(new URL('./cursor-worker.js', import.meta.url))` finds it
+  // beside index.js.
+  entry: { index: 'src/index.ts', 'cursor-worker': 'src/harness/cursor/worker.ts' },
   format: ['esm'],
   target: 'node22',
   clean: true,


### PR DESCRIPTION
## Why

Even with #420, one spinner line names one step, and the Cursor read still blocked the main thread for the whole listing, so the spinner sat still for a minute or more.

## What

- Prices, stack settings, synced days, and every harness run concurrently; results assemble in registration order.
- The stage emits `StageEvent`s; `sync` draws a board with one row per step: icon, label, progress bar, count, elapsed time, redrawn in place. A slow harness is one slow row while the others finish.
- Cursor's history read runs in a worker thread (`dist/cursor-worker.js`, second tsup entry), so the board keeps drawing. `AISTACK_CURSOR_INLINE=1` forces inline.
- The Cursor memo is keyed by root alone. With Cursor open the write-ahead log changes continuously, and the stamp-keyed memo from #420 made the read repeat (297 s instead of 105 s in a traced run).
- Progress every 20 files; Cursor reports its session total so its bar fills.

Verified under a pseudo-terminal on a 1.5 GB Cursor database: 2,280 repaints during a 188 s stage, one Cursor read reused twice. Final frame:

```
│  ● Prices          current
│  ● Stack settings  Alper's Coding Stack
│  ● Synced days     394 held
│  ● Claude Code     624 files · 14.5 s
│  ● Codex           658 files · 7.8 s
│  ● Grok Build      4 files · 0.2 s
│  ● Cursor          326 files · 105.1 s
│  ● opencode        1 file · 0.1 s
│  ● Pi              3 files · 0.1 s
│  ● Git history     388 days
│  ● Review          0 days to send
```

## Still open

- With Cursor open, its scan reads as incomplete (source moved during the read, plus one unreadable session), and an incomplete scan drops every day row for every harness. This machine publishes zero day rows as a result.
- Git history takes 80 s here with no per-repository progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aUJHeza9TjhnoKECY3FhB
